### PR TITLE
Fix devcontainer terminal prompt and history permissions

### DIFF
--- a/.devcontainer/claude-code/Dockerfile
+++ b/.devcontainer/claude-code/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
+    wget \
     unzip \
     zsh \
     sudo \
@@ -119,5 +120,10 @@ RUN mkdir -p /home/node/.config/ccstatusline && \
     chmod 700 /home/node/.config/ccstatusline && \
     chmod 600 /home/node/.config/ccstatusline/settings.json
 
-# Set up zshrc with aliases
-RUN echo 'alias clauded="claude --dangerously-skip-permissions"' >> /home/node/.zshrc
+# Install oh-my-zsh with proper prompt theme and git plugin
+# Using zsh-in-docker for consistent setup with base-image
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
+        -p git \
+        -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+        -x && \
+    echo 'alias clauded="claude --dangerously-skip-permissions"' >> /home/node/.zshrc

--- a/.devcontainer/claude-code/devcontainer.json
+++ b/.devcontainer/claude-code/devcontainer.json
@@ -11,7 +11,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2.13.0": {}
   },
 
-  "initializeCommand": "docker volume inspect claude-code-config >/dev/null 2>&1 && docker run --rm -v claude-code-config:/data alpine chown -R 1001:1001 /data || true",
+  "initializeCommand": "(docker volume inspect claude-code-config >/dev/null 2>&1 && docker run --rm -v claude-code-config:/data alpine chown -R 1001:1001 /data || true) && (docker volume inspect claude-code-bashhistory >/dev/null 2>&1 && docker run --rm -v claude-code-bashhistory:/data alpine chown -R 1001:1001 /data || true)",
   "postCreateCommand": "bash /workspace/.devcontainer/claude-code/scripts/post-create.sh",
 
   "customizations": {

--- a/.devcontainer/claude-code/scripts/post-create.sh
+++ b/.devcontainer/claude-code/scripts/post-create.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "=== Post-Create Setup Starting ==="
 
-# 0. Fix permissions on mounted .claude volume
+# 0a. Fix permissions on mounted .claude volume
 echo "[0/4] Fixing .claude directory permissions..."
 CLAUDE_DIR="/home/node/.claude"
 if [ -d "$CLAUDE_DIR" ]; then
@@ -38,6 +38,20 @@ else
   echo '{}' > "$CLAUDE_DIR/.claude.json"
   echo '{"statusLine": "ccstatusline"}' > "$CLAUDE_DIR/settings.json"
   chmod 600 "$CLAUDE_DIR/.claude.json" "$CLAUDE_DIR/settings.json"
+fi
+
+# 0b. Fix permissions on mounted command history volume
+echo "[0b/4] Fixing command history permissions..."
+HISTORY_DIR="/commandhistory"
+if [ -d "$HISTORY_DIR" ]; then
+  if [ "$(find "$HISTORY_DIR" -not -user "$(whoami)" 2>/dev/null | head -1)" ]; then
+    echo "      History volume has files with incorrect ownership - fixing with sudo..."
+    sudo chown -R node:node "$HISTORY_DIR"
+  fi
+  # Ensure history file exists and is writable
+  touch "$HISTORY_DIR/.bash_history"
+  chmod 600 "$HISTORY_DIR/.bash_history"
+  echo "      Command history permissions fixed"
 fi
 
 # 1. Configure Terraform credentials


### PR DESCRIPTION
## Summary

- Fixes broken terminal prompt showing raw container ID (e.g., `52048b6f5cf6%`)
- Fixes "locking failed for /commandhistory/.bash_history: permission denied" error

## Problem

1. **Broken prompt**: The `claude-code` devcontainer had zsh installed but not configured with a theme, resulting in the default prompt showing container hostname
2. **History permission error**: The `/commandhistory` volume had incorrect ownership from previous containers

## Solution

### Prompt fix (`Dockerfile`)
- Added `wget` package (required for zsh-in-docker)
- Installed oh-my-zsh with git plugin using zsh-in-docker (same as base-image)

### History fix (`devcontainer.json` + `post-create.sh`)
- Added `claude-code-bashhistory` volume to `initializeCommand` permission fix
- Added fallback permission fix in post-create.sh

## Test plan

- [ ] Rebuild devcontainer with "Dev Containers: Rebuild Container"
- [ ] Verify prompt shows `➜  workspace git:(branch)` format
- [ ] Verify no "locking failed" errors on terminal open
- [ ] Verify command history persists across terminal sessions

🤖 Generated with [Claude Code](https://claude.ai/code)