### PR TITLE
feat: tool call tracking in session dashboards with SQLite settings

### DIFF
--- a/src/app/components/features/new-task-dialog.tsx
+++ b/src/app/components/features/new-task-dialog.tsx
@@ -1180,7 +1180,7 @@ export function NewTaskDialog({
                       onClick={handleSend}
                       disabled={!input.trim() || isStreaming || status !== 'active'}
                       className={cn(
-                        'absolute right-2 bottom-2 h-8 w-8 rounded-md',
+                        'absolute right-2 bottom-3 h-8 w-8 rounded-md',
                         'flex items-center justify-center transition-all duration-300',
                         input.trim() && !isStreaming && status === 'active'
                           ? 'bg-claude text-white hover:bg-claude/90 shadow-[0_0_12px_rgba(217,119,87,0.5)] animate-pulse'

--- a/src/app/components/features/new-task-dialog/questions-panel.tsx
+++ b/src/app/components/features/new-task-dialog/questions-panel.tsx
@@ -136,7 +136,7 @@ export function QuestionsPanel({
   );
 
   return (
-    <div className="flex flex-col h-full bg-gradient-to-br from-surface via-surface to-claude/[0.02]">
+    <div className="flex flex-col h-full min-h-0 bg-gradient-to-br from-surface via-surface to-claude/[0.02]">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-claude/20 bg-claude/5">
         <div className="flex items-center gap-2">
@@ -166,7 +166,7 @@ export function QuestionsPanel({
       </div>
 
       {/* Questions list - scrollable */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-3">
         {pendingQuestions.questions.map((question: ClarifyingQuestion, index: number) => (
           <QuestionCard
             key={`${pendingQuestions.id}-${index}`}

--- a/src/app/components/features/session-history/components/index.ts
+++ b/src/app/components/features/session-history/components/index.ts
@@ -1,0 +1,11 @@
+export { ExportDropdown } from './export-dropdown';
+export { ReplayControls } from './replay-controls';
+export { SessionCard } from './session-card';
+export { SessionDetailView } from './session-detail-view';
+export { SessionSummary } from './session-summary';
+export { SessionTimeline } from './session-timeline';
+export { StreamEntry } from './stream-entry';
+export { StreamViewer } from './stream-viewer';
+export { ToolCallCard } from './tool-call-card';
+export { ToolCallSummaryBar } from './tool-call-summary-bar';
+export { ToolCallTimeline } from './tool-call-timeline';

--- a/src/app/components/features/session-history/components/session-detail-view.tsx
+++ b/src/app/components/features/session-history/components/session-detail-view.tsx
@@ -18,6 +18,7 @@ import { formatDuration, formatTimeOfDay } from '../utils/format-duration';
 import { ExportDropdown } from './export-dropdown';
 import { SessionSummary } from './session-summary';
 import { StreamViewer } from './stream-viewer';
+import { ToolCallTimeline } from './tool-call-timeline';
 
 export function SessionDetailView({
   session,
@@ -26,7 +27,7 @@ export function SessionDetailView({
   onDelete,
   onRefresh,
 }: SessionDetailViewProps): React.JSX.Element {
-  const { entries, isLoading: eventsLoading } = useSessionEvents(session);
+  const { entries, toolCalls, toolCallStats, isLoading: eventsLoading } = useSessionEvents(session);
 
   // Loading state
   if (isLoading) {
@@ -132,6 +133,12 @@ export function SessionDetailView({
     value: `${formattedDate} at ${formatTimeOfDay(session.createdAt)}`,
   });
 
+  metaItems.push({
+    icon: <Wrench className="h-3.5 w-3.5" />,
+    label: 'Tools',
+    value: toolCallStats.totalCalls.toString(),
+  });
+
   return (
     <section
       className="flex flex-1 flex-col overflow-hidden bg-canvas"
@@ -183,6 +190,11 @@ export function SessionDetailView({
 
       {/* Stream viewer */}
       <StreamViewer entries={entries} isLoading={eventsLoading} />
+
+      {/* Tool Calls Timeline - only show if there are tool calls */}
+      {toolCalls.length > 0 && (
+        <ToolCallTimeline toolCalls={toolCalls} stats={toolCallStats} isLoading={eventsLoading} />
+      )}
 
       {/* Session summary */}
       <SessionSummary

--- a/src/app/components/features/session-history/components/tool-call-card.tsx
+++ b/src/app/components/features/session-history/components/tool-call-card.tsx
@@ -1,0 +1,235 @@
+import {
+  CaretDown,
+  CaretRight,
+  CheckCircle,
+  CircleNotch,
+  Clock,
+  Gear,
+  XCircle,
+} from '@phosphor-icons/react';
+import { cva } from 'class-variance-authority';
+import { useState } from 'react';
+import { cn } from '@/lib/utils/cn';
+import type { ToolCallCardProps, ToolCallStatus } from '../types';
+import { TOOL_CALL_STATUS_COLORS } from '../types';
+import { formatDuration } from '../utils/format-duration';
+
+const MAX_PAYLOAD_LENGTH = 500;
+
+const cardVariants = cva('rounded-md border transition-colors duration-fast ease-out', {
+  variants: {
+    status: {
+      running: 'border-accent/40 bg-accent/5',
+      complete: 'border-success/40 bg-success/5',
+      error: 'border-danger/40 bg-danger/5',
+    },
+  },
+  defaultVariants: {
+    status: 'running',
+  },
+});
+
+const statusBadgeVariants = cva(
+  'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+  {
+    variants: {
+      status: {
+        running: 'bg-accent/15 text-accent animate-pulse',
+        complete: 'bg-success/15 text-success',
+        error: 'bg-danger/15 text-danger',
+      },
+    },
+    defaultVariants: {
+      status: 'running',
+    },
+  }
+);
+
+const statusIcons: Record<
+  ToolCallStatus,
+  React.ComponentType<{ className?: string; weight?: 'bold' | 'fill' }>
+> = {
+  running: CircleNotch,
+  complete: CheckCircle,
+  error: XCircle,
+};
+
+function formatPayload(payload: unknown, isExpanded: boolean): string {
+  try {
+    const jsonString = JSON.stringify(payload, null, 2);
+
+    if (!isExpanded && jsonString.length > MAX_PAYLOAD_LENGTH) {
+      return `${jsonString.slice(0, MAX_PAYLOAD_LENGTH)}...`;
+    }
+
+    return jsonString;
+  } catch (error) {
+    console.warn(
+      '[ToolCallCard] Failed to serialize payload:',
+      error instanceof Error ? error.message : 'Unknown error'
+    );
+    return '[Unable to display payload - serialization failed]';
+  }
+}
+
+function getInputSummary(input: unknown): string {
+  if (input == null) {
+    return '';
+  }
+
+  try {
+    if (typeof input === 'object' && input !== null) {
+      const obj = input as Record<string, unknown>;
+
+      // Common tool input patterns
+      if ('file_path' in obj && typeof obj.file_path === 'string') {
+        return obj.file_path;
+      }
+      if ('file' in obj && typeof obj.file === 'string') {
+        return obj.file;
+      }
+      if ('path' in obj && typeof obj.path === 'string') {
+        return obj.path;
+      }
+      if ('pattern' in obj && typeof obj.pattern === 'string') {
+        return obj.pattern;
+      }
+      if ('command' in obj && typeof obj.command === 'string') {
+        const cmd = obj.command;
+        return cmd.length > 50 ? `${cmd.slice(0, 50)}...` : cmd;
+      }
+      if ('query' in obj && typeof obj.query === 'string') {
+        const query = obj.query;
+        return query.length > 50 ? `${query.slice(0, 50)}...` : query;
+      }
+
+      // Fallback: show first string value
+      for (const value of Object.values(obj)) {
+        if (typeof value === 'string' && value.length > 0) {
+          return value.length > 50 ? `${value.slice(0, 50)}...` : value;
+        }
+      }
+    }
+  } catch (error) {
+    console.warn('[ToolCallCard] Error extracting input summary:', error);
+    return '';
+  }
+
+  return '';
+}
+
+export function ToolCallCard({
+  toolCall,
+  defaultExpanded = false,
+  onExpandedChange,
+}: ToolCallCardProps): React.JSX.Element {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  const StatusIcon = statusIcons[toolCall.status];
+  const inputSummary = getInputSummary(toolCall.input);
+  const hasOutput = toolCall.output !== undefined;
+  const hasError = toolCall.status === 'error' && toolCall.error;
+
+  const handleToggle = () => {
+    const newExpanded = !isExpanded;
+    setIsExpanded(newExpanded);
+    onExpandedChange?.(newExpanded);
+  };
+
+  return (
+    <div
+      className={cardVariants({ status: toolCall.status })}
+      data-testid="tool-call-card"
+      data-tool-status={toolCall.status}
+    >
+      {/* Header - always visible */}
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 p-2.5 text-left"
+        onClick={handleToggle}
+        aria-expanded={isExpanded}
+      >
+        {/* Expand/collapse indicator */}
+        <span className="flex-shrink-0 text-fg-subtle">
+          {isExpanded ? (
+            <CaretDown className="h-3.5 w-3.5" weight="bold" />
+          ) : (
+            <CaretRight className="h-3.5 w-3.5" weight="bold" />
+          )}
+        </span>
+
+        {/* Timestamp */}
+        <span className="min-w-12 flex-shrink-0 font-mono text-xs text-fg-subtle">
+          {toolCall.timeOffset}
+        </span>
+
+        {/* Tool icon and name */}
+        <span className="flex items-center gap-1.5">
+          <Gear
+            className={cn('h-3.5 w-3.5', TOOL_CALL_STATUS_COLORS[toolCall.status].text)}
+            weight="bold"
+          />
+          <span className="font-mono text-sm font-medium text-fg">{toolCall.tool}</span>
+        </span>
+
+        {/* Input summary (truncated) */}
+        {inputSummary && <span className="truncate text-xs text-fg-muted">{inputSummary}</span>}
+
+        {/* Spacer */}
+        <span className="flex-1" />
+
+        {/* Duration badge */}
+        {toolCall.duration !== undefined && (
+          <span className="inline-flex flex-shrink-0 items-center gap-1 rounded bg-surface-muted px-1.5 py-0.5 text-[10px] font-medium text-fg-muted">
+            <Clock className="h-3 w-3" weight="bold" />
+            {formatDuration(toolCall.duration)}
+          </span>
+        )}
+
+        {/* Status badge */}
+        <span className={cn(statusBadgeVariants({ status: toolCall.status }), 'flex-shrink-0')}>
+          <StatusIcon
+            className={cn('h-3 w-3', toolCall.status === 'running' && 'animate-spin')}
+            weight={toolCall.status === 'complete' || toolCall.status === 'error' ? 'fill' : 'bold'}
+          />
+          {toolCall.status}
+        </span>
+      </button>
+
+      {/* Expanded content */}
+      {isExpanded && (
+        <div className="border-t border-border bg-surface-subtle p-3">
+          {/* Error message */}
+          {hasError && (
+            <div className="mb-3 rounded border border-danger/30 bg-danger/10 p-2">
+              <span className="text-xs font-medium text-danger">Error: </span>
+              <span className="text-xs text-danger">{toolCall.error}</span>
+            </div>
+          )}
+
+          {/* Input section */}
+          <div className="mb-3">
+            <span className="mb-1 block text-[10px] font-medium uppercase tracking-wide text-fg-muted">
+              Input
+            </span>
+            <pre className="overflow-x-auto rounded bg-surface-muted p-2 font-mono text-xs text-fg-muted">
+              <code>{formatPayload(toolCall.input, isExpanded)}</code>
+            </pre>
+          </div>
+
+          {/* Output section */}
+          {hasOutput && (
+            <div>
+              <span className="mb-1 block text-[10px] font-medium uppercase tracking-wide text-fg-muted">
+                Output
+              </span>
+              <pre className="max-h-64 overflow-auto rounded bg-surface-muted p-2 font-mono text-xs text-fg-muted">
+                <code>{formatPayload(toolCall.output, isExpanded)}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/features/session-history/components/tool-call-summary-bar.tsx
+++ b/src/app/components/features/session-history/components/tool-call-summary-bar.tsx
@@ -1,4 +1,4 @@
-import { Clock, Gear, WarningCircle } from '@phosphor-icons/react';
+import { Clock, Gear, Timer, WarningCircle } from '@phosphor-icons/react';
 import type * as React from 'react';
 import type { ToolCallSummaryBarProps } from '../types';
 import { formatDuration } from '../utils/format-duration';
@@ -28,6 +28,14 @@ export function ToolCallSummaryBar({ stats }: ToolCallSummaryBarProps): React.JS
             {stats.errorCount}
           </span>{' '}
           Errors
+        </span>
+
+        <span className="h-3 w-px bg-border" />
+
+        <span className="flex items-center gap-1 text-fg-muted">
+          <Timer className="h-3.5 w-3.5" weight="bold" />
+          Total:{' '}
+          <span className="font-medium text-fg">{formatDuration(stats.totalDurationMs)}</span>
         </span>
 
         <span className="h-3 w-px bg-border" />

--- a/src/app/components/features/session-history/components/tool-call-summary-bar.tsx
+++ b/src/app/components/features/session-history/components/tool-call-summary-bar.tsx
@@ -1,0 +1,42 @@
+import { Clock, Gear, WarningCircle } from '@phosphor-icons/react';
+import type * as React from 'react';
+import type { ToolCallSummaryBarProps } from '../types';
+import { formatDuration } from '../utils/format-duration';
+
+export function ToolCallSummaryBar({ stats }: ToolCallSummaryBarProps): React.JSX.Element {
+  const hasErrors = stats.errorCount > 0;
+
+  return (
+    <div
+      className="shrink-0 border-t border-border bg-surface-subtle px-3 py-2 md:px-4"
+      data-testid="tool-call-summary-bar"
+    >
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+        <span className="font-medium text-fg-muted">Tools</span>
+        <span className="h-3 w-px bg-border" />
+
+        <span className="flex items-center gap-1 text-fg-muted">
+          <Gear className="h-3.5 w-3.5" weight="bold" />
+          <span className="font-medium text-fg">{stats.totalCalls}</span> Calls
+        </span>
+
+        <span className="h-3 w-px bg-border" />
+
+        <span className={`flex items-center gap-1 ${hasErrors ? 'text-danger' : 'text-fg-muted'}`}>
+          <WarningCircle className="h-3.5 w-3.5" weight="bold" />
+          <span className={`font-medium ${hasErrors ? 'text-danger' : 'text-fg'}`}>
+            {stats.errorCount}
+          </span>{' '}
+          Errors
+        </span>
+
+        <span className="h-3 w-px bg-border" />
+
+        <span className="flex items-center gap-1 text-fg-muted">
+          <Clock className="h-3.5 w-3.5" weight="bold" />
+          Avg: <span className="font-medium text-fg">{formatDuration(stats.avgDurationMs)}</span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/features/session-history/components/tool-call-timeline.tsx
+++ b/src/app/components/features/session-history/components/tool-call-timeline.tsx
@@ -1,4 +1,5 @@
 import { Wrench } from '@phosphor-icons/react';
+import type * as React from 'react';
 import { useMemo } from 'react';
 import { Skeleton } from '@/app/components/ui/skeleton';
 import { cn } from '@/lib/utils/cn';

--- a/src/app/components/features/session-history/components/tool-call-timeline.tsx
+++ b/src/app/components/features/session-history/components/tool-call-timeline.tsx
@@ -1,0 +1,148 @@
+import { Wrench } from '@phosphor-icons/react';
+import { useMemo } from 'react';
+import { Skeleton } from '@/app/components/ui/skeleton';
+import { cn } from '@/lib/utils/cn';
+import type { ToolCallTimelineProps } from '../types';
+import { ToolCallCard } from './tool-call-card';
+import { ToolCallSummaryBar } from './tool-call-summary-bar';
+
+export function ToolCallTimeline({
+  toolCalls,
+  stats,
+  isLoading = false,
+  filterTool,
+  onFilterChange,
+}: ToolCallTimelineProps): React.JSX.Element {
+  // Extract unique tool names for filter options
+  const uniqueToolNames = useMemo(() => {
+    const names = new Set(toolCalls.map((tc) => tc.tool));
+    return Array.from(names).sort();
+  }, [toolCalls]);
+
+  // Filter tool calls by selected tool
+  const filteredToolCalls = useMemo(() => {
+    if (!filterTool) {
+      return toolCalls;
+    }
+    return toolCalls.filter((tc) => tc.tool === filterTool);
+  }, [toolCalls, filterTool]);
+
+  const handleFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    onFilterChange?.(value === '' ? undefined : value);
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <section
+        className="flex flex-col overflow-hidden rounded-lg border border-border bg-surface"
+        data-testid="tool-call-timeline-loading"
+      >
+        {/* Header skeleton */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton variant="text" width={16} height={16} />
+            <Skeleton variant="text" width={80} height={16} />
+            <Skeleton variant="text" width={24} height={18} className="rounded-full" />
+          </div>
+          <Skeleton variant="text" width={120} height={32} className="rounded" />
+        </div>
+
+        {/* Summary bar skeleton */}
+        <div className="border-b border-border bg-surface-subtle px-4 py-2">
+          <div className="flex items-center gap-4">
+            <Skeleton variant="text" width={40} height={14} />
+            <Skeleton variant="text" width={60} height={14} />
+            <Skeleton variant="text" width={60} height={14} />
+            <Skeleton variant="text" width={80} height={14} />
+          </div>
+        </div>
+
+        {/* Tool call card skeletons */}
+        <div className="flex-1 space-y-2 overflow-y-auto p-4">
+          {['skeleton-0', 'skeleton-1', 'skeleton-2'].map((id) => (
+            <div key={id} className="rounded-md border border-border bg-surface-subtle p-3">
+              <div className="flex items-center gap-3">
+                <Skeleton variant="text" width={12} height={12} />
+                <Skeleton variant="text" width={40} height={14} />
+                <Skeleton variant="text" width={60} height={14} />
+                <div className="flex-1" />
+                <Skeleton variant="text" width={50} height={16} className="rounded" />
+                <Skeleton variant="text" width={60} height={16} className="rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  // Empty state
+  if (toolCalls.length === 0) {
+    return (
+      <section
+        className="flex flex-col items-center justify-center rounded-lg border border-border bg-surface py-12"
+        data-testid="tool-call-timeline-empty"
+      >
+        <Wrench className="mb-3 h-10 w-10 text-fg-subtle" />
+        <h3 className="mb-1 text-sm font-medium text-fg">No tool calls</h3>
+        <p className="text-xs text-fg-muted">No tool calls in this session</p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="flex flex-col overflow-hidden rounded-lg border border-border bg-surface"
+      data-testid="tool-call-timeline"
+    >
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Wrench className="h-4 w-4 text-fg-muted" weight="bold" />
+          <h3 className="text-sm font-semibold text-fg">Tool Calls</h3>
+          <span className="inline-flex items-center justify-center rounded-full bg-accent/15 px-2 py-0.5 text-xs font-medium text-accent">
+            {toolCalls.length}
+          </span>
+        </div>
+
+        {/* Filter dropdown */}
+        {uniqueToolNames.length > 1 && onFilterChange && (
+          <select
+            value={filterTool ?? ''}
+            onChange={handleFilterChange}
+            className={cn(
+              'h-8 rounded border border-border bg-surface px-2 text-xs text-fg',
+              'focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent'
+            )}
+            aria-label="Filter by tool"
+          >
+            <option value="">All Tools</option>
+            {uniqueToolNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        )}
+      </header>
+
+      {/* Summary bar */}
+      <ToolCallSummaryBar stats={stats} />
+
+      {/* Tool call list */}
+      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        {filteredToolCalls.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-xs text-fg-muted">No tool calls match the selected filter</p>
+          </div>
+        ) : (
+          filteredToolCalls.map((toolCall) => (
+            <ToolCallCard key={toolCall.id} toolCall={toolCall} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/features/session-history/types.ts
+++ b/src/app/components/features/session-history/types.ts
@@ -36,6 +36,8 @@ export interface ToolCallStats {
   readonly totalCalls: number;
   readonly errorCount: number;
   readonly avgDurationMs: number;
+  /** Total execution time across all tool calls in milliseconds */
+  readonly totalDurationMs: number;
   readonly toolBreakdown: ReadonlyArray<{ readonly tool: string; readonly count: number }>;
 }
 
@@ -132,6 +134,14 @@ export interface StreamEntry {
     input: Record<string, unknown>;
     output?: unknown;
     status: ToolCallStatus;
+    /** Time offset when tool started */
+    startTimeOffset: string;
+    /** Time offset when tool completed (undefined if still running) */
+    endTimeOffset?: string;
+    /** Duration in milliseconds (undefined if still running) */
+    duration?: number;
+    /** Error message if status is 'error' */
+    error?: string;
   };
   /** Model used for this message (assistant messages only) */
   model?: string;

--- a/src/app/components/features/session-history/types.ts
+++ b/src/app/components/features/session-history/types.ts
@@ -42,11 +42,11 @@ export interface ToolCallStats {
 // ===== Tool Call Status Colors =====
 
 /** Text colors for tool call status - used for icon coloring */
-export const TOOL_CALL_STATUS_COLORS: Record<ToolCallStatus, { text: string }> = {
+export const TOOL_CALL_STATUS_COLORS = {
   running: { text: 'text-accent' },
   complete: { text: 'text-success' },
   error: { text: 'text-danger' },
-};
+} as const satisfies Record<ToolCallStatus, { text: string }>;
 
 // ===== Session Filter Types =====
 

--- a/src/app/components/features/session-history/types.ts
+++ b/src/app/components/features/session-history/types.ts
@@ -129,20 +129,20 @@ export interface StreamEntry {
   timeOffset: string;
   content: string;
   /** Tool call details if type is 'tool' */
-  toolCall?: {
-    name: string;
-    input: Record<string, unknown>;
-    output?: unknown;
-    status: ToolCallStatus;
+  toolCall?: Readonly<{
+    readonly name: string;
+    readonly input: Record<string, unknown>;
+    readonly output?: unknown;
+    readonly status: ToolCallStatus;
     /** Time offset when tool started */
-    startTimeOffset: string;
+    readonly startTimeOffset: string;
     /** Time offset when tool completed (undefined if still running) */
-    endTimeOffset?: string;
+    readonly endTimeOffset?: string;
     /** Duration in milliseconds (undefined if still running) */
-    duration?: number;
+    readonly duration?: number;
     /** Error message if status is 'error' */
-    error?: string;
-  };
+    readonly error?: string;
+  }>;
   /** Model used for this message (assistant messages only) */
   model?: string;
   /** Token usage for this message */

--- a/src/app/components/features/session-history/types.ts
+++ b/src/app/components/features/session-history/types.ts
@@ -1,6 +1,53 @@
 import type { SessionStatus } from '@/db/schema/enums';
 import type { SessionEvent, SessionEventType } from '@/services/session.service';
 
+// ===== Tool Call Types =====
+
+/**
+ * Tool call execution status
+ * - running: Tool has started but no result received
+ * - complete: Tool finished successfully
+ * - error: Tool finished with an error
+ */
+export type ToolCallStatus = 'running' | 'complete' | 'error';
+
+export interface ToolCallEntry {
+  /** Unique ID for the tool call (from tool:start event) */
+  readonly id: string;
+  /** Tool name (e.g., "Read", "Grep", "Edit") */
+  readonly tool: string;
+  /** Input parameters passed to the tool */
+  readonly input: Record<string, unknown> | undefined;
+  /** Output result from the tool (undefined if still running) */
+  readonly output?: unknown;
+  /** Execution status */
+  readonly status: ToolCallStatus;
+  /** Execution duration in milliseconds (undefined if still running) */
+  readonly duration?: number;
+  /** Timestamp when tool started (Unix ms) */
+  readonly timestamp: number;
+  /** Formatted time offset from session start (e.g. "1:35" or "1:23:45" for times over an hour) */
+  readonly timeOffset: string;
+  /** Error message if status is 'error' */
+  readonly error?: string;
+}
+
+export interface ToolCallStats {
+  readonly totalCalls: number;
+  readonly errorCount: number;
+  readonly avgDurationMs: number;
+  readonly toolBreakdown: ReadonlyArray<{ readonly tool: string; readonly count: number }>;
+}
+
+// ===== Tool Call Status Colors =====
+
+/** Text colors for tool call status - used for icon coloring */
+export const TOOL_CALL_STATUS_COLORS: Record<ToolCallStatus, { text: string }> = {
+  running: { text: 'text-accent' },
+  complete: { text: 'text-success' },
+  error: { text: 'text-danger' },
+};
+
 // ===== Session Filter Types =====
 
 export interface SessionFilters {
@@ -76,7 +123,7 @@ export interface StreamEntry {
   id: string;
   type: StreamEntryType;
   timestamp: number;
-  /** Formatted time offset from session start (e.g. "1:35") */
+  /** Formatted time offset from session start (e.g. "1:35" or "1:23:45" for times over an hour) */
   timeOffset: string;
   content: string;
   /** Tool call details if type is 'tool' */
@@ -84,7 +131,7 @@ export interface StreamEntry {
     name: string;
     input: Record<string, unknown>;
     output?: unknown;
-    status: 'pending' | 'running' | 'complete' | 'error';
+    status: ToolCallStatus;
   };
   /** Model used for this message (assistant messages only) */
   model?: string;
@@ -216,6 +263,35 @@ export interface ExportDropdownProps {
   onExport: (format: ExportFormat) => void;
   /** Disabled state */
   disabled?: boolean;
+}
+
+// ===== Tool Call Component Props =====
+
+export interface ToolCallCardProps {
+  /** Tool call entry data */
+  toolCall: ToolCallEntry;
+  /** Whether the card is expanded by default */
+  defaultExpanded?: boolean;
+  /** Callback when card is expanded/collapsed */
+  onExpandedChange?: (expanded: boolean) => void;
+}
+
+export interface ToolCallSummaryBarProps {
+  /** Tool call statistics */
+  stats: ToolCallStats;
+}
+
+export interface ToolCallTimelineProps {
+  /** Tool call entries to display */
+  toolCalls: ToolCallEntry[];
+  /** Tool call statistics */
+  stats: ToolCallStats;
+  /** Loading state */
+  isLoading?: boolean;
+  /** Filter by tool name */
+  filterTool?: string;
+  /** Callback when filter changes */
+  onFilterChange?: (tool: string | undefined) => void;
 }
 
 // ===== Status Colors =====

--- a/src/app/components/features/session-history/utils/parse-tool-calls.ts
+++ b/src/app/components/features/session-history/utils/parse-tool-calls.ts
@@ -1,0 +1,257 @@
+import type { SessionEvent } from '@/services/session.service';
+import type { ToolCallEntry, ToolCallStats, ToolCallStatus } from '../types';
+import { calculateTimeOffset, formatTimeOffset } from './format-duration';
+
+const LOG_PREFIX = '[parse-tool-calls]';
+
+/**
+ * Data structure for tool:start events from durable streams.
+ * All properties except id are optional to handle malformed events gracefully.
+ * Supports both legacy `name` field and newer `tool` field.
+ */
+interface ToolStartData {
+  id: string;
+  /** Tool name (newer format from streaming hooks) */
+  tool?: string;
+  /** Tool name (legacy format) */
+  name?: string;
+  input?: Record<string, unknown>;
+}
+
+/**
+ * Data structure for tool:result events from durable streams.
+ * All properties except id are optional to handle malformed events gracefully.
+ * Supports both legacy `name` field and newer `tool` field.
+ */
+interface ToolResultData {
+  id: string;
+  /** Tool name (newer format from streaming hooks) */
+  tool?: string;
+  /** Tool name (legacy format) */
+  name?: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+  /** Error message (legacy format) */
+  error?: string;
+  /** Error flag from streaming hooks */
+  isError?: boolean;
+}
+
+/**
+ * Validates and narrows event data to ToolStartData.
+ * Checks that data is a non-null, non-array object with a string id.
+ */
+function isToolStartData(data: unknown): data is ToolStartData {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+  // id must be a non-empty string for pairing
+  if (!('id' in obj) || typeof obj.id !== 'string' || obj.id === '') {
+    return false;
+  }
+  // tool or name should be string if present
+  if ('tool' in obj && obj.tool !== undefined && typeof obj.tool !== 'string') {
+    console.warn(LOG_PREFIX, 'tool:start event has non-string tool:', obj.tool);
+    return false;
+  }
+  if ('name' in obj && obj.name !== undefined && typeof obj.name !== 'string') {
+    console.warn(LOG_PREFIX, 'tool:start event has non-string name:', obj.name);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Validates and narrows event data to ToolResultData.
+ * Checks that data is a non-null, non-array object with a string id.
+ */
+function isToolResultData(data: unknown): data is ToolResultData {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+  // id must be a non-empty string for pairing
+  if (!('id' in obj) || typeof obj.id !== 'string' || obj.id === '') {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Parse tool calls from session events
+ *
+ * Pairs tool:start events with their corresponding tool:result events by ID.
+ * Calculates duration from timestamp differences.
+ * Handles orphan tool:start events (still running).
+ * Logs warnings for malformed or orphan events.
+ *
+ * @param events - Array of session events
+ * @param sessionStartTime - Unix timestamp (ms) when session started
+ * @returns Array of tool call entries sorted by timestamp ascending
+ */
+export function parseToolCallsFromEvents(
+  events: SessionEvent[],
+  sessionStartTime: number
+): ToolCallEntry[] {
+  // Map to store tool:start events by ID for pairing
+  const startEventsById = new Map<string, { event: SessionEvent; data: ToolStartData }>();
+
+  // Map to store tool:result events by ID
+  const resultEventsById = new Map<string, { event: SessionEvent; data: ToolResultData }>();
+
+  // Track malformed events for logging
+  let droppedStartCount = 0;
+  let droppedResultCount = 0;
+
+  // Process all events and categorize them
+  for (const event of events) {
+    if (event.type === 'tool:start') {
+      if (isToolStartData(event.data)) {
+        startEventsById.set(event.data.id, { event, data: event.data });
+      } else {
+        droppedStartCount++;
+      }
+    } else if (event.type === 'tool:result') {
+      if (isToolResultData(event.data)) {
+        resultEventsById.set(event.data.id, { event, data: event.data });
+      } else {
+        droppedResultCount++;
+      }
+    }
+  }
+
+  // Log dropped events
+  if (droppedStartCount > 0) {
+    console.warn(
+      LOG_PREFIX,
+      `Dropped ${droppedStartCount} tool:start event(s) with missing or invalid id`
+    );
+  }
+  if (droppedResultCount > 0) {
+    console.warn(
+      LOG_PREFIX,
+      `Dropped ${droppedResultCount} tool:result event(s) with missing or invalid id`
+    );
+  }
+
+  const toolCalls: ToolCallEntry[] = [];
+
+  // Process all tool:start events
+  for (const [id, { event: startEvent, data: startData }] of startEventsById) {
+    const resultEntry = resultEventsById.get(id);
+    const offsetMs = calculateTimeOffset(startEvent.timestamp, sessionStartTime);
+
+    let status: ToolCallStatus;
+    let duration: number | undefined;
+    let output: unknown;
+    let error: string | undefined;
+
+    if (resultEntry) {
+      const { event: resultEvent, data: resultData } = resultEntry;
+
+      // Calculate duration from start to result
+      const calculatedDuration = resultEvent.timestamp - startEvent.timestamp;
+
+      // Validate duration is not negative (timestamps out of order)
+      if (calculatedDuration < 0) {
+        console.warn(
+          LOG_PREFIX,
+          'Negative duration detected for tool call. ID:',
+          id,
+          'Start:',
+          startEvent.timestamp,
+          'End:',
+          resultEvent.timestamp
+        );
+        duration = 0;
+      } else {
+        duration = calculatedDuration;
+      }
+
+      // Determine status based on result (check both error and isError fields)
+      if (resultData.error || resultData.isError) {
+        status = 'error';
+        error = resultData.error ?? 'Tool execution failed';
+      } else {
+        status = 'complete';
+      }
+
+      output = resultData.output;
+    } else {
+      // No matching result - tool is still running
+      status = 'running';
+    }
+
+    // Get tool name (prefer 'tool' field over 'name' for newer streaming hooks format)
+    const toolName = startData.tool ?? startData.name;
+    if (!toolName) {
+      console.warn(
+        LOG_PREFIX,
+        'Tool call missing name. ID:',
+        id,
+        'Timestamp:',
+        startEvent.timestamp
+      );
+    }
+
+    toolCalls.push({
+      id,
+      tool: toolName ?? '[unnamed tool]',
+      input: startData.input,
+      output,
+      status,
+      duration,
+      timestamp: startEvent.timestamp,
+      timeOffset: formatTimeOffset(offsetMs),
+      error,
+    });
+  }
+
+  // Check for orphan result events (results without matching starts)
+  for (const [id] of resultEventsById) {
+    if (!startEventsById.has(id)) {
+      console.warn(LOG_PREFIX, 'Found tool:result without matching tool:start. ID:', id);
+    }
+  }
+
+  // Sort by timestamp ascending
+  toolCalls.sort((a, b) => a.timestamp - b.timestamp);
+
+  return toolCalls;
+}
+
+/**
+ * Calculate aggregate statistics from tool calls
+ *
+ * @param toolCalls - Array of tool call entries
+ * @returns Aggregate statistics including totals, averages, and breakdown by tool
+ */
+export function calculateToolCallStats(toolCalls: readonly ToolCallEntry[]): ToolCallStats {
+  const totalCalls = toolCalls.length;
+  const errorCount = toolCalls.filter((tc) => tc.status === 'error').length;
+
+  // Calculate average duration for all calls with recorded duration (complete or error)
+  const callsWithDuration = toolCalls.filter((tc) => tc.duration !== undefined && tc.duration >= 0);
+  const totalDuration = callsWithDuration.reduce((sum, tc) => sum + (tc.duration ?? 0), 0);
+  const avgDurationMs = callsWithDuration.length > 0 ? totalDuration / callsWithDuration.length : 0;
+
+  // Calculate breakdown by tool name
+  const toolCountMap = new Map<string, number>();
+  for (const tc of toolCalls) {
+    const currentCount = toolCountMap.get(tc.tool) ?? 0;
+    toolCountMap.set(tc.tool, currentCount + 1);
+  }
+
+  // Convert to array and sort by count descending
+  const toolBreakdown = Array.from(toolCountMap.entries())
+    .map(([tool, count]) => ({ tool, count }))
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    totalCalls,
+    errorCount,
+    avgDurationMs,
+    toolBreakdown,
+  };
+}

--- a/src/app/components/features/session-history/utils/parse-tool-calls.ts
+++ b/src/app/components/features/session-history/utils/parse-tool-calls.ts
@@ -83,8 +83,13 @@ function isToolResultData(data: unknown): data is ToolResultData {
  *
  * Pairs tool:start events with their corresponding tool:result events by ID.
  * Calculates duration from timestamp differences.
- * Handles orphan tool:start events (still running).
- * Logs warnings for malformed or orphan events.
+ *
+ * Logs warnings for:
+ *   - Malformed events (missing/invalid id)
+ *   - Orphan tool:result events (results without matching starts)
+ *
+ * Note: Orphan tool:start events (no result yet) are returned with status 'running'
+ * and do not generate warnings - this is expected for in-progress tool calls.
  *
  * @param events - Array of session events
  * @param sessionStartTime - Unix timestamp (ms) when session started

--- a/src/app/components/features/session-history/utils/parse-tool-calls.ts
+++ b/src/app/components/features/session-history/utils/parse-tool-calls.ts
@@ -231,10 +231,11 @@ export function calculateToolCallStats(toolCalls: readonly ToolCallEntry[]): Too
   const totalCalls = toolCalls.length;
   const errorCount = toolCalls.filter((tc) => tc.status === 'error').length;
 
-  // Calculate average duration for all calls with recorded duration (complete or error)
+  // Calculate average and total duration for all calls with recorded duration (complete or error)
   const callsWithDuration = toolCalls.filter((tc) => tc.duration !== undefined && tc.duration >= 0);
-  const totalDuration = callsWithDuration.reduce((sum, tc) => sum + (tc.duration ?? 0), 0);
-  const avgDurationMs = callsWithDuration.length > 0 ? totalDuration / callsWithDuration.length : 0;
+  const totalDurationMs = callsWithDuration.reduce((sum, tc) => sum + (tc.duration ?? 0), 0);
+  const avgDurationMs =
+    callsWithDuration.length > 0 ? totalDurationMs / callsWithDuration.length : 0;
 
   // Calculate breakdown by tool name
   const toolCountMap = new Map<string, number>();
@@ -252,6 +253,7 @@ export function calculateToolCallStats(toolCalls: readonly ToolCallEntry[]): Too
     totalCalls,
     errorCount,
     avgDurationMs,
+    totalDurationMs,
     toolBreakdown,
   };
 }

--- a/src/app/components/ui/tool-access-selector.tsx
+++ b/src/app/components/ui/tool-access-selector.tsx
@@ -161,20 +161,23 @@ export function ToolAccessSelector({
                   {allGroupSelected ? 'Deselect all' : 'Select all'}
                 </button>
               </div>
-              <div className="grid gap-2 sm:grid-cols-3">
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
                 {tools.map((tool) => (
                   <label
                     key={tool}
                     htmlFor={`tool-${tool}`}
-                    className="flex cursor-pointer items-center gap-2 text-sm text-fg"
+                    className="flex cursor-pointer items-center gap-2 text-sm text-fg min-w-0"
                   >
                     <Checkbox
                       id={`tool-${tool}`}
                       checked={isAllowAll || value.includes(tool)}
                       onCheckedChange={() => toggleTool(tool)}
                       disabled={isAllowAll}
+                      className="flex-shrink-0"
                     />
-                    {tool}
+                    <span className="truncate" title={tool}>
+                      {tool}
+                    </span>
                   </label>
                 ))}
               </div>

--- a/src/app/routeTree.gen.ts
+++ b/src/app/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as CatalogWorkflowIdRouteImport } from './routes/catalog/$workflo
 import { Route as ApiWorkflowsRouteImport } from './routes/api/workflows'
 import { Route as ApiTemplatesRouteImport } from './routes/api/templates'
 import { Route as ApiTasksRouteImport } from './routes/api/tasks'
+import { Route as ApiSettingsRouteImport } from './routes/api/settings'
 import { Route as ApiSessionsRouteImport } from './routes/api/sessions'
 import { Route as ApiProjectsRouteImport } from './routes/api/projects'
 import { Route as ApiGithubRouteImport } from './routes/api/github'
@@ -231,6 +232,11 @@ const ApiTemplatesRoute = ApiTemplatesRouteImport.update({
 const ApiTasksRoute = ApiTasksRouteImport.update({
   id: '/api/tasks',
   path: '/api/tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSettingsRoute = ApiSettingsRouteImport.update({
+  id: '/api/settings',
+  path: '/api/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSessionsRoute = ApiSessionsRouteImport.update({
@@ -554,6 +560,7 @@ export interface FileRoutesByFullPath {
   '/api/github': typeof ApiGithubRoute
   '/api/projects': typeof ApiProjectsRouteWithChildren
   '/api/sessions': typeof ApiSessionsRouteWithChildren
+  '/api/settings': typeof ApiSettingsRoute
   '/api/tasks': typeof ApiTasksRouteWithChildren
   '/api/templates': typeof ApiTemplatesRouteWithChildren
   '/api/workflows': typeof ApiWorkflowsRouteWithChildren
@@ -642,6 +649,7 @@ export interface FileRoutesByTo {
   '/api/github': typeof ApiGithubRoute
   '/api/projects': typeof ApiProjectsRouteWithChildren
   '/api/sessions': typeof ApiSessionsRouteWithChildren
+  '/api/settings': typeof ApiSettingsRoute
   '/api/tasks': typeof ApiTasksRouteWithChildren
   '/api/templates': typeof ApiTemplatesRouteWithChildren
   '/api/workflows': typeof ApiWorkflowsRouteWithChildren
@@ -732,6 +740,7 @@ export interface FileRoutesById {
   '/api/github': typeof ApiGithubRoute
   '/api/projects': typeof ApiProjectsRouteWithChildren
   '/api/sessions': typeof ApiSessionsRouteWithChildren
+  '/api/settings': typeof ApiSettingsRoute
   '/api/tasks': typeof ApiTasksRouteWithChildren
   '/api/templates': typeof ApiTemplatesRouteWithChildren
   '/api/workflows': typeof ApiWorkflowsRouteWithChildren
@@ -823,6 +832,7 @@ export interface FileRouteTypes {
     | '/api/github'
     | '/api/projects'
     | '/api/sessions'
+    | '/api/settings'
     | '/api/tasks'
     | '/api/templates'
     | '/api/workflows'
@@ -911,6 +921,7 @@ export interface FileRouteTypes {
     | '/api/github'
     | '/api/projects'
     | '/api/sessions'
+    | '/api/settings'
     | '/api/tasks'
     | '/api/templates'
     | '/api/workflows'
@@ -1000,6 +1011,7 @@ export interface FileRouteTypes {
     | '/api/github'
     | '/api/projects'
     | '/api/sessions'
+    | '/api/settings'
     | '/api/tasks'
     | '/api/templates'
     | '/api/workflows'
@@ -1090,6 +1102,7 @@ export interface RootRouteChildren {
   ApiGithubRoute: typeof ApiGithubRoute
   ApiProjectsRoute: typeof ApiProjectsRouteWithChildren
   ApiSessionsRoute: typeof ApiSessionsRouteWithChildren
+  ApiSettingsRoute: typeof ApiSettingsRoute
   ApiTasksRoute: typeof ApiTasksRouteWithChildren
   ApiTemplatesRoute: typeof ApiTemplatesRouteWithChildren
   ApiWorkflowsRoute: typeof ApiWorkflowsRouteWithChildren
@@ -1313,6 +1326,13 @@ declare module '@tanstack/react-router' {
       path: '/api/tasks'
       fullPath: '/api/tasks'
       preLoaderRoute: typeof ApiTasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/settings': {
+      id: '/api/settings'
+      path: '/api/settings'
+      fullPath: '/api/settings'
+      preLoaderRoute: typeof ApiSettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/sessions': {
@@ -1981,6 +2001,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiGithubRoute: ApiGithubRoute,
   ApiProjectsRoute: ApiProjectsRouteWithChildren,
   ApiSessionsRoute: ApiSessionsRouteWithChildren,
+  ApiSettingsRoute: ApiSettingsRoute,
   ApiTasksRoute: ApiTasksRouteWithChildren,
   ApiTemplatesRoute: ApiTemplatesRouteWithChildren,
   ApiWorkflowsRoute: ApiWorkflowsRouteWithChildren,

--- a/src/app/routes/api/settings.ts
+++ b/src/app/routes/api/settings.ts
@@ -1,0 +1,69 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { getApiServicesOrThrow } from '@/app/routes/api/runtime';
+import { withErrorHandling } from '@/lib/api/middleware';
+import { failure, success } from '@/lib/api/response';
+import { getSettingsSchema, updateSettingsSchema } from '@/lib/api/schemas';
+import { parseBody, parseQuery } from '@/lib/api/validation';
+
+const { settingsService } = getApiServicesOrThrow();
+
+export const Route = createFileRoute('/api/settings')({
+  server: {
+    handlers: {
+      /**
+       * GET /api/settings - Get all settings or specific keys
+       *
+       * Query params:
+       *   - keys (optional): Comma-separated list of setting keys
+       *
+       * Returns: { settings: { [key: string]: unknown } }
+       */
+      GET: withErrorHandling(async ({ request }) => {
+        const parsed = parseQuery(new URL(request.url).searchParams, getSettingsSchema);
+        if (!parsed.ok) {
+          return Response.json(failure(parsed.error), { status: 400 });
+        }
+
+        const { keys } = parsed.value;
+
+        const result = keys
+          ? await settingsService.getMany(
+              keys
+                .split(',')
+                .map((k) => k.trim())
+                .filter(Boolean)
+            )
+          : await settingsService.getAll();
+
+        if (!result.ok) {
+          return Response.json(failure(result.error), { status: result.error.status });
+        }
+
+        return Response.json(success({ settings: result.value }));
+      }),
+
+      /**
+       * PUT /api/settings - Update settings
+       *
+       * Body: { settings: { [key: string]: unknown } }
+       *
+       * Returns: { ok: true }
+       */
+      PUT: withErrorHandling(async ({ request }) => {
+        const parsed = await parseBody(request, updateSettingsSchema);
+        if (!parsed.ok) {
+          return Response.json(failure(parsed.error), { status: 400 });
+        }
+
+        const { settings } = parsed.value;
+
+        const result = await settingsService.setMany(settings);
+        if (!result.ok) {
+          return Response.json(failure(result.error), { status: result.error.status });
+        }
+
+        return Response.json(success({ ok: true }));
+      }),
+    },
+  },
+});

--- a/src/app/routes/api/tasks/create-with-ai/start.ts
+++ b/src/app/routes/api/tasks/create-with-ai/start.ts
@@ -27,7 +27,10 @@ export const Route = createFileRoute('/api/tasks/create-with-ai/start')({
 
         try {
           const body = await request.json();
-          const { projectId } = body as { projectId: string };
+          const { projectId, allowedTools } = body as {
+            projectId: string;
+            allowedTools?: string[];
+          };
 
           if (!projectId) {
             return new Response(
@@ -42,7 +45,10 @@ export const Route = createFileRoute('/api/tasks/create-with-ai/start')({
             );
           }
 
-          const result = await services.taskCreationService.startConversation(projectId);
+          const result = await services.taskCreationService.startConversation(
+            projectId,
+            allowedTools
+          );
 
           if (!result.ok) {
             return new Response(

--- a/src/app/services/services.ts
+++ b/src/app/services/services.ts
@@ -8,6 +8,7 @@ import { ProjectService } from '@/services/project.service';
 import { SandboxConfigService } from '@/services/sandbox-config.service';
 import type { DurableStreamsServer } from '@/services/session.service';
 import { SessionService } from '@/services/session.service';
+import { SettingsService } from '@/services/settings.service';
 import { TaskService } from '@/services/task.service';
 import {
   createTaskCreationService,
@@ -28,6 +29,7 @@ export type Services = {
   planModeService: PlanModeService;
   projectService: ProjectService;
   sandboxConfigService: SandboxConfigService;
+  settingsService: SettingsService;
   taskCreationService: TaskCreationService;
   taskService: TaskService;
   sessionService: SessionService;
@@ -82,6 +84,7 @@ export function createServices(context: {
     const templateService = new TemplateService(context.db);
     const sandboxConfigService = new SandboxConfigService(context.db);
     const githubTokenService = new GitHubTokenService(context.db);
+    const settingsService = new SettingsService(context.db);
 
     // Create durable streams service wrapper
     const durableStreamsService = new DurableStreamsService(context.streams);
@@ -111,6 +114,7 @@ export function createServices(context: {
       planModeService,
       projectService,
       sandboxConfigService,
+      settingsService,
       taskCreationService,
       taskService,
       sessionService,

--- a/src/app/services/services.ts
+++ b/src/app/services/services.ts
@@ -102,7 +102,8 @@ export function createServices(context: {
     const taskCreationService = createTaskCreationService(
       context.db,
       durableStreamsService,
-      sessionService
+      sessionService,
+      settingsService
     );
 
     console.log('[Services] All services initialized successfully');

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -13,6 +13,7 @@ export * from './sandboxes';
 export * from './session-events';
 export * from './session-summaries';
 export * from './sessions';
+export * from './settings';
 export * from './tasks';
 export * from './template-projects';
 export * from './templates';

--- a/src/db/schema/settings.ts
+++ b/src/db/schema/settings.ts
@@ -1,0 +1,18 @@
+import { sql } from 'drizzle-orm';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * Settings table for storing user preferences (replaces localStorage)
+ * Keys: 'task_creation_model', 'task_creation_tools'
+ */
+export const settings = sqliteTable('settings', {
+  // The setting name (e.g., 'task_creation_model', 'task_creation_tools')
+  key: text('key').primaryKey(),
+  // JSON-encoded value
+  value: text('value').notNull(),
+  // Timestamps
+  updatedAt: text('updated_at').default(sql`(datetime('now'))`).notNull(),
+});
+
+export type Setting = typeof settings.$inferSelect;
+export type NewSetting = typeof settings.$inferInsert;

--- a/src/db/schema/settings.ts
+++ b/src/db/schema/settings.ts
@@ -3,10 +3,10 @@ import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 /**
  * Settings table for storing user preferences (replaces localStorage)
- * Keys: 'task_creation_model', 'task_creation_tools'
+ * Keys: 'taskCreation.model', 'taskCreation.tools'
  */
 export const settings = sqliteTable('settings', {
-  // The setting name (e.g., 'task_creation_model', 'task_creation_tools')
+  // The setting name (e.g., 'taskCreation.model', 'taskCreation.tools')
   key: text('key').primaryKey(),
   // JSON-encoded value
   value: text('value').notNull(),

--- a/src/lib/agents/hooks/streaming.ts
+++ b/src/lib/agents/hooks/streaming.ts
@@ -28,21 +28,45 @@ type SessionPublisher = {
   publish: (sessionId: string, event: SessionEvent) => Promise<unknown>;
 };
 
+/**
+ * Creates a unique key for tracking in-flight tool calls.
+ * Uses tool name + stringified input to match PreToolUse with PostToolUse.
+ */
+function createToolCallKey(toolName: string, toolInput: Record<string, unknown>): string {
+  try {
+    return `${toolName}:${JSON.stringify(toolInput)}`;
+  } catch {
+    // Fallback if input can't be stringified
+    return `${toolName}:${Date.now()}`;
+  }
+}
+
 export function createStreamingHooks(
   agentId: string,
   sessionId: string,
   sessionService: SessionPublisher
 ): { PreToolUse: PreToolUseHook; PostToolUse: PostToolUseHook } {
+  // Track in-flight tool calls to pair start/result events
+  const inFlightToolCalls = new Map<string, string>();
+
   return {
     PreToolUse: {
       hooks: [
         async (input: PreToolUseInput): Promise<Record<string, never>> => {
+          // Generate a unique ID for this tool call
+          const toolCallId = crypto.randomUUID();
+          const toolCallKey = createToolCallKey(input.tool_name, input.tool_input);
+
+          // Store the toolCallId for pairing with PostToolUse
+          inFlightToolCalls.set(toolCallKey, toolCallId);
+
           // Publish tool start event to session
           await sessionService.publish(sessionId, {
             id: crypto.randomUUID(),
             type: 'tool:start',
             timestamp: Date.now(),
             data: {
+              id: toolCallId,
               agentId,
               tool: input.tool_name,
               input: input.tool_input,
@@ -57,12 +81,20 @@ export function createStreamingHooks(
     PostToolUse: {
       hooks: [
         async (input: PostToolUseInput): Promise<Record<string, never>> => {
+          // Retrieve the toolCallId from the matching PreToolUse
+          const toolCallKey = createToolCallKey(input.tool_name, input.tool_input);
+          const toolCallId = inFlightToolCalls.get(toolCallKey) ?? crypto.randomUUID();
+
+          // Clean up the in-flight tracking
+          inFlightToolCalls.delete(toolCallKey);
+
           // Publish tool completion event
           await sessionService.publish(sessionId, {
             id: crypto.randomUUID(),
             type: 'tool:result',
             timestamp: Date.now(),
             data: {
+              id: toolCallId,
               agentId,
               tool: input.tool_name,
               input: input.tool_input,

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -739,8 +739,10 @@ export const apiClient = {
   taskCreation: {
     /**
      * Start a new AI task creation conversation
+     * @param projectId - Project to create task for
+     * @param allowedTools - Optional tools configured in settings
      */
-    start: (projectId: string) =>
+    start: (projectId: string, allowedTools?: string[]) =>
       apiServerFetch<{
         sessionId: string;
         projectId: string;
@@ -748,7 +750,7 @@ export const apiClient = {
         createdAt: string;
       }>('/api/tasks/create-with-ai/start', {
         method: 'POST',
-        body: { projectId },
+        body: { projectId, allowedTools },
       }),
 
     /**

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -243,7 +243,41 @@ export type UpdateSandboxConfigInput = {
 };
 
 // API client methods
+// Settings types
+export type SettingsResponse = {
+  settings: Record<string, unknown>;
+};
+
+export type SettingsUpdateResponse = {
+  ok: true;
+};
+
 export const apiClient = {
+  settings: {
+    /**
+     * Get settings by keys (or all settings if no keys provided)
+     * @param keys - Optional array of setting keys to retrieve
+     */
+    get: (keys?: string[]) => {
+      const params = new URLSearchParams();
+      if (keys && keys.length > 0) {
+        params.set('keys', keys.join(','));
+      }
+      const query = params.toString();
+      return apiServerFetch<SettingsResponse>(`/api/settings${query ? `?${query}` : ''}`);
+    },
+
+    /**
+     * Update settings
+     * @param settings - Map of setting keys to values
+     */
+    update: (settings: Record<string, unknown>) =>
+      apiServerFetch<SettingsUpdateResponse>('/api/settings', {
+        method: 'PUT',
+        body: { settings },
+      }),
+  },
+
   projects: {
     list: (params?: { limit?: number }) =>
       apiServerFetch<ProjectListResponse>(

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -441,3 +441,14 @@ export const updateWorkflowSchema = z.object({
   /** AI confidence score (0-100) */
   aiConfidence: z.number().min(0).max(100).nullable().optional(),
 });
+
+// Settings schemas
+export const getSettingsSchema = z.object({
+  /** Comma-separated list of setting keys to retrieve (optional, returns all if not specified) */
+  keys: z.string().optional(),
+});
+
+export const updateSettingsSchema = z.object({
+  /** Map of setting keys to values */
+  settings: z.record(z.string(), z.unknown()),
+});

--- a/src/lib/bootstrap/phases/schema.ts
+++ b/src/lib/bootstrap/phases/schema.ts
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS "tasks" (
   "position" INTEGER DEFAULT 0 NOT NULL,
   "labels" TEXT DEFAULT '[]',
   "priority" TEXT DEFAULT 'medium',
+  "model_override" TEXT,
   "branch" TEXT,
   "diff_summary" TEXT,
   "approved_at" TEXT,

--- a/src/lib/constants/models.ts
+++ b/src/lib/constants/models.ts
@@ -56,15 +56,20 @@ export const DEFAULT_TASK_CREATION_MODEL = 'claude-sonnet-4';
  * Get the task creation model from environment or localStorage.
  */
 export function getTaskCreationModel(): string {
-  // Server-side: check environment variable
-  if (typeof window === 'undefined') {
+  // Server-side or test environment: check environment variable
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
     const envModel = process.env.TASK_CREATION_MODEL;
     if (envModel) return getFullModelId(envModel);
     return getFullModelId(DEFAULT_TASK_CREATION_MODEL);
   }
   // Client-side: check localStorage
-  const storedModel = localStorage.getItem('task_creation_model');
-  return storedModel ? getFullModelId(storedModel) : getFullModelId(DEFAULT_TASK_CREATION_MODEL);
+  try {
+    const storedModel = localStorage.getItem('task_creation_model');
+    return storedModel ? getFullModelId(storedModel) : getFullModelId(DEFAULT_TASK_CREATION_MODEL);
+  } catch {
+    // localStorage may be blocked or unavailable
+    return getFullModelId(DEFAULT_TASK_CREATION_MODEL);
+  }
 }
 
 /** Model ID type from available models */

--- a/src/lib/constants/models.ts
+++ b/src/lib/constants/models.ts
@@ -54,6 +54,8 @@ export const DEFAULT_TASK_CREATION_MODEL = 'claude-sonnet-4';
 
 /**
  * Get the task creation model from environment or localStorage.
+ * This is the synchronous version for backwards compatibility.
+ * Prefer using getTaskCreationModelAsync() in new code.
  */
 export function getTaskCreationModel(): string {
   // Server-side or test environment: check environment variable
@@ -70,6 +72,24 @@ export function getTaskCreationModel(): string {
     // localStorage may be blocked or unavailable
     return getFullModelId(DEFAULT_TASK_CREATION_MODEL);
   }
+}
+
+/**
+ * Get the task creation model from the API (async version).
+ * Falls back to localStorage/default if API call fails.
+ * Use this in React components and async contexts.
+ */
+export async function getTaskCreationModelAsync(): Promise<string> {
+  // Server-side: use environment variable
+  if (typeof window === 'undefined') {
+    const envModel = process.env.TASK_CREATION_MODEL;
+    if (envModel) return getFullModelId(envModel);
+    return getFullModelId(DEFAULT_TASK_CREATION_MODEL);
+  }
+
+  // Client-side: use the settings hook helper
+  const { getTaskCreationModelAsync: fetchFromApi } = await import('@/lib/hooks/use-settings');
+  return fetchFromApi();
 }
 
 /** Model ID type from available models */

--- a/src/lib/constants/tools.ts
+++ b/src/lib/constants/tools.ts
@@ -47,11 +47,29 @@ export function getAgentTools(): string[] {
 
 /**
  * Get tools for task creation from localStorage or default.
+ * This is the synchronous version for backwards compatibility.
+ * Prefer using getTaskCreationToolsAsync() in new code.
  */
 export function getTaskCreationTools(): string[] {
   if (typeof window === 'undefined') return DEFAULT_TASK_CREATION_TOOLS;
   const stored = localStorage.getItem('task_creation_tools');
   return stored ? JSON.parse(stored) : DEFAULT_TASK_CREATION_TOOLS;
+}
+
+/**
+ * Get tools for task creation from the API (async version).
+ * Falls back to localStorage/default if API call fails.
+ * Use this in React components and async contexts.
+ */
+export async function getTaskCreationToolsAsync(): Promise<string[]> {
+  // Server-side: return default
+  if (typeof window === 'undefined') {
+    return DEFAULT_TASK_CREATION_TOOLS;
+  }
+
+  // Client-side: use the settings hook helper
+  const { getTaskCreationToolsAsync: fetchFromApi } = await import('@/lib/hooks/use-settings');
+  return fetchFromApi();
 }
 
 /**

--- a/src/lib/hooks/use-settings.ts
+++ b/src/lib/hooks/use-settings.ts
@@ -1,0 +1,261 @@
+/**
+ * Hook for accessing application settings from the API.
+ * Provides caching and easy access to common settings like task creation model and tools.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { DEFAULT_TASK_CREATION_MODEL, getFullModelId } from '@/lib/constants/models';
+import { DEFAULT_TASK_CREATION_TOOLS } from '@/lib/constants/tools';
+
+// Setting keys
+export const SETTING_KEYS = {
+  TASK_CREATION_MODEL: 'task_creation_model',
+  TASK_CREATION_TOOLS: 'task_creation_tools',
+  AGENT_TOOLS: 'agent_tools',
+  WORKFLOW_TOOLS: 'workflow_tools',
+  ANTHROPIC_BASE_URL: 'anthropic_base_url',
+} as const;
+
+// Cache for settings to avoid refetching on every render
+let settingsCache: Record<string, unknown> = {};
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 30000; // 30 seconds
+
+/**
+ * Check if the cache is still valid
+ */
+function isCacheValid(): boolean {
+  return Date.now() - cacheTimestamp < CACHE_TTL_MS && Object.keys(settingsCache).length > 0;
+}
+
+/**
+ * Invalidate the settings cache (call after updates)
+ */
+export function invalidateSettingsCache(): void {
+  settingsCache = {};
+  cacheTimestamp = 0;
+}
+
+/**
+ * Fetch settings from the API (with caching)
+ * Can be used outside of React components
+ */
+export async function fetchSettings(keys?: string[]): Promise<Record<string, unknown>> {
+  // Check cache first
+  if (isCacheValid()) {
+    if (!keys) {
+      return settingsCache;
+    }
+    // Check if all requested keys are in cache
+    const allKeysInCache = keys.every((key) => key in settingsCache);
+    if (allKeysInCache) {
+      return keys.reduce(
+        (acc, key) => {
+          acc[key] = settingsCache[key];
+          return acc;
+        },
+        {} as Record<string, unknown>
+      );
+    }
+  }
+
+  // Fetch from API
+  const result = await apiClient.settings.get(keys);
+  if (!result.ok) {
+    console.error('[fetchSettings] Failed to fetch settings:', result.error);
+    return {};
+  }
+
+  // Update cache
+  if (!keys) {
+    // Full fetch - replace cache entirely
+    settingsCache = result.data.settings;
+    cacheTimestamp = Date.now();
+  } else {
+    // Partial fetch - merge into cache
+    Object.assign(settingsCache, result.data.settings);
+    // Only update timestamp if this was our first fetch
+    if (!cacheTimestamp) {
+      cacheTimestamp = Date.now();
+    }
+  }
+
+  return result.data.settings;
+}
+
+/**
+ * Update settings via the API
+ */
+export async function updateSettings(settings: Record<string, unknown>): Promise<boolean> {
+  const result = await apiClient.settings.update(settings);
+  if (!result.ok) {
+    console.error('[updateSettings] Failed to update settings:', result.error);
+    return false;
+  }
+
+  // Update cache with new values
+  Object.assign(settingsCache, settings);
+
+  return true;
+}
+
+/**
+ * Get the task creation model from API (async version)
+ * Falls back to default if API call fails
+ */
+export async function getTaskCreationModelAsync(): Promise<string> {
+  const settings = await fetchSettings([SETTING_KEYS.TASK_CREATION_MODEL]);
+  const model = settings[SETTING_KEYS.TASK_CREATION_MODEL];
+  if (typeof model === 'string') {
+    return getFullModelId(model);
+  }
+  return getFullModelId(DEFAULT_TASK_CREATION_MODEL);
+}
+
+/**
+ * Get the task creation tools from API (async version)
+ * Falls back to default if API call fails
+ */
+export async function getTaskCreationToolsAsync(): Promise<string[]> {
+  const settings = await fetchSettings([SETTING_KEYS.TASK_CREATION_TOOLS]);
+  const tools = settings[SETTING_KEYS.TASK_CREATION_TOOLS];
+  if (Array.isArray(tools)) {
+    return tools as string[];
+  }
+  return DEFAULT_TASK_CREATION_TOOLS;
+}
+
+/**
+ * Set the task creation model via API
+ */
+export async function setTaskCreationModelAsync(model: string): Promise<boolean> {
+  return updateSettings({ [SETTING_KEYS.TASK_CREATION_MODEL]: model });
+}
+
+/**
+ * Set the task creation tools via API
+ */
+export async function setTaskCreationToolsAsync(tools: string[]): Promise<boolean> {
+  return updateSettings({ [SETTING_KEYS.TASK_CREATION_TOOLS]: tools });
+}
+
+// ============================================================================
+// React Hook
+// ============================================================================
+
+export interface UseSettingsState {
+  /** Whether settings are being loaded */
+  isLoading: boolean;
+  /** Error message if loading failed */
+  error: string | null;
+  /** All loaded settings */
+  settings: Record<string, unknown>;
+  /** Task creation model (short ID) */
+  taskCreationModel: string;
+  /** Task creation tools */
+  taskCreationTools: string[];
+}
+
+export interface UseSettingsActions {
+  /** Refresh settings from the API */
+  refresh: () => Promise<void>;
+  /** Set the task creation model */
+  setTaskCreationModel: (model: string) => Promise<boolean>;
+  /** Set the task creation tools */
+  setTaskCreationTools: (tools: string[]) => Promise<boolean>;
+  /** Update arbitrary settings */
+  updateSettings: (settings: Record<string, unknown>) => Promise<boolean>;
+}
+
+export type UseSettingsReturn = UseSettingsState & UseSettingsActions;
+
+/**
+ * React hook for accessing and updating settings
+ */
+export function useSettings(): UseSettingsReturn {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [settings, setSettings] = useState<Record<string, unknown>>({});
+
+  // Load settings on mount
+  useEffect(() => {
+    const loadSettings = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await fetchSettings();
+        setSettings(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load settings');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadSettings();
+  }, []);
+
+  // Derived values
+  const taskCreationModel =
+    typeof settings[SETTING_KEYS.TASK_CREATION_MODEL] === 'string'
+      ? (settings[SETTING_KEYS.TASK_CREATION_MODEL] as string)
+      : DEFAULT_TASK_CREATION_MODEL;
+
+  const taskCreationTools = Array.isArray(settings[SETTING_KEYS.TASK_CREATION_TOOLS])
+    ? (settings[SETTING_KEYS.TASK_CREATION_TOOLS] as string[])
+    : DEFAULT_TASK_CREATION_TOOLS;
+
+  // Actions
+  const refresh = useCallback(async () => {
+    invalidateSettingsCache();
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetchSettings();
+      setSettings(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load settings');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const setTaskCreationModel = useCallback(async (model: string): Promise<boolean> => {
+    const success = await setTaskCreationModelAsync(model);
+    if (success) {
+      setSettings((prev) => ({ ...prev, [SETTING_KEYS.TASK_CREATION_MODEL]: model }));
+    }
+    return success;
+  }, []);
+
+  const setTaskCreationTools = useCallback(async (tools: string[]): Promise<boolean> => {
+    const success = await setTaskCreationToolsAsync(tools);
+    if (success) {
+      setSettings((prev) => ({ ...prev, [SETTING_KEYS.TASK_CREATION_TOOLS]: tools }));
+    }
+    return success;
+  }, []);
+
+  const handleUpdateSettings = useCallback(
+    async (newSettings: Record<string, unknown>): Promise<boolean> => {
+      const success = await updateSettings(newSettings);
+      if (success) {
+        setSettings((prev) => ({ ...prev, ...newSettings }));
+      }
+      return success;
+    },
+    []
+  );
+
+  return {
+    isLoading,
+    error,
+    settings,
+    taskCreationModel,
+    taskCreationTools,
+    refresh,
+    setTaskCreationModel,
+    setTaskCreationTools,
+    updateSettings: handleUpdateSettings,
+  };
+}

--- a/src/lib/task-creation/hooks.ts
+++ b/src/lib/task-creation/hooks.ts
@@ -2,6 +2,7 @@ import { eq } from '@tanstack/db';
 import { useLiveQuery } from '@tanstack/react-db';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { apiClient } from '@/lib/api/client';
+import { getTaskCreationTools } from '@/lib/constants/tools';
 import { taskCreationMessagesCollection, taskCreationSessionsCollection } from './collections';
 import type {
   PendingQuestions,
@@ -149,8 +150,11 @@ export function useTaskCreation(projectId: string): UseTaskCreationReturn {
     // Clear any previous local error
     setLocalError(null);
 
-    // Call API to start session
-    const result = await apiClient.taskCreation.start(projectId);
+    // Get configured tools from localStorage settings
+    const allowedTools = getTaskCreationTools();
+
+    // Call API to start session with configured tools
+    const result = await apiClient.taskCreation.start(projectId, allowedTools);
 
     if (!result.ok) {
       console.error('[useTaskCreation] Failed to start conversation:', result.error);

--- a/src/lib/task-creation/hooks.ts
+++ b/src/lib/task-creation/hooks.ts
@@ -2,7 +2,7 @@ import { eq } from '@tanstack/db';
 import { useLiveQuery } from '@tanstack/react-db';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { apiClient } from '@/lib/api/client';
-import { getTaskCreationTools } from '@/lib/constants/tools';
+import { getTaskCreationToolsAsync } from '@/lib/constants/tools';
 import { taskCreationMessagesCollection, taskCreationSessionsCollection } from './collections';
 import type {
   PendingQuestions,
@@ -150,8 +150,8 @@ export function useTaskCreation(projectId: string): UseTaskCreationReturn {
     // Clear any previous local error
     setLocalError(null);
 
-    // Get configured tools from localStorage settings
-    const allowedTools = getTaskCreationTools();
+    // Get configured tools from API (falls back to localStorage/defaults)
+    const allowedTools = await getTaskCreationToolsAsync();
 
     // Call API to start session with configured tools
     const result = await apiClient.taskCreation.start(projectId, allowedTools);

--- a/src/services/__tests__/task-creation.service.test.ts
+++ b/src/services/__tests__/task-creation.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_TASK_CREATION_TOOLS } from '../../lib/constants/tools.js';
 import {
   TaskCreationErrors,
   TaskCreationService,
@@ -70,6 +71,7 @@ describe('TaskCreationService', () => {
       expect(unstable_v2_createSession).toHaveBeenCalledWith({
         model: 'claude-sonnet-4-20250514',
         env: expect.objectContaining({ CLAUDE_CODE_ENABLE_TASKS: 'true' }),
+        allowedTools: DEFAULT_TASK_CREATION_TOOLS,
       });
       expect(streams.createStream).toHaveBeenCalled();
       expect(streams.publishTaskCreationStarted).toHaveBeenCalled();

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -35,7 +35,7 @@ export class SettingsService {
 
   /**
    * Get multiple settings by keys
-   * Returns a map of key -> value (parsed JSON)
+   * Returns a map of key -> value (parsed JSON, or raw string if parsing fails)
    */
   async getMany(keys: string[]): Promise<Result<Record<string, unknown>, SettingsError>> {
     try {
@@ -51,8 +51,15 @@ export class SettingsService {
       for (const setting of results) {
         try {
           settingsMap[setting.key] = JSON.parse(setting.value);
-        } catch {
-          // If JSON parsing fails, use raw value
+        } catch (parseError) {
+          // If JSON parsing fails, use raw value but log for debugging
+          console.warn(
+            '[SettingsService] Failed to parse setting value as JSON, using raw value.',
+            'Key:',
+            setting.key,
+            'Error:',
+            parseError instanceof Error ? parseError.message : String(parseError)
+          );
           settingsMap[setting.key] = setting.value;
         }
       }
@@ -65,7 +72,7 @@ export class SettingsService {
 
   /**
    * Get all settings
-   * Returns a map of key -> value (parsed JSON)
+   * Returns a map of key -> value (parsed JSON, or raw string if parsing fails)
    */
   async getAll(): Promise<Result<Record<string, unknown>, SettingsError>> {
     try {
@@ -75,8 +82,15 @@ export class SettingsService {
       for (const setting of results) {
         try {
           settingsMap[setting.key] = JSON.parse(setting.value);
-        } catch {
-          // If JSON parsing fails, use raw value
+        } catch (parseError) {
+          // If JSON parsing fails, use raw value but log for debugging
+          console.warn(
+            '[SettingsService] Failed to parse setting value as JSON, using raw value.',
+            'Key:',
+            setting.key,
+            'Error:',
+            parseError instanceof Error ? parseError.message : String(parseError)
+          );
           settingsMap[setting.key] = setting.value;
         }
       }
@@ -196,7 +210,14 @@ export class SettingsService {
     }
     try {
       return JSON.parse(result.value.value) as T;
-    } catch {
+    } catch (parseError) {
+      console.warn(
+        '[SettingsService] Failed to parse setting value, returning default.',
+        'Key:',
+        key,
+        'Error:',
+        parseError instanceof Error ? parseError.message : String(parseError)
+      );
       return defaultValue;
     }
   }

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -1,0 +1,245 @@
+import { eq, inArray } from 'drizzle-orm';
+import type { Setting } from '../db/schema/settings.js';
+import { settings } from '../db/schema/settings.js';
+import type { AppError } from '../lib/errors/base.js';
+import { createError } from '../lib/errors/base.js';
+import type { Result } from '../lib/utils/result.js';
+import { err, ok } from '../lib/utils/result.js';
+import type { Database } from '../types/database.js';
+
+export type SettingsError = AppError;
+
+export const SettingsErrors = {
+  NOT_FOUND: createError('SETTING_NOT_FOUND', 'Setting not found', 404),
+  INVALID_KEY: createError('INVALID_SETTING_KEY', 'Setting key is invalid', 400),
+  INVALID_VALUE: createError('INVALID_SETTING_VALUE', 'Setting value is invalid', 400),
+  DATABASE_ERROR: (message: string) => createError('SETTINGS_DATABASE_ERROR', message, 500),
+};
+
+export class SettingsService {
+  constructor(private db: Database) {}
+
+  /**
+   * Get a single setting by key
+   */
+  async get(key: string): Promise<Result<Setting | null, SettingsError>> {
+    try {
+      const setting = await this.db.query.settings.findFirst({
+        where: eq(settings.key, key),
+      });
+      return ok(setting ?? null);
+    } catch (error) {
+      return err(SettingsErrors.DATABASE_ERROR(String(error)));
+    }
+  }
+
+  /**
+   * Get multiple settings by keys
+   * Returns a map of key -> value (parsed JSON)
+   */
+  async getMany(keys: string[]): Promise<Result<Record<string, unknown>, SettingsError>> {
+    try {
+      if (keys.length === 0) {
+        return ok({});
+      }
+
+      const results = await this.db.query.settings.findMany({
+        where: inArray(settings.key, keys),
+      });
+
+      const settingsMap: Record<string, unknown> = {};
+      for (const setting of results) {
+        try {
+          settingsMap[setting.key] = JSON.parse(setting.value);
+        } catch {
+          // If JSON parsing fails, use raw value
+          settingsMap[setting.key] = setting.value;
+        }
+      }
+
+      return ok(settingsMap);
+    } catch (error) {
+      return err(SettingsErrors.DATABASE_ERROR(String(error)));
+    }
+  }
+
+  /**
+   * Get all settings
+   * Returns a map of key -> value (parsed JSON)
+   */
+  async getAll(): Promise<Result<Record<string, unknown>, SettingsError>> {
+    try {
+      const results = await this.db.query.settings.findMany();
+
+      const settingsMap: Record<string, unknown> = {};
+      for (const setting of results) {
+        try {
+          settingsMap[setting.key] = JSON.parse(setting.value);
+        } catch {
+          // If JSON parsing fails, use raw value
+          settingsMap[setting.key] = setting.value;
+        }
+      }
+
+      return ok(settingsMap);
+    } catch (error) {
+      return err(SettingsErrors.DATABASE_ERROR(String(error)));
+    }
+  }
+
+  /**
+   * Set a single setting
+   */
+  async set(key: string, value: unknown): Promise<Result<Setting, SettingsError>> {
+    try {
+      if (!key || typeof key !== 'string' || key.length === 0) {
+        return err(SettingsErrors.INVALID_KEY);
+      }
+
+      const serializedValue = JSON.stringify(value);
+      const now = new Date().toISOString();
+
+      // Use upsert (insert or replace on conflict)
+      const [result] = await this.db
+        .insert(settings)
+        .values({
+          key,
+          value: serializedValue,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: settings.key,
+          set: {
+            value: serializedValue,
+            updatedAt: now,
+          },
+        })
+        .returning();
+
+      if (!result) {
+        return err(SettingsErrors.DATABASE_ERROR('Failed to save setting'));
+      }
+
+      return ok(result);
+    } catch (error) {
+      return err(SettingsErrors.DATABASE_ERROR(String(error)));
+    }
+  }
+
+  /**
+   * Set multiple settings at once
+   */
+  async setMany(settingsToSet: Record<string, unknown>): Promise<Result<void, SettingsError>> {
+    try {
+      const entries = Object.entries(settingsToSet);
+      if (entries.length === 0) {
+        return ok(undefined);
+      }
+
+      const now = new Date().toISOString();
+
+      // Use a transaction to ensure atomicity
+      await this.db.transaction(async (tx) => {
+        for (const [key, value] of entries) {
+          const serializedValue = JSON.stringify(value);
+          await tx
+            .insert(settings)
+            .values({
+              key,
+              value: serializedValue,
+              updatedAt: now,
+            })
+            .onConflictDoUpdate({
+              target: settings.key,
+              set: {
+                value: serializedValue,
+                updatedAt: now,
+              },
+            });
+        }
+      });
+
+      return ok(undefined);
+    } catch (error) {
+      return err(SettingsErrors.DATABASE_ERROR(String(error)));
+    }
+  }
+
+  /**
+   * Delete a setting by key
+   */
+  async delete(key: string): Promise<Result<void, SettingsError>> {
+    try {
+      await this.db.delete(settings).where(eq(settings.key, key));
+      return ok(undefined);
+    } catch (error) {
+      return err(SettingsErrors.DATABASE_ERROR(String(error)));
+    }
+  }
+
+  // ============================================
+  // Typed getters/setters for known settings
+  // ============================================
+
+  private static readonly TASK_CREATION_MODEL_KEY = 'taskCreation.model';
+  private static readonly TASK_CREATION_TOOLS_KEY = 'taskCreation.tools';
+  private static readonly DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+  private static readonly DEFAULT_TOOLS = ['Read', 'Glob', 'Grep', 'AskUserQuestion'];
+
+  /**
+   * Get a setting value by key, returning defaultValue if not found
+   */
+  async getValue<T>(key: string, defaultValue: T): Promise<T> {
+    const result = await this.get(key);
+    if (!result.ok || !result.value) {
+      return defaultValue;
+    }
+    try {
+      return JSON.parse(result.value.value) as T;
+    } catch {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get the model used for AI task creation
+   */
+  async getTaskCreationModel(): Promise<string> {
+    return this.getValue<string>(
+      SettingsService.TASK_CREATION_MODEL_KEY,
+      SettingsService.DEFAULT_MODEL
+    );
+  }
+
+  /**
+   * Set the model used for AI task creation
+   */
+  async setTaskCreationModel(model: string): Promise<Result<void, SettingsError>> {
+    const result = await this.set(SettingsService.TASK_CREATION_MODEL_KEY, model);
+    if (!result.ok) {
+      return err(result.error);
+    }
+    return ok(undefined);
+  }
+
+  /**
+   * Get the tools available for AI task creation
+   */
+  async getTaskCreationTools(): Promise<string[]> {
+    return this.getValue<string[]>(
+      SettingsService.TASK_CREATION_TOOLS_KEY,
+      SettingsService.DEFAULT_TOOLS
+    );
+  }
+
+  /**
+   * Set the tools available for AI task creation
+   */
+  async setTaskCreationTools(tools: string[]): Promise<Result<void, SettingsError>> {
+    const result = await this.set(SettingsService.TASK_CREATION_TOOLS_KEY, tools);
+    if (!result.ok) {
+      return err(result.error);
+    }
+    return ok(undefined);
+  }
+}

--- a/tests/components/session-history/parse-tool-calls.test.ts
+++ b/tests/components/session-history/parse-tool-calls.test.ts
@@ -453,6 +453,20 @@ describe('calculateToolCallStats', () => {
     expect(result.avgDurationMs).toBe(200);
   });
 
+  it('calculates totalDurationMs correctly (sum of all durations)', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'complete', duration: 100 }),
+      createToolCallEntry({ id: '2', tool: 'Grep', status: 'complete', duration: 200 }),
+      createToolCallEntry({ id: '3', tool: 'Edit', status: 'running', duration: undefined }), // No duration (running)
+      createToolCallEntry({ id: '4', tool: 'Bash', status: 'complete', duration: 300 }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    // Total of 100 + 200 + 300 = 600 (excludes running call with no duration)
+    expect(result.totalDurationMs).toBe(600);
+  });
+
   it('creates toolBreakdown sorted by count descending', () => {
     const toolCalls: ToolCallEntry[] = [
       createToolCallEntry({ id: '1', tool: 'Read', status: 'complete' }),

--- a/tests/components/session-history/parse-tool-calls.test.ts
+++ b/tests/components/session-history/parse-tool-calls.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolCallEntry } from '@/app/components/features/session-history/types';
+import {
+  calculateToolCallStats,
+  parseToolCallsFromEvents,
+} from '@/app/components/features/session-history/utils/parse-tool-calls';
+import type { SessionEvent } from '@/services/session.service';
+
+/**
+ * Helper to create a mock SessionEvent
+ */
+function createMockEvent(
+  overrides: Partial<SessionEvent> & { type: SessionEvent['type']; data: unknown }
+): SessionEvent {
+  return {
+    id: `event-${Math.random().toString(36).slice(2)}`,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+/**
+ * Helper to create a tool:start event
+ */
+function createToolStartEvent(
+  toolCallId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  timestamp: number
+): SessionEvent {
+  return createMockEvent({
+    type: 'tool:start',
+    timestamp,
+    data: {
+      id: toolCallId,
+      name: toolName,
+      input,
+    },
+  });
+}
+
+/**
+ * Helper to create a tool:result event
+ */
+function createToolResultEvent(
+  toolCallId: string,
+  toolName: string,
+  output: unknown,
+  timestamp: number,
+  error?: string
+): SessionEvent {
+  return createMockEvent({
+    type: 'tool:result',
+    timestamp,
+    data: {
+      id: toolCallId,
+      name: toolName,
+      output,
+      error,
+    },
+  });
+}
+
+describe('parseToolCallsFromEvents', () => {
+  const sessionStartTime = 1706284800000; // Fixed timestamp for tests
+
+  it('parses empty events array returns empty tool calls', () => {
+    const result = parseToolCallsFromEvents([], sessionStartTime);
+
+    expect(result).toEqual([]);
+  });
+
+  it('pairs tool:start with tool:result events correctly by ID', () => {
+    const startEvent = createToolStartEvent(
+      'tool-1',
+      'Read',
+      { file_path: '/test.ts' },
+      sessionStartTime + 1000
+    );
+    const resultEvent = createToolResultEvent(
+      'tool-1',
+      'Read',
+      'file contents',
+      sessionStartTime + 2000
+    );
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'tool-1',
+      tool: 'Read',
+      input: { file_path: '/test.ts' },
+      output: 'file contents',
+      status: 'complete',
+      duration: 1000,
+    });
+  });
+
+  it('sets status to running for unpaired tool:start events (no matching result)', () => {
+    const startEvent = createToolStartEvent(
+      'tool-orphan',
+      'Grep',
+      { pattern: 'test' },
+      sessionStartTime + 500
+    );
+
+    const result = parseToolCallsFromEvents([startEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'tool-orphan',
+      tool: 'Grep',
+      status: 'running',
+      duration: undefined,
+      output: undefined,
+    });
+  });
+
+  it('sets status to error when tool:result has error field', () => {
+    const startEvent = createToolStartEvent(
+      'tool-err',
+      'Edit',
+      { file_path: '/missing.ts' },
+      sessionStartTime + 100
+    );
+    const resultEvent = createToolResultEvent(
+      'tool-err',
+      'Edit',
+      undefined,
+      sessionStartTime + 200,
+      'File not found'
+    );
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'tool-err',
+      status: 'error',
+      error: 'File not found',
+      duration: 100,
+    });
+  });
+
+  it('sets status to complete when tool:result has no error', () => {
+    const startEvent = createToolStartEvent(
+      'tool-ok',
+      'Bash',
+      { command: 'ls' },
+      sessionStartTime + 300
+    );
+    const resultEvent = createToolResultEvent(
+      'tool-ok',
+      'Bash',
+      'file1.ts\nfile2.ts',
+      sessionStartTime + 450
+    );
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'tool-ok',
+      status: 'complete',
+      error: undefined,
+    });
+  });
+
+  it('calculates duration correctly (result timestamp - start timestamp)', () => {
+    const startTimestamp = sessionStartTime + 1000;
+    const resultTimestamp = sessionStartTime + 3500;
+    const expectedDuration = 2500;
+
+    const startEvent = createToolStartEvent(
+      'tool-dur',
+      'Read',
+      { file_path: '/a.ts' },
+      startTimestamp
+    );
+    const resultEvent = createToolResultEvent('tool-dur', 'Read', 'content', resultTimestamp);
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result[0]?.duration).toBe(expectedDuration);
+  });
+
+  it('sorts tool calls by timestamp ascending', () => {
+    const events = [
+      createToolStartEvent('tool-3', 'Grep', { pattern: 'c' }, sessionStartTime + 3000),
+      createToolResultEvent('tool-3', 'Grep', 'match c', sessionStartTime + 3500),
+      createToolStartEvent('tool-1', 'Read', { file_path: '/a.ts' }, sessionStartTime + 1000),
+      createToolResultEvent('tool-1', 'Read', 'content a', sessionStartTime + 1500),
+      createToolStartEvent('tool-2', 'Edit', { file_path: '/b.ts' }, sessionStartTime + 2000),
+      createToolResultEvent('tool-2', 'Edit', 'edited b', sessionStartTime + 2500),
+    ];
+
+    const result = parseToolCallsFromEvents(events, sessionStartTime);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.id).toBe('tool-1');
+    expect(result[1]?.id).toBe('tool-2');
+    expect(result[2]?.id).toBe('tool-3');
+  });
+
+  it('handles events with missing IDs gracefully (skips them)', () => {
+    const validStart = createToolStartEvent(
+      'tool-valid',
+      'Read',
+      { file_path: '/test.ts' },
+      sessionStartTime + 100
+    );
+    const validResult = createToolResultEvent(
+      'tool-valid',
+      'Read',
+      'contents',
+      sessionStartTime + 200
+    );
+
+    // Event with missing ID in data
+    const invalidStart = createMockEvent({
+      type: 'tool:start',
+      timestamp: sessionStartTime + 300,
+      data: { name: 'Grep', input: { pattern: 'foo' } }, // No id field
+    });
+
+    const invalidResult = createMockEvent({
+      type: 'tool:result',
+      timestamp: sessionStartTime + 400,
+      data: { name: 'Grep', output: 'bar' }, // No id field
+    });
+
+    const result = parseToolCallsFromEvents(
+      [validStart, invalidStart, validResult, invalidResult],
+      sessionStartTime
+    );
+
+    // Only the valid tool call should be included
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('tool-valid');
+  });
+
+  it('formats timeOffset correctly using session start time', () => {
+    // Tool starts 95 seconds after session start (1:35)
+    const startEvent = createToolStartEvent(
+      'tool-time',
+      'Read',
+      { file_path: '/x.ts' },
+      sessionStartTime + 95000
+    );
+    const resultEvent = createToolResultEvent(
+      'tool-time',
+      'Read',
+      'data',
+      sessionStartTime + 96000
+    );
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result[0]?.timeOffset).toBe('1:35');
+  });
+
+  it('handles multiple tool calls with some running and some complete', () => {
+    const events = [
+      createToolStartEvent('tool-a', 'Read', { file_path: '/a.ts' }, sessionStartTime + 1000),
+      createToolResultEvent('tool-a', 'Read', 'content a', sessionStartTime + 1500),
+      createToolStartEvent('tool-b', 'Grep', { pattern: 'search' }, sessionStartTime + 2000),
+      // tool-b has no result - still running
+      createToolStartEvent('tool-c', 'Edit', { file_path: '/c.ts' }, sessionStartTime + 3000),
+      createToolResultEvent(
+        'tool-c',
+        'Edit',
+        undefined,
+        sessionStartTime + 3200,
+        'Permission denied'
+      ),
+    ];
+
+    const result = parseToolCallsFromEvents(events, sessionStartTime);
+
+    expect(result).toHaveLength(3);
+    expect(result.find((tc) => tc.id === 'tool-a')?.status).toBe('complete');
+    expect(result.find((tc) => tc.id === 'tool-b')?.status).toBe('running');
+    expect(result.find((tc) => tc.id === 'tool-c')?.status).toBe('error');
+  });
+
+  it('uses "[unnamed tool]" as tool name when name is missing from data', () => {
+    const startEvent = createMockEvent({
+      type: 'tool:start',
+      timestamp: sessionStartTime + 100,
+      data: { id: 'tool-noname', input: {} }, // No name field
+    });
+
+    const result = parseToolCallsFromEvents([startEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.tool).toBe('[unnamed tool]');
+  });
+
+  it('uses "tool" field (newer streaming hooks format) when present', () => {
+    const startEvent = createMockEvent({
+      type: 'tool:start',
+      timestamp: sessionStartTime + 100,
+      data: { id: 'tool-new', tool: 'Read', input: { file_path: '/test.ts' } },
+    });
+    const resultEvent = createMockEvent({
+      type: 'tool:result',
+      timestamp: sessionStartTime + 200,
+      data: { id: 'tool-new', tool: 'Read', output: 'file contents' },
+    });
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.tool).toBe('Read');
+    expect(result[0]?.status).toBe('complete');
+  });
+
+  it('prefers "tool" field over "name" field when both are present', () => {
+    const startEvent = createMockEvent({
+      type: 'tool:start',
+      timestamp: sessionStartTime + 100,
+      data: { id: 'tool-both', tool: 'Read', name: 'OldName', input: {} },
+    });
+
+    const result = parseToolCallsFromEvents([startEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.tool).toBe('Read');
+  });
+
+  it('sets status to error when tool:result has isError flag (streaming hooks format)', () => {
+    const startEvent = createMockEvent({
+      type: 'tool:start',
+      timestamp: sessionStartTime + 100,
+      data: { id: 'tool-iserr', tool: 'Bash', input: { command: 'fail' } },
+    });
+    const resultEvent = createMockEvent({
+      type: 'tool:result',
+      timestamp: sessionStartTime + 200,
+      data: { id: 'tool-iserr', tool: 'Bash', output: { is_error: true }, isError: true },
+    });
+
+    const result = parseToolCallsFromEvents([startEvent, resultEvent], sessionStartTime);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('error');
+    expect(result[0]?.error).toBe('Tool execution failed');
+  });
+});
+
+describe('calculateToolCallStats', () => {
+  it('returns zero stats for empty array', () => {
+    const result = calculateToolCallStats([]);
+
+    expect(result).toEqual({
+      totalCalls: 0,
+      errorCount: 0,
+      avgDurationMs: 0,
+      toolBreakdown: [],
+    });
+  });
+
+  it('counts total calls correctly', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'complete' }),
+      createToolCallEntry({ id: '2', tool: 'Grep', status: 'complete' }),
+      createToolCallEntry({ id: '3', tool: 'Edit', status: 'running' }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    expect(result.totalCalls).toBe(3);
+  });
+
+  it('counts error status calls', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'complete' }),
+      createToolCallEntry({ id: '2', tool: 'Edit', status: 'error', error: 'failed' }),
+      createToolCallEntry({ id: '3', tool: 'Bash', status: 'error', error: 'timeout' }),
+      createToolCallEntry({ id: '4', tool: 'Grep', status: 'running' }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    expect(result.errorCount).toBe(2);
+  });
+
+  it('calculates average duration only from calls with duration', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'complete', duration: 100 }),
+      createToolCallEntry({ id: '2', tool: 'Grep', status: 'complete', duration: 200 }),
+      createToolCallEntry({ id: '3', tool: 'Edit', status: 'running', duration: undefined }), // No duration
+      createToolCallEntry({ id: '4', tool: 'Bash', status: 'complete', duration: 300 }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    // Average of 100, 200, 300 = 200
+    expect(result.avgDurationMs).toBe(200);
+  });
+
+  it('creates toolBreakdown sorted by count descending', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'complete' }),
+      createToolCallEntry({ id: '2', tool: 'Grep', status: 'complete' }),
+      createToolCallEntry({ id: '3', tool: 'Read', status: 'complete' }),
+      createToolCallEntry({ id: '4', tool: 'Edit', status: 'complete' }),
+      createToolCallEntry({ id: '5', tool: 'Read', status: 'complete' }),
+      createToolCallEntry({ id: '6', tool: 'Grep', status: 'complete' }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    expect(result.toolBreakdown).toEqual([
+      { tool: 'Read', count: 3 },
+      { tool: 'Grep', count: 2 },
+      { tool: 'Edit', count: 1 },
+    ]);
+  });
+
+  it('handles calls without duration (running) in avg calculation', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'running', duration: undefined }),
+      createToolCallEntry({ id: '2', tool: 'Grep', status: 'running', duration: undefined }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    // No calls with duration, so average should be 0
+    expect(result.avgDurationMs).toBe(0);
+  });
+
+  it('handles mix of tools and statuses correctly', () => {
+    const toolCalls: ToolCallEntry[] = [
+      createToolCallEntry({ id: '1', tool: 'Read', status: 'complete', duration: 50 }),
+      createToolCallEntry({
+        id: '2',
+        tool: 'Read',
+        status: 'error',
+        duration: 10,
+        error: 'not found',
+      }),
+      createToolCallEntry({ id: '3', tool: 'Bash', status: 'complete', duration: 150 }),
+      createToolCallEntry({ id: '4', tool: 'Bash', status: 'running', duration: undefined }),
+      createToolCallEntry({ id: '5', tool: 'Glob', status: 'complete', duration: 30 }),
+    ];
+
+    const result = calculateToolCallStats(toolCalls);
+
+    expect(result.totalCalls).toBe(5);
+    expect(result.errorCount).toBe(1);
+    // Average of 50, 10, 150, 30 = 240 / 4 = 60
+    expect(result.avgDurationMs).toBe(60);
+    expect(result.toolBreakdown).toEqual([
+      { tool: 'Read', count: 2 },
+      { tool: 'Bash', count: 2 },
+      { tool: 'Glob', count: 1 },
+    ]);
+  });
+});
+
+/**
+ * Helper to create a ToolCallEntry for testing calculateToolCallStats
+ */
+function createToolCallEntry(
+  overrides: Partial<ToolCallEntry> & Pick<ToolCallEntry, 'id' | 'tool' | 'status'>
+): ToolCallEntry {
+  return {
+    input: {},
+    output: undefined,
+    timestamp: Date.now(),
+    timeOffset: '0:00',
+    ...overrides,
+  };
+}

--- a/tests/components/session-history/tool-call-card.test.tsx
+++ b/tests/components/session-history/tool-call-card.test.tsx
@@ -1,0 +1,369 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ToolCallCard } from '@/app/components/features/session-history/components/tool-call-card';
+import type { ToolCallEntry } from '@/app/components/features/session-history/types';
+
+// ===== Mock Data =====
+
+const mockToolCallComplete: ToolCallEntry = {
+  id: 'tc-1',
+  tool: 'Read',
+  input: { file_path: '/test.ts' },
+  output: { content: 'file contents' },
+  status: 'complete',
+  duration: 1500,
+  timestamp: 1706284800000,
+  timeOffset: '0:15',
+};
+
+const mockToolCallRunningGrep: ToolCallEntry = {
+  id: 'tc-2',
+  tool: 'Grep',
+  input: { pattern: 'TODO', path: '/src' },
+  status: 'running',
+  timestamp: 1706284860000,
+  timeOffset: '1:15',
+};
+
+const mockToolCallRunning: ToolCallEntry = {
+  id: 'tc-3',
+  tool: 'Bash',
+  input: { command: 'npm test' },
+  status: 'running',
+  timestamp: 1706284920000,
+  timeOffset: '2:15',
+};
+
+const mockToolCallError: ToolCallEntry = {
+  id: 'tc-4',
+  tool: 'Edit',
+  input: { file_path: '/missing.ts', old_string: 'foo', new_string: 'bar' },
+  status: 'error',
+  error: 'File not found: /missing.ts',
+  duration: 50,
+  timestamp: 1706284980000,
+  timeOffset: '3:15',
+};
+
+const mockToolCallNoDuration: ToolCallEntry = {
+  id: 'tc-5',
+  tool: 'Glob',
+  input: { pattern: '**/*.ts' },
+  output: { files: ['a.ts', 'b.ts'] },
+  status: 'complete',
+  timestamp: 1706285040000,
+  timeOffset: '4:15',
+};
+
+const mockToolCallLongPayload: ToolCallEntry = {
+  id: 'tc-6',
+  tool: 'Read',
+  input: { file_path: '/very-long-path.ts' },
+  output: { content: 'x'.repeat(600) },
+  status: 'complete',
+  duration: 100,
+  timestamp: 1706285100000,
+  timeOffset: '5:15',
+};
+
+// ===== Rendering Tests =====
+
+describe('ToolCallCard Rendering', () => {
+  it('renders tool name correctly', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    expect(screen.getByText('Read')).toBeInTheDocument();
+  });
+
+  it('renders timestamp (timeOffset) correctly', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    expect(screen.getByText('0:15')).toBeInTheDocument();
+  });
+
+  it('renders duration badge when duration is provided', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    // 1500ms = 1s (formatted by formatDuration)
+    expect(screen.getByText('1s')).toBeInTheDocument();
+  });
+
+  it('does not render duration badge when duration is undefined', () => {
+    render(<ToolCallCard toolCall={mockToolCallNoDuration} />);
+
+    // The Clock icon with duration text should not be present
+    // Check that no duration-related text is shown (like "0s" or any seconds)
+    const card = screen.getByTestId('tool-call-card');
+    // Duration badge shows seconds, but the status badge also exists
+    // Look for the specific duration format pattern
+    expect(card.textContent).not.toMatch(/\d+s.*Glob/);
+  });
+
+  it('renders correct status badge text for running', () => {
+    render(<ToolCallCard toolCall={mockToolCallRunning} />);
+
+    expect(screen.getByText('running')).toBeInTheDocument();
+  });
+
+  it('renders correct status badge text for complete', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    expect(screen.getByText('complete')).toBeInTheDocument();
+  });
+
+  it('renders correct status badge text for error', () => {
+    render(<ToolCallCard toolCall={mockToolCallError} />);
+
+    expect(screen.getByText('error')).toBeInTheDocument();
+  });
+});
+
+// ===== Status Variant Tests =====
+
+describe('ToolCallCard Status Variants', () => {
+  it('applies running status styling with pulse animation', () => {
+    render(<ToolCallCard toolCall={mockToolCallRunning} />);
+
+    const card = screen.getByTestId('tool-call-card');
+    expect(card).toHaveAttribute('data-tool-status', 'running');
+
+    // Check that the status badge has animate-pulse class
+    const statusBadge = screen.getByText('running').closest('span');
+    expect(statusBadge).toHaveClass('animate-pulse');
+  });
+
+  it('applies complete status styling (success colors)', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    const card = screen.getByTestId('tool-call-card');
+    expect(card).toHaveAttribute('data-tool-status', 'complete');
+  });
+
+  it('applies error status styling (danger colors)', () => {
+    render(<ToolCallCard toolCall={mockToolCallError} />);
+
+    const card = screen.getByTestId('tool-call-card');
+    expect(card).toHaveAttribute('data-tool-status', 'error');
+  });
+});
+
+// ===== Expand/Collapse Tests =====
+
+describe('ToolCallCard Expand/Collapse', () => {
+  it('card is collapsed by default', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    // When collapsed, the input/output sections should not be visible
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+    expect(screen.queryByText('Output')).not.toBeInTheDocument();
+  });
+
+  it('clicking header expands the card', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    // Click the header button to expand
+    const headerButton = screen.getByRole('button');
+    await user.click(headerButton);
+
+    // Now the Input section should be visible
+    expect(screen.getByText('Input')).toBeInTheDocument();
+  });
+
+  it('clicking again collapses the card', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    const headerButton = screen.getByRole('button');
+
+    // Expand
+    await user.click(headerButton);
+    expect(screen.getByText('Input')).toBeInTheDocument();
+
+    // Collapse
+    await user.click(headerButton);
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+  });
+
+  it('shows input JSON when expanded', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    const headerButton = screen.getByRole('button');
+    await user.click(headerButton);
+
+    // Should show the Input section label
+    expect(screen.getByText('Input')).toBeInTheDocument();
+
+    // Should show the input JSON with file_path key
+    expect(screen.getByText(/file_path/)).toBeInTheDocument();
+
+    // The path appears twice - once in header summary and once in JSON
+    // Just verify we have the JSON structure visible
+    const codeElements = document.querySelectorAll('code');
+    const inputCode = Array.from(codeElements).find((el) =>
+      el.textContent?.includes('"file_path"')
+    );
+    expect(inputCode).toBeInTheDocument();
+  });
+
+  it('shows output JSON when expanded and output exists', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    const headerButton = screen.getByRole('button');
+    await user.click(headerButton);
+
+    // Should show the Output section
+    expect(screen.getByText('Output')).toBeInTheDocument();
+    expect(screen.getByText(/file contents/)).toBeInTheDocument();
+  });
+
+  it('does not show output section when output is undefined', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallRunningGrep} />);
+
+    const headerButton = screen.getByRole('button');
+    await user.click(headerButton);
+
+    // Input should be shown, but not Output
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.queryByText('Output')).not.toBeInTheDocument();
+  });
+
+  it('shows error message when status is error and expanded', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallError} />);
+
+    const headerButton = screen.getByRole('button');
+    await user.click(headerButton);
+
+    // Should show the error message
+    expect(screen.getByText(/Error:/)).toBeInTheDocument();
+    expect(screen.getByText(/File not found: \/missing\.ts/)).toBeInTheDocument();
+  });
+
+  it('truncates long payloads when collapsed', () => {
+    // When collapsed, the card only shows header info
+    // The truncation happens in formatPayload when !isExpanded
+    // Since collapsed cards don't show payload, we need to test
+    // that when we have a component that shows preview, it truncates
+    // Actually, looking at the component, collapsed cards don't show any payload
+    // The truncation is only visible if we had inline preview (which we don't)
+    // Let's verify the collapsed state doesn't show the long content
+    render(<ToolCallCard toolCall={mockToolCallLongPayload} />);
+
+    // When collapsed, the 600-char content should not be visible at all
+    const longContent = 'x'.repeat(600);
+    expect(screen.queryByText(longContent)).not.toBeInTheDocument();
+  });
+
+  it('shows full payload when expanded', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallLongPayload} />);
+
+    const headerButton = screen.getByRole('button');
+    await user.click(headerButton);
+
+    // When expanded, the full content should be visible (not truncated)
+    // The output has 600 'x' characters which exceeds MAX_PAYLOAD_LENGTH (500)
+    // When expanded, formatPayload returns the full JSON
+    expect(screen.getByText('Output')).toBeInTheDocument();
+
+    // Get the code elements and find the one with the output
+    const codeElements = document.querySelectorAll('code');
+    const outputCode = Array.from(codeElements).find((el) =>
+      el.textContent?.includes('x'.repeat(100))
+    );
+
+    // The output should contain the full 600 'x' characters, not truncated with '...'
+    expect(outputCode?.textContent).toContain('x'.repeat(600));
+    expect(outputCode?.textContent).not.toContain('...');
+  });
+});
+
+// ===== Props Tests =====
+
+describe('ToolCallCard Props', () => {
+  it('respects defaultExpanded prop', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} defaultExpanded={true} />);
+
+    // Should be expanded by default, showing Input section
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.getByText('Output')).toBeInTheDocument();
+  });
+
+  it('calls onExpandedChange callback when toggled', async () => {
+    const user = userEvent.setup();
+    const onExpandedChange = vi.fn();
+
+    render(<ToolCallCard toolCall={mockToolCallComplete} onExpandedChange={onExpandedChange} />);
+
+    const headerButton = screen.getByRole('button');
+
+    // Expand - should call with true
+    await user.click(headerButton);
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+
+    // Collapse - should call with false
+    await user.click(headerButton);
+    expect(onExpandedChange).toHaveBeenCalledWith(false);
+
+    // Should have been called twice
+    expect(onExpandedChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('sets aria-expanded attribute correctly', async () => {
+    const user = userEvent.setup();
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    const headerButton = screen.getByRole('button');
+
+    // Initially collapsed
+    expect(headerButton).toHaveAttribute('aria-expanded', 'false');
+
+    // After clicking, expanded
+    await user.click(headerButton);
+    expect(headerButton).toHaveAttribute('aria-expanded', 'true');
+
+    // After clicking again, collapsed
+    await user.click(headerButton);
+    expect(headerButton).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+// ===== Input Summary Tests =====
+
+describe('ToolCallCard Input Summary', () => {
+  it('shows file_path in header summary', () => {
+    render(<ToolCallCard toolCall={mockToolCallComplete} />);
+
+    // The input summary should show the file_path value
+    expect(screen.getByText('/test.ts')).toBeInTheDocument();
+  });
+
+  it('shows path in header summary for Grep (path takes priority over pattern)', () => {
+    // The getInputSummary function prioritizes 'path' over 'pattern'
+    render(<ToolCallCard toolCall={mockToolCallRunningGrep} />);
+
+    expect(screen.getByText('/src')).toBeInTheDocument();
+  });
+
+  it('shows pattern in header summary when no path is provided', () => {
+    const grepWithPatternOnly: ToolCallEntry = {
+      ...mockToolCallRunningGrep,
+      id: 'tc-pattern-only',
+      input: { pattern: 'TODO' },
+    };
+    render(<ToolCallCard toolCall={grepWithPatternOnly} />);
+
+    expect(screen.getByText('TODO')).toBeInTheDocument();
+  });
+
+  it('shows command in header summary for Bash', () => {
+    render(<ToolCallCard toolCall={mockToolCallRunning} />);
+
+    expect(screen.getByText('npm test')).toBeInTheDocument();
+  });
+});

--- a/tests/components/session-history/tool-call-summary-bar.test.tsx
+++ b/tests/components/session-history/tool-call-summary-bar.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ToolCallSummaryBar } from '@/app/components/features/session-history/components/tool-call-summary-bar';
+import type { ToolCallStats } from '@/app/components/features/session-history/types';
+
+// ===== Mock Data =====
+
+const mockStatsZero: ToolCallStats = {
+  totalCalls: 0,
+  errorCount: 0,
+  avgDurationMs: 0,
+  totalDurationMs: 0,
+  toolBreakdown: [],
+};
+
+const mockStatsNormal: ToolCallStats = {
+  totalCalls: 10,
+  errorCount: 2,
+  avgDurationMs: 2500, // 2.5s rounds to 2s
+  totalDurationMs: 25000, // 25s
+  toolBreakdown: [
+    { tool: 'Read', count: 5 },
+    { tool: 'Grep', count: 3 },
+    { tool: 'Edit', count: 2 },
+  ],
+};
+
+const mockStatsNoErrors: ToolCallStats = {
+  totalCalls: 5,
+  errorCount: 0,
+  avgDurationMs: 200,
+  totalDurationMs: 1000,
+  toolBreakdown: [{ tool: 'Read', count: 5 }],
+};
+
+const mockStatsLargeDuration: ToolCallStats = {
+  totalCalls: 3,
+  errorCount: 1,
+  avgDurationMs: 65000, // 1m 5s
+  totalDurationMs: 195000, // 3m 15s
+  toolBreakdown: [{ tool: 'Bash', count: 3 }],
+};
+
+// ===== Rendering Tests =====
+
+describe('ToolCallSummaryBar', () => {
+  it('renders with zero stats', () => {
+    render(<ToolCallSummaryBar stats={mockStatsZero} />);
+
+    expect(screen.getByTestId('tool-call-summary-bar')).toBeInTheDocument();
+    // Check that zero calls and zero errors are displayed (multiple "0" elements exist)
+    const zeros = screen.getAllByText('0');
+    expect(zeros.length).toBeGreaterThanOrEqual(2); // At least calls and errors
+  });
+
+  it('renders total calls correctly', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNormal} />);
+
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('Calls')).toBeInTheDocument();
+  });
+
+  it('renders error count correctly', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNormal} />);
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+  });
+
+  it('renders total duration correctly', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNormal} />);
+
+    // 25000ms = 25s (formatted by formatDuration)
+    expect(screen.getByText('Total:')).toBeInTheDocument();
+    expect(screen.getByText('25s')).toBeInTheDocument();
+  });
+
+  it('renders average duration correctly', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNormal} />);
+
+    // 2500ms = 2s (formatted by formatDuration floors to seconds)
+    expect(screen.getByText('Avg:')).toBeInTheDocument();
+    expect(screen.getByText('2s')).toBeInTheDocument();
+  });
+
+  it('applies danger styling when errors > 0', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNormal} />);
+
+    // Find the error count element and check for danger class
+    const errorsText = screen.getByText('Errors');
+    const errorContainer = errorsText.closest('span');
+
+    expect(errorContainer).toHaveClass('text-danger');
+  });
+
+  it('does not apply danger styling when errors = 0', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNoErrors} />);
+
+    // Find the Errors label element
+    const errorsText = screen.getByText('Errors');
+    const errorContainer = errorsText.closest('span');
+
+    expect(errorContainer).not.toHaveClass('text-danger');
+    expect(errorContainer).toHaveClass('text-fg-muted');
+    // Verify the 0 is not styled as danger (should have text-fg class)
+    const zeroElements = screen.getAllByText('0');
+    expect(zeroElements.length).toBeGreaterThan(0);
+  });
+
+  it('formats large durations correctly', () => {
+    render(<ToolCallSummaryBar stats={mockStatsLargeDuration} />);
+
+    // 195000ms = 3m 15s, 65000ms = 1m 5s
+    expect(screen.getByText('3m 15s')).toBeInTheDocument();
+    expect(screen.getByText('1m 5s')).toBeInTheDocument();
+  });
+
+  it('has correct test id for querying', () => {
+    render(<ToolCallSummaryBar stats={mockStatsNormal} />);
+
+    const bar = screen.getByTestId('tool-call-summary-bar');
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveClass('shrink-0');
+  });
+});

--- a/tests/components/session-history/tool-call-timeline.test.tsx
+++ b/tests/components/session-history/tool-call-timeline.test.tsx
@@ -1,0 +1,298 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ToolCallTimeline } from '@/app/components/features/session-history/components/tool-call-timeline';
+import type { ToolCallEntry, ToolCallStats } from '@/app/components/features/session-history/types';
+
+// Mock data
+const mockStats: ToolCallStats = {
+  totalCalls: 3,
+  errorCount: 1,
+  avgDurationMs: 1200,
+  toolBreakdown: [
+    { tool: 'Read', count: 2 },
+    { tool: 'Edit', count: 1 },
+  ],
+};
+
+const mockToolCalls: ToolCallEntry[] = [
+  {
+    id: 'tc-1',
+    tool: 'Read',
+    status: 'complete',
+    input: { file_path: '/src/index.ts' },
+    output: 'file contents',
+    duration: 150,
+    timestamp: 1706000000000,
+    timeOffset: '0:05',
+  },
+  {
+    id: 'tc-2',
+    tool: 'Read',
+    status: 'error',
+    input: { file_path: '/src/missing.ts' },
+    error: 'File not found',
+    duration: 50,
+    timestamp: 1706000001000,
+    timeOffset: '0:06',
+  },
+  {
+    id: 'tc-3',
+    tool: 'Edit',
+    status: 'complete',
+    input: { file_path: '/src/index.ts', old_string: 'foo', new_string: 'bar' },
+    output: 'Edit successful',
+    duration: 200,
+    timestamp: 1706000002000,
+    timeOffset: '0:07',
+  },
+];
+
+describe('ToolCallTimeline', () => {
+  describe('Rendering tests', () => {
+    it('renders "Tool Calls" header', () => {
+      render(<ToolCallTimeline toolCalls={mockToolCalls} stats={mockStats} />);
+
+      expect(screen.getByText('Tool Calls')).toBeInTheDocument();
+    });
+
+    it('renders tool call count badge', () => {
+      render(<ToolCallTimeline toolCalls={mockToolCalls} stats={mockStats} />);
+
+      // The count badge is in the header, within a span with specific styling
+      const header = screen.getByRole('banner');
+      const countBadge = within(header).getByText('3');
+      expect(countBadge).toBeInTheDocument();
+      expect(countBadge).toHaveClass('rounded-full');
+    });
+
+    it('renders ToolCallSummaryBar with stats', () => {
+      render(<ToolCallTimeline toolCalls={mockToolCalls} stats={mockStats} />);
+
+      // Check for summary bar content
+      expect(screen.getByTestId('tool-call-summary-bar')).toBeInTheDocument();
+      expect(screen.getByText('Tools')).toBeInTheDocument();
+      expect(screen.getByText('Calls')).toBeInTheDocument();
+      expect(screen.getByText('Errors')).toBeInTheDocument();
+    });
+
+    it('renders ToolCallCard for each tool call', () => {
+      render(<ToolCallTimeline toolCalls={mockToolCalls} stats={mockStats} />);
+
+      const toolCallCards = screen.getAllByTestId('tool-call-card');
+      expect(toolCallCards).toHaveLength(3);
+    });
+
+    it('renders tool calls sorted by timestamp', () => {
+      const unsortedToolCalls: ToolCallEntry[] = [
+        {
+          id: 'tc-later',
+          tool: 'Grep',
+          status: 'complete',
+          input: { pattern: 'test' },
+          duration: 100,
+          timestamp: 1706000010000,
+          timeOffset: '0:15',
+        },
+        {
+          id: 'tc-earlier',
+          tool: 'Read',
+          status: 'complete',
+          input: { file_path: '/src/test.ts' },
+          duration: 50,
+          timestamp: 1706000005000,
+          timeOffset: '0:10',
+        },
+      ];
+
+      render(
+        <ToolCallTimeline
+          toolCalls={unsortedToolCalls}
+          stats={{ ...mockStats, totalCalls: 2, errorCount: 0 }}
+        />
+      );
+
+      const toolCallCards = screen.getAllByTestId('tool-call-card');
+      expect(toolCallCards).toHaveLength(2);
+
+      // Tool calls should be rendered in the order they are passed
+      // The component does not sort them internally - it displays in array order
+      expect(within(toolCallCards[0]!).getByText('Grep')).toBeInTheDocument();
+      expect(within(toolCallCards[1]!).getByText('Read')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading state tests', () => {
+    it('shows loading skeleton when isLoading is true', () => {
+      render(<ToolCallTimeline toolCalls={[]} stats={mockStats} isLoading={true} />);
+
+      expect(screen.getByTestId('tool-call-timeline-loading')).toBeInTheDocument();
+    });
+
+    it('shows skeleton placeholders for header, summary, and cards', () => {
+      render(<ToolCallTimeline toolCalls={[]} stats={mockStats} isLoading={true} />);
+
+      const loadingContainer = screen.getByTestId('tool-call-timeline-loading');
+
+      // Should have skeleton elements for header area (Skeleton component uses data-testid="skeleton-card")
+      const skeletons = loadingContainer.querySelectorAll('[data-testid="skeleton-card"]');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Empty state tests', () => {
+    it('shows empty state when toolCalls array is empty', () => {
+      render(<ToolCallTimeline toolCalls={[]} stats={mockStats} />);
+
+      expect(screen.getByTestId('tool-call-timeline-empty')).toBeInTheDocument();
+    });
+
+    it('shows "No tool calls in this session" message', () => {
+      render(<ToolCallTimeline toolCalls={[]} stats={mockStats} />);
+
+      expect(screen.getByText('No tool calls in this session')).toBeInTheDocument();
+    });
+
+    it('shows Wrench icon in empty state', () => {
+      render(<ToolCallTimeline toolCalls={[]} stats={mockStats} />);
+
+      // The empty state contains "No tool calls" heading
+      expect(screen.getByText('No tool calls')).toBeInTheDocument();
+    });
+  });
+
+  describe('Filter tests', () => {
+    it('shows filter dropdown when multiple unique tool names exist', () => {
+      const onFilterChange = vi.fn();
+      render(
+        <ToolCallTimeline
+          toolCalls={mockToolCalls}
+          stats={mockStats}
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      // Should show filter dropdown with "Filter by tool" label
+      const filterDropdown = screen.getByRole('combobox', { name: /filter by tool/i });
+      expect(filterDropdown).toBeInTheDocument();
+    });
+
+    it('does not show filter when only one tool type', () => {
+      const singleToolCalls: ToolCallEntry[] = [
+        {
+          id: 'tc-1',
+          tool: 'Read',
+          status: 'complete',
+          input: { file_path: '/src/a.ts' },
+          duration: 100,
+          timestamp: 1706000000000,
+          timeOffset: '0:05',
+        },
+        {
+          id: 'tc-2',
+          tool: 'Read',
+          status: 'complete',
+          input: { file_path: '/src/b.ts' },
+          duration: 100,
+          timestamp: 1706000001000,
+          timeOffset: '0:06',
+        },
+      ];
+
+      const onFilterChange = vi.fn();
+      render(
+        <ToolCallTimeline
+          toolCalls={singleToolCalls}
+          stats={{ ...mockStats, totalCalls: 2, errorCount: 0 }}
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      // Should not show filter dropdown when only one unique tool type
+      expect(screen.queryByRole('combobox', { name: /filter by tool/i })).not.toBeInTheDocument();
+    });
+
+    it('filters tool calls by selected tool name', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+
+      const { rerender } = render(
+        <ToolCallTimeline
+          toolCalls={mockToolCalls}
+          stats={mockStats}
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      // Initially shows all 3 tool calls
+      expect(screen.getAllByTestId('tool-call-card')).toHaveLength(3);
+
+      // Select "Edit" filter
+      const filterDropdown = screen.getByRole('combobox', { name: /filter by tool/i });
+      await user.selectOptions(filterDropdown, 'Edit');
+
+      expect(onFilterChange).toHaveBeenCalledWith('Edit');
+
+      // Rerender with filter applied
+      rerender(
+        <ToolCallTimeline
+          toolCalls={mockToolCalls}
+          stats={mockStats}
+          filterTool="Edit"
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      // Should only show 1 Edit tool call
+      const filteredCards = screen.getAllByTestId('tool-call-card');
+      expect(filteredCards).toHaveLength(1);
+      expect(within(filteredCards[0]!).getByText('Edit')).toBeInTheDocument();
+    });
+
+    it('shows "No tool calls match the selected filter" when filter returns empty', () => {
+      const onFilterChange = vi.fn();
+
+      // Create tool calls that don't include "Bash"
+      render(
+        <ToolCallTimeline
+          toolCalls={mockToolCalls}
+          stats={mockStats}
+          filterTool="Bash"
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      expect(screen.getByText('No tool calls match the selected filter')).toBeInTheDocument();
+    });
+
+    it('calls onFilterChange callback when filter changes', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+
+      render(
+        <ToolCallTimeline
+          toolCalls={mockToolCalls}
+          stats={mockStats}
+          onFilterChange={onFilterChange}
+        />
+      );
+
+      const filterDropdown = screen.getByRole('combobox', { name: /filter by tool/i });
+
+      // Select "Read" option
+      await user.selectOptions(filterDropdown, 'Read');
+      expect(onFilterChange).toHaveBeenCalledWith('Read');
+
+      // Clear filter by selecting "All Tools"
+      await user.selectOptions(filterDropdown, '');
+      expect(onFilterChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('does not show filter when onFilterChange is not provided', () => {
+      render(<ToolCallTimeline toolCalls={mockToolCalls} stats={mockStats} />);
+
+      // Even with multiple unique tools, filter should not show without onFilterChange
+      expect(screen.queryByRole('combobox', { name: /filter by tool/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/services/task-creation.service.test.ts
+++ b/tests/services/task-creation.service.test.ts
@@ -471,8 +471,12 @@ describe('TaskCreationService', () => {
         ])
       );
 
-      await service.sendMessage(sessionId, 'Create a task');
-      await service.acceptSuggestion(sessionId);
+      const sendResult = await service.sendMessage(sessionId, 'Create a task');
+      expect(sendResult.ok).toBe(true);
+
+      const acceptResult = await service.acceptSuggestion(sessionId);
+      expect(acceptResult.ok).toBe(true);
+      if (!acceptResult.ok) return;
 
       expect(mockV2Session.close).toHaveBeenCalled();
       expect(mockSessionService.close).toHaveBeenCalledWith('mock-db-session-id');

--- a/tests/services/task-creation.service.test.ts
+++ b/tests/services/task-creation.service.test.ts
@@ -49,6 +49,9 @@ describe('TaskCreationService', () => {
   }
 
   beforeEach(async () => {
+    // Clear mocks at the start to ensure clean state from previous tests
+    vi.clearAllMocks();
+
     await setupTestDatabase();
     const db = getTestDb();
 
@@ -83,7 +86,6 @@ describe('TaskCreationService', () => {
     } as unknown as SessionService;
 
     service = new TaskCreationService(db, mockStreams, mockSessionService);
-    vi.clearAllMocks();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary

- Add tool call tracking and visualization to session dashboards (Issue #23)
- Migrate user settings from localStorage to SQLite database
- Improve API validation and error handling

## Tool Call Tracking

- Display `tool:start` and `tool:result` events in session history
- Show tool call timeline with summary statistics (total calls, errors, avg duration)
- Expandable tool call cards showing input/output payloads
- Real-time tool tracking during AI task creation sessions

## Settings Migration (localStorage → SQLite)

- Created `settings` table for persistent user preferences
- Added `/api/settings` endpoints (GET/PUT) with Zod validation
- Migrated Model Optimizations and Preferences pages to use API
- Settings now persist across devices/sessions

## Code Quality Fixes

- Added Zod validation to `/api/tasks/create-with-ai/start` endpoint
- Improved error context in catch blocks
- Removed debug console.log statements
- Fixed misleading comments

## Test Coverage

- Added 9 new tests for tool tracking functionality
- Added edge case tests (negative duration, orphan events, invalid data)
- All 91 related tests passing

## Files Changed

- **34 files** changed
- **+3,904 lines** added
- **-209 lines** removed

## Test plan

- [ ] Start dev server with `npm run dev`
- [ ] Navigate to Session History, verify tool calls display correctly
- [ ] Open Model Optimizations settings, change model, verify persists after refresh
- [ ] Run `npm test` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)