### PR TITLE
feat: add Helm chart for remote mode with PostgreSQL and OpenShift support

### DIFF
--- a/charts/agentpane/.helmignore
+++ b/charts/agentpane/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/agentpane/Chart.yaml
+++ b/charts/agentpane/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: agentpane
+description: AgentPane - AI agent orchestration platform with Kubernetes-native agent execution
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.28.0-0"
+keywords:
+  - ai
+  - agents
+  - claude
+  - orchestration
+  - devtools
+home: https://github.com/agentpane/agentpane
+maintainers:
+  - name: AgentPane
+    url: https://github.com/agentpane
+dependencies:
+  - name: postgresql
+    version: "16.5.2"
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    condition: database.internal.enabled

--- a/charts/agentpane/templates/_helpers.tpl
+++ b/charts/agentpane/templates/_helpers.tpl
@@ -1,0 +1,173 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agentpane.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "agentpane.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agentpane.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agentpane.labels" -}}
+helm.sh/chart: {{ include "agentpane.chart" . }}
+{{ include "agentpane.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: agentpane
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agentpane.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agentpane.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "agentpane.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agentpane.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* =========================================================================
+   Secret name resolvers
+   ========================================================================= */}}
+
+{{/*
+Resolve the AI credentials secret name.
+Returns existingSecret if set, otherwise the chart-managed secret name.
+*/}}
+{{- define "agentpane.ai.secretName" -}}
+{{- if .Values.ai.existingSecret }}
+{{- .Values.ai.existingSecret }}
+{{- else }}
+{{- printf "%s-ai" (include "agentpane.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the database secret name.
+For external: returns existingSecret if set, otherwise chart-managed secret.
+For internal (Bitnami subchart): returns the subchart's secret name.
+*/}}
+{{- define "agentpane.database.secretName" -}}
+{{- if and .Values.database.external.enabled .Values.database.external.existingSecret }}
+{{- .Values.database.external.existingSecret }}
+{{- else if and .Values.database.internal.enabled .Values.database.internal.auth.existingSecret }}
+{{- .Values.database.internal.auth.existingSecret }}
+{{- else if .Values.database.external.enabled }}
+{{- printf "%s-database" (include "agentpane.fullname" .) }}
+{{- else }}
+{{- printf "%s-postgresql" .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the database URL.
+Constructs the PostgreSQL connection string from individual components when using external DB
+without an existingSecret containing a full URL.
+*/}}
+{{- define "agentpane.database.url" -}}
+{{- if .Values.database.external.enabled }}
+{{- $host := .Values.database.external.host }}
+{{- $port := .Values.database.external.port | default 5432 }}
+{{- $user := .Values.database.external.username }}
+{{- $db := .Values.database.external.database | default "agentpane" }}
+{{- $ssl := .Values.database.external.sslMode | default "require" }}
+{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%v/%s?sslmode=%s" $user $host $port $db $ssl }}
+{{- else }}
+{{- $host := printf "%s-postgresql" .Release.Name }}
+{{- $user := .Values.database.internal.auth.username | default "agentpane" }}
+{{- $db := .Values.database.internal.auth.database | default "agentpane" }}
+{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:5432/%s" $user $host $db }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the database password secret key.
+*/}}
+{{- define "agentpane.database.passwordKey" -}}
+{{- if .Values.database.external.enabled }}
+{{- .Values.database.external.secretKeys.passwordKey | default "password" }}
+{{- else }}
+{{- .Values.database.internal.auth.secretKeys.passwordKey | default "password" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the GitHub credentials secret name.
+*/}}
+{{- define "agentpane.github.secretName" -}}
+{{- if .Values.github.existingSecret }}
+{{- .Values.github.existingSecret }}
+{{- else }}
+{{- printf "%s-github" (include "agentpane.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Sandbox namespace name
+*/}}
+{{- define "agentpane.sandbox.namespace" -}}
+{{- .Values.sandbox.namespace | default "agentpane-sandboxes" }}
+{{- end }}
+
+{{/*
+Detect OpenShift by checking for SecurityContextConstraints API
+*/}}
+{{- define "agentpane.openshift.enabled" -}}
+{{- if .Values.openshift.enabled }}
+{{- true }}
+{{- else if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+{{- true }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container image reference
+*/}}
+{{- define "agentpane.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Sandbox container image reference
+*/}}
+{{- define "agentpane.sandbox.image" -}}
+{{- $tag := .Values.sandbox.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.sandbox.image.repository $tag }}
+{{- end }}

--- a/charts/agentpane/templates/configmap.yaml
+++ b/charts/agentpane/templates/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentpane.fullname" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+data:
+  DB_MODE: {{ .Values.database.mode | quote }}
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  {{- if .Values.config.corsOrigin }}
+  CORS_ORIGIN: {{ .Values.config.corsOrigin | quote }}
+  {{- end }}
+  MAX_CONCURRENT_AGENTS: {{ .Values.config.maxConcurrentAgents | quote }}
+  MAX_TURNS: {{ .Values.config.maxTurns | quote }}
+  {{- if .Values.config.model }}
+  AGENT_MODEL: {{ .Values.config.model | quote }}
+  {{- end }}
+  SANDBOX_NAMESPACE: {{ include "agentpane.sandbox.namespace" . | quote }}
+  SANDBOX_MAX_CONCURRENT_PODS: {{ .Values.sandbox.maxConcurrentPods | quote }}
+  SANDBOX_IMAGE: {{ include "agentpane.sandbox.image" . | quote }}
+  SANDBOX_EPHEMERAL_PVC_SIZE: {{ .Values.sandbox.ephemeralPvc.size | quote }}
+  {{- if .Values.sandbox.ephemeralPvc.storageClass }}
+  SANDBOX_EPHEMERAL_PVC_STORAGE_CLASS: {{ .Values.sandbox.ephemeralPvc.storageClass | quote }}
+  {{- end }}
+  {{- if .Values.github.enabled }}
+  GITHUB_APP_ID: {{ .Values.github.appId | quote }}
+  GITHUB_APP_NAME: {{ .Values.github.appName | quote }}
+  GITHUB_CLIENT_ID: {{ .Values.github.clientId | quote }}
+  {{- end }}

--- a/charts/agentpane/templates/deployment.yaml
+++ b/charts/agentpane/templates/deployment.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentpane.fullname" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "agentpane.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "agentpane.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "agentpane.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "agentpane.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "agentpane.fullname" . }}
+          env:
+            {{/* ---- Database URL ---- */}}
+            {{- if and .Values.database.external.enabled .Values.database.external.existingSecret }}
+            {{/* External DB with full URL in existing secret */}}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.external.existingSecret }}
+                  key: {{ .Values.database.external.secretKeys.urlKey | default "DATABASE_URL" }}
+            {{- else }}
+            {{/* Construct URL from password — requires DATABASE_PASSWORD intermediate var */}}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentpane.database.secretName" . }}
+                  key: {{ include "agentpane.database.passwordKey" . }}
+            - name: DATABASE_URL
+              value: {{ include "agentpane.database.url" . | quote }}
+            {{- end }}
+            {{/* ---- AI Credentials ---- */}}
+            {{- if or .Values.ai.anthropicApiKey .Values.ai.existingSecret }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentpane.ai.secretName" . }}
+                  key: {{ .Values.ai.secretKeys.anthropicApiKeyKey | default "ANTHROPIC_API_KEY" }}
+            {{- end }}
+            {{- if or .Values.ai.claudeOauthToken .Values.ai.existingSecret }}
+            - name: CLAUDE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentpane.ai.secretName" . }}
+                  key: {{ .Values.ai.secretKeys.claudeOauthTokenKey | default "CLAUDE_OAUTH_TOKEN" }}
+                  optional: true
+            {{- end }}
+            {{/* ---- GitHub Credentials ---- */}}
+            {{- if .Values.github.enabled }}
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentpane.github.secretName" . }}
+                  key: {{ .Values.github.secretKeys.clientSecretKey | default "GITHUB_CLIENT_SECRET" }}
+            - name: GITHUB_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentpane.github.secretName" . }}
+                  key: {{ .Values.github.secretKeys.privateKeyKey | default "GITHUB_PRIVATE_KEY" }}
+                  optional: true
+            - name: GITHUB_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentpane.github.secretName" . }}
+                  key: {{ .Values.github.secretKeys.webhookSecretKey | default "GITHUB_WEBHOOK_SECRET" }}
+                  optional: true
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/agentpane/templates/hpa.yaml
+++ b/charts/agentpane/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agentpane.fullname" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agentpane.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/agentpane/templates/httproute.yaml
+++ b/charts/agentpane/templates/httproute.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "agentpane.fullname" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gateway.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  hostnames:
+    - {{ .Values.gateway.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "agentpane.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/agentpane/templates/sandbox-limitrange.yaml
+++ b/charts/agentpane/templates/sandbox-limitrange.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.limitRange.enabled -}}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: sandbox-limits
+  namespace: {{ include "agentpane.sandbox.namespace" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: {{ .Values.sandbox.resources.limits.cpu | quote }}
+        memory: {{ .Values.sandbox.resources.limits.memory }}
+      defaultRequest:
+        cpu: {{ .Values.sandbox.resources.requests.cpu | quote }}
+        memory: {{ .Values.sandbox.resources.requests.memory }}
+      max:
+        cpu: {{ .Values.sandbox.limitRange.maxCpu | quote }}
+        memory: {{ .Values.sandbox.limitRange.maxMemory }}
+      min:
+        cpu: {{ .Values.sandbox.limitRange.minCpu }}
+        memory: {{ .Values.sandbox.limitRange.minMemory }}
+{{- end }}

--- a/charts/agentpane/templates/sandbox-namespace.yaml
+++ b/charts/agentpane/templates/sandbox-namespace.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.sandbox.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "agentpane.sandbox.namespace" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+    agentpane.io/managed: "true"
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
+{{- end }}

--- a/charts/agentpane/templates/sandbox-networkpolicy.yaml
+++ b/charts/agentpane/templates/sandbox-networkpolicy.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.networkPolicy.enabled -}}
+{{/* Default deny all ingress — sandbox pods should not receive inbound traffic */}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-default-deny
+  namespace: {{ include "agentpane.sandbox.namespace" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    # DNS resolution (required for all network operations)
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.sandbox.networkPolicy.allowHttps }}
+    # HTTPS egress (package managers, API calls, Git over HTTPS)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+    # HTTP egress (some package managers)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- if .Values.sandbox.networkPolicy.allowGitSsh }}
+    # SSH egress (Git over SSH)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 22
+    {{- end }}
+    {{- range .Values.sandbox.networkPolicy.additionalEgressCidrs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/agentpane/templates/sandbox-rbac.yaml
+++ b/charts/agentpane/templates/sandbox-rbac.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.sandbox.enabled -}}
+{{/* Role in the sandbox namespace — allows the controller to manage agent pods and PVCs */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agentpane.fullname" . }}-sandbox-controller
+  namespace: {{ include "agentpane.sandbox.namespace" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+rules:
+  # Pod lifecycle management
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "watch", "delete", "deletecollection"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create", "get"]
+  # Ephemeral PVC management
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  # Events for observability
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  # ConfigMaps for agent configuration
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list", "delete"]
+  # Secrets for agent credentials (scoped to sandbox namespace)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "delete"]
+  # Network policy management
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "get", "list", "update", "delete"]
+  # Resource quota reads
+  - apiGroups: [""]
+    resources: ["resourcequotas"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["limitranges"]
+    verbs: ["get", "list"]
+---
+{{/* Bind the role to the app's service account */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agentpane.fullname" . }}-sandbox-controller
+  namespace: {{ include "agentpane.sandbox.namespace" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agentpane.fullname" . }}-sandbox-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentpane.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+{{/* ClusterRole for cross-namespace reads (health checks, node info) */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "agentpane.fullname" . }}-cluster-reader
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "agentpane.fullname" . }}-cluster-reader
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "agentpane.fullname" . }}-cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentpane.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/agentpane/templates/sandbox-resourcequota.yaml
+++ b/charts/agentpane/templates/sandbox-resourcequota.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.resourceQuota.enabled -}}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: sandbox-quota
+  namespace: {{ include "agentpane.sandbox.namespace" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+spec:
+  hard:
+    pods: {{ .Values.sandbox.resourceQuota.maxPods | quote }}
+    persistentvolumeclaims: {{ .Values.sandbox.resourceQuota.maxPvcs | quote }}
+    requests.cpu: {{ .Values.sandbox.resourceQuota.totalCpuRequests | quote }}
+    requests.memory: {{ .Values.sandbox.resourceQuota.totalMemoryRequests }}
+{{- end }}

--- a/charts/agentpane/templates/scc.yaml
+++ b/charts/agentpane/templates/scc.yaml
@@ -1,0 +1,79 @@
+{{- if and (include "agentpane.openshift.enabled" .) .Values.openshift.createSCC -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "agentpane.fullname" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      SCC for AgentPane application and agent sandbox pods.
+      Based on restricted-v2 with minimal additions for agent execution.
+# Based on restricted-v2 — no host access, no privilege escalation
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: false
+requiredDropCapabilities:
+  - ALL
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "agentpane.serviceAccountName" . }}
+---
+{{/* SCC for sandbox namespace service accounts */}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "agentpane.fullname" . }}-sandbox
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      SCC for AgentPane sandbox agent pods.
+      Restricted baseline with ephemeral PVC support.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: false
+requiredDropCapabilities:
+  - ALL
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+groups:
+  - system:serviceaccounts:{{ include "agentpane.sandbox.namespace" . }}
+{{- end }}

--- a/charts/agentpane/templates/secret.yaml
+++ b/charts/agentpane/templates/secret.yaml
@@ -1,0 +1,55 @@
+{{/* AI credentials secret — only created when no existingSecret is provided */}}
+{{- if not .Values.ai.existingSecret }}
+{{- if or .Values.ai.anthropicApiKey .Values.ai.claudeOauthToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-ai" (include "agentpane.fullname" .) }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.ai.anthropicApiKey }}
+  {{ .Values.ai.secretKeys.anthropicApiKeyKey | default "ANTHROPIC_API_KEY" }}: {{ .Values.ai.anthropicApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.ai.claudeOauthToken }}
+  {{ .Values.ai.secretKeys.claudeOauthTokenKey | default "CLAUDE_OAUTH_TOKEN" }}: {{ .Values.ai.claudeOauthToken | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+---
+{{/* Database secret — only for external DB without existingSecret */}}
+{{- if and .Values.database.external.enabled (not .Values.database.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-database" (include "agentpane.fullname" .) }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.database.external.password }}
+  {{ .Values.database.external.secretKeys.passwordKey | default "password" }}: {{ .Values.database.external.password | b64enc | quote }}
+  {{- end }}
+{{- end }}
+---
+{{/* GitHub credentials secret — only created when GitHub is enabled without existingSecret */}}
+{{- if and .Values.github.enabled (not .Values.github.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-github" (include "agentpane.fullname" .) }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.github.clientSecret }}
+  {{ .Values.github.secretKeys.clientSecretKey | default "GITHUB_CLIENT_SECRET" }}: {{ .Values.github.clientSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.github.privateKey }}
+  {{ .Values.github.secretKeys.privateKeyKey | default "GITHUB_PRIVATE_KEY" }}: {{ .Values.github.privateKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.github.webhookSecret }}
+  {{ .Values.github.secretKeys.webhookSecretKey | default "GITHUB_WEBHOOK_SECRET" }}: {{ .Values.github.webhookSecret | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/agentpane/templates/service.yaml
+++ b/charts/agentpane/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentpane.fullname" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agentpane.selectorLabels" . | nindent 4 }}

--- a/charts/agentpane/templates/serviceaccount.yaml
+++ b/charts/agentpane/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentpane.serviceAccountName" . }}
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/agentpane/templates/tests/test-connection.yaml
+++ b/charts/agentpane/templates/tests/test-connection.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "agentpane.fullname" . }}-test-connection
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: ["wget"]
+      args:
+        - "--no-verbose"
+        - "--tries=3"
+        - "--timeout=10"
+        - "-O-"
+        - "http://{{ include "agentpane.fullname" . }}:{{ .Values.service.port }}/api/healthz"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL

--- a/charts/agentpane/values.yaml
+++ b/charts/agentpane/values.yaml
@@ -1,0 +1,367 @@
+# -- Number of replicas for the AgentPane deployment
+replicaCount: 1
+
+image:
+  # -- Container image repository
+  repository: agentpane/agentpane
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag (defaults to .Chart.AppVersion)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+# -- Override the release name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+
+# -----------------------------------------------------------------------------
+# Database Configuration
+# -----------------------------------------------------------------------------
+database:
+  # -- Database mode (always "postgres" for Helm deployment)
+  mode: postgres
+
+  internal:
+    # -- Deploy Bitnami PostgreSQL subchart
+    enabled: true
+    auth:
+      # -- PostgreSQL username
+      username: agentpane
+      # -- PostgreSQL password (ignored if existingSecret is set)
+      password: ""
+      # -- PostgreSQL database name
+      database: agentpane
+      # -- Name of an existing Secret containing the password
+      existingSecret: ""
+      secretKeys:
+        # -- Key in the existing Secret that contains the password
+        passwordKey: "password"
+
+  external:
+    # -- Use an external PostgreSQL instance (when internal.enabled is false)
+    enabled: false
+    # -- Hostname of the external PostgreSQL server
+    host: ""
+    # -- Port of the external PostgreSQL server
+    port: 5432
+    # -- Username for the external PostgreSQL server
+    username: ""
+    # -- Password for the external PostgreSQL server (ignored if existingSecret is set)
+    password: ""
+    # -- Database name on the external PostgreSQL server
+    database: agentpane
+    # -- SSL mode for external connection (disable, require, verify-ca, verify-full)
+    sslMode: "require"
+    # -- Name of an existing Secret containing the full DATABASE_URL
+    existingSecret: ""
+    secretKeys:
+      # -- Key in the existing Secret that contains DATABASE_URL
+      urlKey: "DATABASE_URL"
+      # -- Key in the existing Secret that contains the password (if not using full URL)
+      passwordKey: "password"
+
+# -----------------------------------------------------------------------------
+# AI Credentials
+# -----------------------------------------------------------------------------
+ai:
+  # -- Anthropic API key (ignored if existingSecret is set)
+  anthropicApiKey: ""
+  # -- Claude OAuth token (ignored if existingSecret is set)
+  claudeOauthToken: ""
+  # -- Name of an existing Secret containing AI credentials
+  existingSecret: ""
+  secretKeys:
+    # -- Key in the existing Secret for the Anthropic API key
+    anthropicApiKeyKey: "ANTHROPIC_API_KEY"
+    # -- Key in the existing Secret for the Claude OAuth token
+    claudeOauthTokenKey: "CLAUDE_OAUTH_TOKEN"
+
+# -----------------------------------------------------------------------------
+# GitHub Integration
+# -----------------------------------------------------------------------------
+github:
+  # -- Enable GitHub integration
+  enabled: false
+  # -- GitHub App ID
+  appId: ""
+  # -- GitHub App name/slug
+  appName: ""
+  # -- GitHub OAuth client ID
+  clientId: ""
+  # -- GitHub OAuth client secret (ignored if existingSecret is set)
+  clientSecret: ""
+  # -- GitHub App private key in PEM format (ignored if existingSecret is set)
+  privateKey: ""
+  # -- GitHub webhook secret (ignored if existingSecret is set)
+  webhookSecret: ""
+  # -- Name of an existing Secret containing GitHub credentials
+  existingSecret: ""
+  secretKeys:
+    # -- Key in the existing Secret for the client secret
+    clientSecretKey: "GITHUB_CLIENT_SECRET"
+    # -- Key in the existing Secret for the private key
+    privateKeyKey: "GITHUB_PRIVATE_KEY"
+    # -- Key in the existing Secret for the webhook secret
+    webhookSecretKey: "GITHUB_WEBHOOK_SECRET"
+
+# -----------------------------------------------------------------------------
+# Application Configuration
+# -----------------------------------------------------------------------------
+config:
+  # -- Node environment
+  nodeEnv: production
+  # -- Log level (debug, info, warn, error)
+  logLevel: info
+  # -- CORS allowed origin
+  corsOrigin: ""
+  # -- Maximum concurrent agents per project
+  maxConcurrentAgents: 3
+  # -- Maximum agent execution turns
+  maxTurns: 50
+  # -- Claude model to use
+  model: "claude-sonnet-4-20250514"
+
+# -----------------------------------------------------------------------------
+# Service Account
+# -----------------------------------------------------------------------------
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- Annotations to add to the ServiceAccount
+  annotations: {}
+  # -- Name of the ServiceAccount (generated if not set)
+  name: ""
+  # -- Automount API credentials
+  automountServiceAccountToken: true
+
+# -----------------------------------------------------------------------------
+# Pod Configuration
+# -----------------------------------------------------------------------------
+# -- Annotations to add to pods
+podAnnotations: {}
+# -- Labels to add to pods
+podLabels: {}
+
+podSecurityContext:
+  # -- Run as non-root
+  runAsNonRoot: true
+  # -- Run as user ID (1000 = bun user in the container)
+  runAsUser: 1000
+  # -- Run as group ID
+  runAsGroup: 1000
+  # -- Filesystem group
+  fsGroup: 1000
+  # -- Seccomp profile type
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  # -- Disallow privilege escalation
+  allowPrivilegeEscalation: false
+  # -- Read-only root filesystem
+  readOnlyRootFilesystem: true
+  # -- Drop all capabilities
+  capabilities:
+    drop:
+      - ALL
+
+# -----------------------------------------------------------------------------
+# Service
+# -----------------------------------------------------------------------------
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 3001
+
+# -----------------------------------------------------------------------------
+# Gateway API (HTTPRoute)
+# -----------------------------------------------------------------------------
+gateway:
+  # -- Create an HTTPRoute resource
+  enabled: false
+  # -- Hostname for the HTTPRoute
+  hostname: agentpane.example.com
+  # -- Parent Gateway references
+  parentRefs: []
+  #   - name: my-gateway
+  #     namespace: gateway-system
+  #     sectionName: https
+  # -- Additional annotations for the HTTPRoute
+  annotations: {}
+  # -- TLS configuration (handled by the Gateway, not the HTTPRoute)
+  tls: {}
+
+# -----------------------------------------------------------------------------
+# Resources
+# -----------------------------------------------------------------------------
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+# -----------------------------------------------------------------------------
+# Autoscaling
+# -----------------------------------------------------------------------------
+autoscaling:
+  # -- Enable Horizontal Pod Autoscaler
+  enabled: false
+  # -- Minimum replicas
+  minReplicas: 1
+  # -- Maximum replicas
+  maxReplicas: 5
+  # -- Target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage
+  targetMemoryUtilizationPercentage: 80
+
+# -----------------------------------------------------------------------------
+# Probes
+# -----------------------------------------------------------------------------
+livenessProbe:
+  httpGet:
+    path: /api/liveness
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /api/readiness
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /api/liveness
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+# -----------------------------------------------------------------------------
+# Node Scheduling
+# -----------------------------------------------------------------------------
+# -- Node selector labels
+nodeSelector: {}
+# -- Tolerations
+tolerations: []
+# -- Affinity rules
+affinity: {}
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# -----------------------------------------------------------------------------
+# Agent Sandbox Configuration
+# -----------------------------------------------------------------------------
+sandbox:
+  # -- Enable agent sandbox pod management
+  enabled: true
+
+  image:
+    # -- Agent sandbox container image repository
+    repository: agentpane/agent-sandbox
+    # -- Image pull policy for sandbox pods
+    pullPolicy: IfNotPresent
+    # -- Overrides the sandbox image tag
+    tag: ""
+
+  # -- Namespace for agent sandbox pods
+  namespace: agentpane-sandboxes
+
+  # -- Maximum concurrent agent pods
+  maxConcurrentPods: 10
+
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+
+  ephemeralPvc:
+    # -- Storage class for ephemeral agent PVCs (empty = cluster default)
+    storageClass: ""
+    # -- Size of each ephemeral agent PVC
+    size: 10Gi
+    # -- Access mode for ephemeral PVCs
+    accessMode: ReadWriteOnce
+
+  networkPolicy:
+    # -- Create network policies for sandbox namespace
+    enabled: true
+    # -- Allow egress to external HTTPS
+    allowHttps: true
+    # -- Allow egress for Git over SSH
+    allowGitSsh: true
+    # -- Additional egress CIDR blocks to allow
+    additionalEgressCidrs: []
+
+  resourceQuota:
+    # -- Create resource quota for sandbox namespace
+    enabled: true
+    # -- Maximum number of agent pods
+    maxPods: 20
+    # -- Maximum number of PVCs
+    maxPvcs: 20
+    # -- Total CPU request limit across all sandbox pods
+    totalCpuRequests: "16"
+    # -- Total memory request limit across all sandbox pods
+    totalMemoryRequests: 32Gi
+
+  limitRange:
+    # -- Create limit range for sandbox namespace
+    enabled: true
+    # -- Maximum CPU per container
+    maxCpu: "4"
+    # -- Maximum memory per container
+    maxMemory: 8Gi
+    # -- Minimum CPU per container
+    minCpu: 100m
+    # -- Minimum memory per container
+    minMemory: 256Mi
+
+# -----------------------------------------------------------------------------
+# OpenShift Compatibility
+# -----------------------------------------------------------------------------
+openshift:
+  # -- Enable OpenShift-specific resources (auto-detected if not set)
+  enabled: false
+  # -- Create SecurityContextConstraints
+  createSCC: true
+
+# -----------------------------------------------------------------------------
+# Bitnami PostgreSQL Subchart Overrides
+# -----------------------------------------------------------------------------
+postgresql:
+  auth:
+    username: agentpane
+    password: ""
+    database: agentpane
+    existingSecret: ""
+    secretKeys:
+      adminPasswordKey: "postgres-password"
+      userPasswordKey: "password"
+  primary:
+    persistence:
+      enabled: true
+      size: 20Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi


### PR DESCRIPTION
Adds a production-ready Helm chart for deploying AgentPane in remote mode
with PostgreSQL as the database backend. Key design decisions:

- Bundled Bitnami PostgreSQL subchart (toggleable) or external DATABASE_URL
- Gateway API HTTPRoute for networking (works on both K8s and OpenShift)
- Standard secretKeyRef pattern with existingSecret overrides for all credentials
- Agent sandbox pods in dedicated namespace with RBAC, network policies,
  resource quotas, and limit ranges
- Per-agent ephemeral PVCs for workspace isolation
- OpenShift SecurityContextConstraints (auto-detected or manual toggle)
- Non-root containers, read-only root filesystem, restricted pod security

https://claude.ai/code/session_014pRy7cK4LutSqtGgj75pDr