### PR TITLE
feat: add dependency graph for Terraform Stacks mode

### DIFF
--- a/src/app/components/features/terraform/terraform-right-panel.tsx
+++ b/src/app/components/features/terraform/terraform-right-panel.tsx
@@ -37,20 +37,21 @@ export function TerraformRightPanel(): React.JSX.Element {
     setActiveFileIdx(0);
   }, [generatedFiles]);
 
-  // Reset to code tab when entering stacks mode (dependencies/variables tabs hidden)
+  // Reset to code tab when entering stacks mode (variables tab hidden)
   useEffect(() => {
-    if (isStacks && activeTab !== 'code') {
+    if (isStacks && activeTab === 'variables') {
       setActiveTab('code');
     }
   }, [isStacks, activeTab]);
 
   // Auto-switch tab when code is first generated
   useEffect(() => {
-    if (generatedCode && !prevCodeRef.current) {
-      setActiveTab(composeMode === 'stacks' ? 'code' : 'dependencies');
+    const hasOutput = composeMode === 'stacks' ? (generatedFiles?.length ?? 0) > 0 : !!generatedCode;
+    if (hasOutput && !prevCodeRef.current) {
+      setActiveTab('dependencies');
     }
     prevCodeRef.current = generatedCode;
-  }, [generatedCode, composeMode]);
+  }, [generatedCode, generatedFiles, composeMode]);
 
   return (
     <Tabs
@@ -65,12 +66,10 @@ export function TerraformRightPanel(): React.JSX.Element {
             <Code className="h-3 w-3" />
             {isStacks ? 'Files' : 'Code'}
           </TabsTrigger>
-          {!isStacks && (
-            <TabsTrigger value="dependencies" className="h-6 gap-1 px-2 text-[11px]">
-              <GitBranch className="h-3 w-3" />
-              Dependencies
-            </TabsTrigger>
-          )}
+          <TabsTrigger value="dependencies" className="h-6 gap-1 px-2 text-[11px]">
+            <GitBranch className="h-3 w-3" />
+            Dependencies
+          </TabsTrigger>
           {!isStacks && (
             <TabsTrigger value="variables" className="h-6 gap-1 px-2 text-[11px]">
               <Sliders className="h-3 w-3" />
@@ -113,12 +112,10 @@ export function TerraformRightPanel(): React.JSX.Element {
         </div>
       </TabsContent>
 
-      {/* Dependencies tab (standard Terraform only) */}
-      {!isStacks && (
-        <TabsContent value="dependencies" className="mt-0 min-h-0 flex-1">
-          <TerraformDependencyDiagram />
-        </TabsContent>
-      )}
+      {/* Dependencies tab */}
+      <TabsContent value="dependencies" className="mt-0 min-h-0 flex-1">
+        <TerraformDependencyDiagram />
+      </TabsContent>
 
       {/* Variables tab (standard Terraform only) */}
       {!isStacks && (

--- a/src/app/components/features/terraform/terraform-right-panel.tsx
+++ b/src/app/components/features/terraform/terraform-right-panel.tsx
@@ -46,7 +46,8 @@ export function TerraformRightPanel(): React.JSX.Element {
 
   // Auto-switch tab when code is first generated
   useEffect(() => {
-    const hasOutput = composeMode === 'stacks' ? (generatedFiles?.length ?? 0) > 0 : !!generatedCode;
+    const hasOutput =
+      composeMode === 'stacks' ? (generatedFiles?.length ?? 0) > 0 : !!generatedCode;
     if (hasOutput && !prevCodeRef.current) {
       setActiveTab('dependencies');
     }

--- a/src/lib/terraform/parse-stacks-dependencies.ts
+++ b/src/lib/terraform/parse-stacks-dependencies.ts
@@ -1,0 +1,147 @@
+import type {
+  TerraformGraph,
+  TerraformGraphEdge,
+  TerraformGraphNode,
+} from './parse-hcl-dependencies';
+import type { GeneratedFile, ModuleMatch } from './types';
+
+interface ParsedComponent {
+  name: string;
+  source: string;
+  body: string;
+}
+
+/**
+ * Extracts component blocks from Terraform Stacks code using brace-counting to handle nested braces.
+ */
+function extractComponentBlocks(code: string): ParsedComponent[] {
+  const components: ParsedComponent[] = [];
+  const componentPattern = /component\s+"([^"]+)"\s*\{/g;
+  let match: RegExpExecArray | null;
+
+  for (match = componentPattern.exec(code); match !== null; match = componentPattern.exec(code)) {
+    const name = match[1] ?? '';
+    const startIndex = match.index + match[0].length;
+    let depth = 1;
+    let i = startIndex;
+
+    while (i < code.length && depth > 0) {
+      if (code[i] === '{') depth++;
+      else if (code[i] === '}') depth--;
+      i++;
+    }
+
+    const body = code.slice(startIndex, i - 1);
+    const sourceMatch = body.match(/source\s*=\s*"([^"]+)"/);
+    components.push({
+      name,
+      source: sourceMatch?.[1] ?? '',
+      body,
+    });
+  }
+
+  return components;
+}
+
+/**
+ * Extracts implicit component references (component.X.output_name) from a component body.
+ * Returns map of referenced component name -> set of output names.
+ */
+function extractComponentRefs(body: string, ownName: string): Map<string, Set<string>> {
+  const refs = new Map<string, Set<string>>();
+  const refPattern = /component\.(\w+)\.(\w+)/g;
+  let match: RegExpExecArray | null;
+
+  for (match = refPattern.exec(body); match !== null; match = refPattern.exec(body)) {
+    const componentName = match[1] ?? '';
+    const outputName = match[2] ?? '';
+    if (componentName === ownName) continue;
+    if (!refs.has(componentName)) refs.set(componentName, new Set());
+    refs.get(componentName)?.add(outputName);
+  }
+
+  return refs;
+}
+
+/**
+ * Infers provider from component source string.
+ */
+function inferProvider(source: string, matchedModule?: ModuleMatch): string {
+  if (matchedModule?.provider) {
+    const p = matchedModule.provider.toLowerCase();
+    if (p.includes('aws') || p.includes('amazon')) return 'aws';
+    if (p.includes('azure') || p.includes('azurerm')) return 'azure';
+    if (p.includes('gcp') || p.includes('google')) return 'gcp';
+    return p;
+  }
+  const s = source.toLowerCase();
+  if (s.includes('aws') || s.includes('amazon')) return 'aws';
+  if (s.includes('azure') || s.includes('azurerm')) return 'azure';
+  if (s.includes('gcp') || s.includes('google')) return 'gcp';
+  return 'unknown';
+}
+
+/**
+ * Parses Terraform Stacks files to extract component dependency graph.
+ * Concatenates all file contents and extracts component blocks and their cross-references.
+ * Unlike standard Terraform modules, Stacks components do not use depends_on,
+ * so all edges are implicit (based on component.X.output references).
+ */
+export function parseStacksDependencies(
+  files: GeneratedFile[],
+  matchedModules: ModuleMatch[]
+): TerraformGraph {
+  const code = files.map((f) => f.code).join('\n');
+  const parsed = extractComponentBlocks(code);
+  if (parsed.length === 0) return { nodes: [], edges: [] };
+
+  const componentNames = new Set(parsed.map((c) => c.name));
+
+  // Build a source -> ModuleMatch lookup
+  const matchBySource = new Map<string, ModuleMatch>();
+  const matchByName = new Map<string, ModuleMatch>();
+  for (const mm of matchedModules) {
+    matchBySource.set(mm.source, mm);
+    // Also match by component name (lowercase, strip common prefixes)
+    const simpleName = mm.name
+      .toLowerCase()
+      .replace(/^terraform-/, '')
+      .replace(/^(aws|azure|gcp)-/, '');
+    matchByName.set(simpleName, mm);
+  }
+
+  const nodes: TerraformGraphNode[] = parsed.map((c) => {
+    const matched = matchBySource.get(c.source) ?? matchByName.get(c.name.toLowerCase());
+    return {
+      id: c.name,
+      label: c.name.replace(/_/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase()),
+      provider: inferProvider(c.source, matched),
+      source: c.source,
+      confidence: matched?.confidence ?? 0,
+    };
+  });
+
+  const edges: TerraformGraphEdge[] = [];
+  const edgeIds = new Set<string>();
+
+  for (const c of parsed) {
+    const implicitRefs = extractComponentRefs(c.body, c.name);
+    for (const [refComponent, outputs] of implicitRefs) {
+      if (componentNames.has(refComponent)) {
+        const edgeId = `${refComponent}->${c.name}`;
+        if (!edgeIds.has(edgeId)) {
+          edgeIds.add(edgeId);
+          edges.push({
+            id: edgeId,
+            source: refComponent,
+            target: c.name,
+            type: 'implicit',
+            label: [...outputs].join(', '),
+          });
+        }
+      }
+    }
+  }
+
+  return { nodes, edges };
+}

--- a/tests/lib/terraform/parse-stacks-dependencies.test.ts
+++ b/tests/lib/terraform/parse-stacks-dependencies.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+import { parseStacksDependencies } from '../../../src/lib/terraform/parse-stacks-dependencies';
+import type { GeneratedFile, ModuleMatch } from '../../../src/lib/terraform/types';
+
+function makeModuleMatch(overrides: Partial<ModuleMatch> = {}): ModuleMatch {
+  return {
+    moduleId: 'mod-1',
+    name: 'test-module',
+    provider: 'aws',
+    version: '1.0.0',
+    source: 'terraform-aws-modules/vpc/aws',
+    confidence: 0.95,
+    matchReason: 'exact',
+    ...overrides,
+  };
+}
+
+function makeFile(filename: string, code: string): GeneratedFile {
+  return { filename, code };
+}
+
+describe('parseStacksDependencies', () => {
+  it('returns empty graph for empty files', () => {
+    const result = parseStacksDependencies([], []);
+    expect(result).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('returns empty graph for files with no component blocks', () => {
+    const files = [makeFile('main.tfstack.hcl', 'provider "aws" { region = "us-east-1" }')];
+    const result = parseStacksDependencies(files, []);
+    expect(result).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('parses a single component block correctly', () => {
+    const files = [
+      makeFile(
+        'components.tfstack.hcl',
+        `
+component "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+
+  inputs = {
+    name = "my-vpc"
+    cidr = "10.0.0.0/16"
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0]).toMatchObject({
+      id: 'vpc',
+      label: 'Vpc',
+      source: 'terraform-aws-modules/vpc/aws',
+      provider: 'aws',
+    });
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('parses multiple components with nested braces', () => {
+    const files = [
+      makeFile(
+        'components.tfstack.hcl',
+        `
+component "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  inputs = {
+    tags = {
+      Name = "my-vpc"
+      Env  = "prod"
+    }
+  }
+}
+
+component "eks" {
+  source = "terraform-aws-modules/eks/aws"
+
+  inputs = {
+    cluster_config = {
+      node_groups = {
+        default = {
+          instance_type = "t3.medium"
+        }
+      }
+    }
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.map((n) => n.id)).toEqual(['vpc', 'eks']);
+    expect(result.nodes[1]?.source).toBe('terraform-aws-modules/eks/aws');
+  });
+
+  it('extracts component.X.output references as implicit edges', () => {
+    const files = [
+      makeFile(
+        'components.tfstack.hcl',
+        `
+component "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+
+component "eks" {
+  source     = "terraform-aws-modules/eks/aws"
+
+  inputs = {
+    vpc_id     = component.vpc.vpc_id
+    subnet_ids = component.vpc.private_subnets
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      id: 'vpc->eks',
+      source: 'vpc',
+      target: 'eks',
+      type: 'implicit',
+    });
+    expect(result.edges[0]?.label).toContain('vpc_id');
+    expect(result.edges[0]?.label).toContain('private_subnets');
+  });
+
+  it('excludes self-references', () => {
+    const files = [
+      makeFile(
+        'components.tfstack.hcl',
+        `
+component "app" {
+  source = "terraform-aws-modules/ecs/aws"
+
+  inputs = {
+    name = component.app.cluster_name
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('ignores references to non-existent components', () => {
+    const files = [
+      makeFile(
+        'components.tfstack.hcl',
+        `
+component "eks" {
+  source = "terraform-aws-modules/eks/aws"
+
+  inputs = {
+    vpc_id = component.nonexistent.vpc_id
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('concatenates content from multiple files', () => {
+    const files = [
+      makeFile(
+        'networking.tfstack.hcl',
+        `
+component "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+`
+      ),
+      makeFile(
+        'compute.tfstack.hcl',
+        `
+component "eks" {
+  source = "terraform-aws-modules/eks/aws"
+
+  inputs = {
+    vpc_id = component.vpc.vpc_id
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    expect(result.nodes).toHaveLength(2);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({
+      source: 'vpc',
+      target: 'eks',
+      type: 'implicit',
+    });
+  });
+
+  describe('provider inference from source string', () => {
+    it('infers aws from source containing "aws"', () => {
+      const files = [
+        makeFile('c.tfstack.hcl', 'component "x" { source = "terraform-aws-modules/vpc/aws" }'),
+      ];
+      const result = parseStacksDependencies(files, []);
+      expect(result.nodes[0]?.provider).toBe('aws');
+    });
+
+    it('infers azure from source containing "azure"', () => {
+      const files = [
+        makeFile('c.tfstack.hcl', 'component "x" { source = "Azure/network/azurerm" }'),
+      ];
+      const result = parseStacksDependencies(files, []);
+      expect(result.nodes[0]?.provider).toBe('azure');
+    });
+
+    it('infers gcp from source containing "google"', () => {
+      const files = [
+        makeFile(
+          'c.tfstack.hcl',
+          'component "x" { source = "terraform-google-modules/network/google" }'
+        ),
+      ];
+      const result = parseStacksDependencies(files, []);
+      expect(result.nodes[0]?.provider).toBe('gcp');
+    });
+
+    it('returns unknown for unrecognized source', () => {
+      const files = [makeFile('c.tfstack.hcl', 'component "x" { source = "custom/module/foo" }')];
+      const result = parseStacksDependencies(files, []);
+      expect(result.nodes[0]?.provider).toBe('unknown');
+    });
+
+    it('prefers provider from matchedModule over source inference', () => {
+      const files = [makeFile('c.tfstack.hcl', 'component "x" { source = "custom/module/foo" }')];
+      const matched = [makeModuleMatch({ source: 'custom/module/foo', provider: 'Google Cloud' })];
+      const result = parseStacksDependencies(files, matched);
+      expect(result.nodes[0]?.provider).toBe('gcp');
+    });
+  });
+
+  it('confidence comes from matchedModules lookup', () => {
+    const files = [
+      makeFile('c.tfstack.hcl', 'component "vpc" { source = "terraform-aws-modules/vpc/aws" }'),
+    ];
+    const matched = [
+      makeModuleMatch({
+        source: 'terraform-aws-modules/vpc/aws',
+        confidence: 0.99,
+      }),
+    ];
+    const result = parseStacksDependencies(files, matched);
+    expect(result.nodes[0]?.confidence).toBe(0.99);
+  });
+
+  it('deduplicates edges between the same pair of components', () => {
+    const files = [
+      makeFile(
+        'components.tfstack.hcl',
+        `
+component "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+
+component "eks" {
+  source = "terraform-aws-modules/eks/aws"
+
+  inputs = {
+    vpc_id     = component.vpc.vpc_id
+    subnet_ids = component.vpc.private_subnets
+  }
+}
+`
+      ),
+    ];
+    const result = parseStacksDependencies(files, []);
+    // Only one edge from vpc->eks, with both outputs in the label
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]?.id).toBe('vpc->eks');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `parseStacksDependencies` parser for Stacks `component` blocks, mirroring the existing HCL module parser but using `component.X.output` reference syntax
- Enables the Dependencies tab in Stacks mode by removing `!isStacks` guards on the tab trigger and content
- Updates `terraform-dependency-diagram.tsx` to branch on `composeMode` and use the correct parser
- Includes 15 new unit tests covering component parsing, cross-references, provider inference, and edge deduplication

## Test plan
- [x] All 33 tests pass (18 existing HCL + 15 new Stacks)
- [ ] Switch to Stacks mode, generate a multi-component stack, verify Dependencies tab shows component graph
- [ ] Verify standard Terraform mode dependency graph still works unchanged
- [ ] Verify Variables tab is still hidden in Stacks mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)