### PR TITLE
fix: use tool start input for session events and add task detail navigation

### DIFF
--- a/src/app/components/features/session-history/hooks/use-session-events.ts
+++ b/src/app/components/features/session-history/hooks/use-session-events.ts
@@ -423,7 +423,8 @@ export function parseEventsToStreamEntries(
       content = toolName;
       toolCall = {
         name: toolName,
-        input: resultData.input ?? {},
+        input:
+          (toolId ? toolStartEvents.get(toolId)?.data.input : undefined) ?? resultData.input ?? {},
         output: resultData.output,
         status: hasError ? 'error' : 'complete',
         startTimeOffset,
@@ -618,7 +619,10 @@ export function parseEventsToStreamEntries(
         content = toolName;
         toolCall = {
           name: toolName,
-          input: resultData.input ?? {},
+          input:
+            (toolId ? toolStartEvents.get(toolId)?.data.input : undefined) ??
+            resultData.input ??
+            {},
           output: resultData.output,
           status: hasError ? 'error' : 'complete',
           startTimeOffset,

--- a/src/app/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/src/app/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { TaskDetailDialog } from '@/app/components/features/task-detail-dialog';
@@ -8,7 +8,7 @@ import { apiClient, type ProjectListItem } from '@/lib/api/client';
 // Client task type - subset of Task for client-side display
 type ClientTask = Pick<
   Task,
-  'id' | 'projectId' | 'title' | 'description' | 'column' | 'position'
+  'id' | 'projectId' | 'title' | 'description' | 'column' | 'position' | 'sessionId'
 > & {
   priority?: 'low' | 'medium' | 'high' | 'critical';
 };
@@ -18,6 +18,7 @@ export const Route = createFileRoute('/projects/$projectId/tasks/$taskId')({
 });
 
 function TaskDetailRoute(): React.JSX.Element {
+  const router = useRouter();
   const { projectId, taskId } = Route.useParams();
   const [task, setTask] = useState<ClientTask | null>(null);
   const [project, setProject] = useState<ProjectListItem | null>(null);
@@ -73,13 +74,20 @@ function TaskDetailRoute(): React.JSX.Element {
       <TaskDetailDialog
         task={task as Parameters<typeof TaskDetailDialog>[0]['task']}
         open
-        onOpenChange={() => {}}
+        onOpenChange={(open) => {
+          if (!open) {
+            router.navigate({ to: '/projects/$projectId', params: { projectId } });
+          }
+        }}
         onSave={async (data) => {
           // TODO: Add API endpoint for updating tasks
           setTask((prev) => (prev ? { ...prev, ...data } : null));
         }}
         onDelete={async (_id) => {
           // TODO: Add API endpoint for deleting tasks
+        }}
+        onViewSession={(sessionId) => {
+          window.location.href = `/projects/${projectId}/sessions/${sessionId}`;
         }}
       />
     </LayoutShell>


### PR DESCRIPTION
## Summary
- Prefer tool start event input over result input for accurate tool call display in session history
- Add close navigation to task detail route (navigates back to project)
- Add session view navigation from task detail dialog
- Include `sessionId` in client task type

## Test plan
- [ ] Verify tool call inputs display correctly in session history
- [ ] Verify closing task detail dialog navigates back to project view
- [ ] Verify "View Session" navigates to the correct session page

🤖 Generated with [Claude Code](https://claude.com/claude-code)