### PR TITLE
Add comprehensive RBAC test suite and token service refactoring

### DIFF
--- a/src/db/schema/shared/enums.ts
+++ b/src/db/schema/shared/enums.ts
@@ -64,23 +64,23 @@ export const RBAC_ROLE_LEVEL: Record<RbacRole, number> = {
   viewer: 1,
 };
 
-/** Resolve the highest role from a list of role strings. Returns null if empty. */
+/** Resolve the highest role from a list of role objects. Returns null if empty. */
 export function resolveHighestRole(
-  roles: Array<{ role: string }>
+  roles: Array<{ role: RbacRole }>
 ): { role: RbacRole; level: number } | null {
-  let highestLevel = 0;
-  let highestRole: RbacRole = 'viewer';
-  let found = false;
+  let highestRole: RbacRole | null = null;
+  let highestLevel = -1;
+
   for (const m of roles) {
-    if (!RBAC_ROLES.includes(m.role as RbacRole)) continue;
-    found = true;
-    const level = RBAC_ROLE_LEVEL[m.role as RbacRole];
+    const level = RBAC_ROLE_LEVEL[m.role];
     if (level > highestLevel) {
       highestLevel = level;
-      highestRole = m.role as RbacRole;
+      highestRole = m.role;
     }
   }
-  return found ? { role: highestRole, level: highestLevel } : null;
+
+  if (!highestRole) return null;
+  return { role: highestRole, level: highestLevel };
 }
 
 export const INVITATION_STATUS = ['pending', 'accepted', 'declined', 'expired', 'revoked'] as const;

--- a/src/lib/api/__tests__/auth-middleware.test.ts
+++ b/src/lib/api/__tests__/auth-middleware.test.ts
@@ -35,6 +35,7 @@ describe('getAuthContext', () => {
 
   describe('cookie extraction', () => {
     it('should return auth context with method "session" when session cookie is present', async () => {
+      process.env.NODE_ENV = 'development';
       const request = makeRequest({
         Cookie: 'agentpane_session=abc123',
       });
@@ -53,6 +54,7 @@ describe('getAuthContext', () => {
     });
 
     it('should extract session cookie when multiple cookies are present', async () => {
+      process.env.NODE_ENV = 'development';
       const request = makeRequest({
         Cookie: 'other=xyz; agentpane_session=mytoken99; another=123',
       });
@@ -67,6 +69,7 @@ describe('getAuthContext', () => {
     });
 
     it('should use first 8 chars of token for userId when no validator is provided', async () => {
+      process.env.NODE_ENV = 'development';
       const request = makeRequest({
         Cookie: 'agentpane_session=abcdefghijklmnop',
       });
@@ -85,6 +88,7 @@ describe('getAuthContext', () => {
 
   describe('bearer token', () => {
     it('should return auth context with method "api_token" when Bearer token is present', async () => {
+      process.env.NODE_ENV = 'development';
       const request = makeRequest({
         Authorization: 'Bearer token123',
       });
@@ -99,6 +103,7 @@ describe('getAuthContext', () => {
     });
 
     it('should use first 8 chars of token for userId when no validator is provided', async () => {
+      process.env.NODE_ENV = 'development';
       const request = makeRequest({
         Authorization: 'Bearer abcdefghijklmnopqrstuvwxyz',
       });
@@ -113,6 +118,7 @@ describe('getAuthContext', () => {
     });
 
     it('should prefer session cookie over Bearer token when both are present', async () => {
+      process.env.NODE_ENV = 'development';
       const request = makeRequest({
         Cookie: 'agentpane_session=sesstoken',
         Authorization: 'Bearer apitoken',

--- a/src/lib/api/rbac-middleware.ts
+++ b/src/lib/api/rbac-middleware.ts
@@ -5,8 +5,7 @@
  * Slots in after the existing authMiddleware in the request pipeline.
  */
 
-import { createHash } from 'node:crypto';
-import { and, eq, sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { Context, Next } from 'hono';
 import { RBAC_ROLE_LEVEL, type RbacRole, resolveHighestRole } from '../../db/schema/shared/enums';
 import { agents } from '../../db/schema/sqlite/agents';
@@ -105,83 +104,64 @@ export function enrichAuthContext(db: Database) {
 
       // Load token scope for API token auth
       if (auth.authMethod === 'api_token') {
-        const authHeader = c.req.header('Authorization');
-        if (authHeader?.startsWith('Bearer ')) {
-          const rawToken = authHeader.substring(7).trim();
-          if (!rawToken || (!rawToken.startsWith('ap_') && rawToken.length < 20)) {
-            return c.json(
-              { ok: false, error: { code: 'UNAUTHORIZED', message: 'Invalid API token format' } },
-              401
-            );
-          }
-          const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+        // H1: Use cached token from createAuthMiddleware to avoid duplicate hash+query
+        const token = c.get('_resolvedApiToken') as
+          | { id: string; role: string; scopeProjectId: string | null; scopeTags: unknown; expiresAt: string | null }
+          | undefined;
 
-          const tokenRecords = await db
-            .select({
-              id: apiTokens.id,
-              role: apiTokens.role,
-              scopeProjectId: apiTokens.scopeProjectId,
-              scopeTags: apiTokens.scopeTags,
-              expiresAt: apiTokens.expiresAt,
-            })
-            .from(apiTokens)
-            .where(and(eq(apiTokens.tokenHash, tokenHash), eq(apiTokens.status, 'active')));
-
-          const token = tokenRecords[0];
-          if (token) {
-            // Check if token has expired
-            if (token.expiresAt && new Date(token.expiresAt) < new Date()) {
-              // Lazily update status to expired (fire-and-forget)
-              void db
-                .update(apiTokens)
-                .set({ status: 'expired' })
-                .where(eq(apiTokens.id, token.id))
-                .catch((err) => log.warn('Failed to update expired token status', { error: err }));
-              return c.json(
-                { ok: false, error: { code: 'UNAUTHORIZED', message: 'API token has expired' } },
-                401
-              );
-            }
-            rbacAuth.tokenScope = {
-              tokenId: token.id,
-              role: token.role as RbacRole,
-              projectId: token.scopeProjectId,
-              tags: token.scopeTags as string[] | null,
-            };
-
-            // Cap the resolved role at the token's role ceiling
-            if (rbacAuth.resolvedRole) {
-              const tokenLevel = RBAC_ROLE_LEVEL[token.role as RbacRole];
-              if (rbacAuth.roleLevel && rbacAuth.roleLevel > tokenLevel) {
-                rbacAuth.resolvedRole = token.role as RbacRole;
-                rbacAuth.roleLevel = tokenLevel;
-              }
-            } else {
-              // User has no membership role — use token role as effective role
-              rbacAuth.resolvedRole = token.role as RbacRole;
-              rbacAuth.roleLevel = RBAC_ROLE_LEVEL[token.role as RbacRole];
-            }
-
-            // Update lastUsedAt and useCount asynchronously (fire-and-forget to avoid blocking the request)
+        if (token) {
+          // Check if token has expired
+          if (token.expiresAt && new Date(token.expiresAt) < new Date()) {
+            // Lazily update status to expired (fire-and-forget)
             void db
               .update(apiTokens)
-              .set({
-                lastUsedAt: new Date().toISOString(),
-                useCount: sql`COALESCE(${apiTokens.useCount}, 0) + 1`,
-              })
+              .set({ status: 'expired' })
               .where(eq(apiTokens.id, token.id))
-              .catch((err) => log.error('Failed to update token usage tracking', { error: err }));
-          } else {
-            // Token hash not found or token is not active — deny access
-            log.warn('API token not found or inactive', { data: { path: c.req.path } });
+              .catch((err) => log.warn('Failed to update expired token status', { error: err }));
             return c.json(
-              {
-                ok: false,
-                error: { code: 'UNAUTHORIZED', message: 'Invalid or revoked API token' },
-              },
+              { ok: false, error: { code: 'UNAUTHORIZED', message: 'API token has expired' } },
               401
             );
           }
+          rbacAuth.tokenScope = {
+            tokenId: token.id,
+            role: token.role as RbacRole,
+            projectId: token.scopeProjectId,
+            tags: token.scopeTags as string[] | null,
+          };
+
+          // Cap the resolved role at the token's role ceiling
+          if (rbacAuth.resolvedRole) {
+            const tokenLevel = RBAC_ROLE_LEVEL[token.role as RbacRole];
+            if (rbacAuth.roleLevel && rbacAuth.roleLevel > tokenLevel) {
+              rbacAuth.resolvedRole = token.role as RbacRole;
+              rbacAuth.roleLevel = tokenLevel;
+            }
+          } else {
+            // User has no membership role — use token role as effective role
+            rbacAuth.resolvedRole = token.role as RbacRole;
+            rbacAuth.roleLevel = RBAC_ROLE_LEVEL[token.role as RbacRole];
+          }
+
+          // Update lastUsedAt and useCount asynchronously (fire-and-forget to avoid blocking the request)
+          void db
+            .update(apiTokens)
+            .set({
+              lastUsedAt: new Date().toISOString(),
+              useCount: sql`COALESCE(${apiTokens.useCount}, 0) + 1`,
+            })
+            .where(eq(apiTokens.id, token.id))
+            .catch((err) => log.error('Failed to update token usage tracking', { error: err }));
+        } else {
+          // Token not found in cache — deny access
+          log.warn('API token not found or inactive', { data: { path: c.req.path } });
+          return c.json(
+            {
+              ok: false,
+              error: { code: 'UNAUTHORIZED', message: 'Invalid or revoked API token' },
+            },
+            401
+          );
         }
       }
     } catch (error) {
@@ -315,15 +295,62 @@ export function requireRole(minimumRole: RbacRole, rbacService: RbacService) {
 }
 
 /**
+ * Tag resolver functions - resolve tags for a given resource ID
+ */
+type TagResolver = (id: string, db: Database) => Promise<string[]>;
+
+const TAG_RESOLVERS: Record<string, TagResolver> = {
+  project: async (id, db) => {
+    const rows = await db.select({ tagId: projectTags.tagId })
+      .from(projectTags).where(eq(projectTags.projectId, id));
+    return rows.map(r => r.tagId);
+  },
+  task: async (id, db) => {
+    const rows = await db.select({ tagId: taskTags.tagId })
+      .from(taskTags).where(eq(taskTags.taskId, id));
+    if (rows.length > 0) return rows.map(r => r.tagId);
+    // Fallback to parent project tags
+    const taskRows = await db.select({ projectId: tasks.projectId })
+      .from(tasks).where(eq(tasks.id, id));
+    if (taskRows[0]?.projectId) {
+      return TAG_RESOLVERS.project(taskRows[0].projectId, db);
+    }
+    return [];
+  },
+  session: async (id, db) => {
+    const sessionRows = await db.select({ taskId: sessions.taskId, projectId: sessions.projectId })
+      .from(sessions).where(eq(sessions.id, id));
+    const session = sessionRows[0];
+    if (!session) return [];
+    if (session.taskId) {
+      const resolvedTaskTags = await TAG_RESOLVERS.task(session.taskId, db);
+      if (resolvedTaskTags.length > 0) return resolvedTaskTags;
+    }
+    if (session.projectId) {
+      return TAG_RESOLVERS.project(session.projectId, db);
+    }
+    return [];
+  },
+  agent: async (id, db) => {
+    const agentRows = await db.select({ projectId: agents.projectId })
+      .from(agents).where(eq(agents.id, id));
+    if (agentRows[0]?.projectId) {
+      return TAG_RESOLVERS.project(agentRows[0].projectId, db);
+    }
+    return [];
+  },
+};
+
+/** Map URL path prefixes to resource types */
+const PATH_TO_RESOURCE: Array<[string, string]> = [
+  ['/api/projects/', 'project'],
+  ['/api/tasks/', 'task'],
+  ['/api/sessions/', 'session'],
+  ['/api/agents/', 'agent'],
+];
+
+/**
  * Middleware that checks tag-based access for API tokens with tag restrictions.
- *
- * For API tokens with scopeTags, this middleware verifies that the requested
- * resource (project or task) has at least one tag matching the token's allowed tags.
- *
- * Bypassed when:
- * - User is not using an API token
- * - Token has no tag restrictions (scopeTags is null or empty)
- * - User is in dev mode
  */
 export function requireTagAccess(db: Database) {
   return async (c: Context, next: Next) => {
@@ -347,189 +374,40 @@ export function requireTagAccess(db: Database) {
     }
 
     const scopeTags = auth.tokenScope.tags;
-
-    // Determine the resource type from the route path
     const path = c.req.path;
 
-    // For project routes: check project tags
-    if (path.startsWith('/api/projects/')) {
-      const projectId = c.req.param('id');
-      if (projectId) {
-        const projectTagRows = await db
-          .select({ tagId: projectTags.tagId })
-          .from(projectTags)
-          .where(eq(projectTags.projectId, projectId));
-
-        const resourceTagIds = projectTagRows.map((r) => r.tagId);
-
-        if (!scopeTags.some((t) => resourceTagIds.includes(t))) {
-          return c.json(
-            {
-              ok: false,
-              error: { code: 'FORBIDDEN', message: 'Token tags do not match project tags' },
-            },
-            403
-          );
-        }
+    // Determine resource type from path
+    let resourceType: string | null = null;
+    for (const [prefix, type] of PATH_TO_RESOURCE) {
+      if (path.startsWith(prefix)) {
+        resourceType = type;
+        break;
       }
     }
 
-    // For task routes: check task tags, fallback to parent project tags
-    if (path.startsWith('/api/tasks/')) {
-      const taskId = c.req.param('id');
-      if (taskId) {
-        const taskTagRows = await db
-          .select({ tagId: taskTags.tagId })
-          .from(taskTags)
-          .where(eq(taskTags.taskId, taskId));
+    if (!resourceType) return next();
 
-        const resourceTagIds = taskTagRows.map((r) => r.tagId);
+    const resourceId = c.req.param('id');
+    if (!resourceId) return next();
 
-        // Check task's own tags first
-        if (!scopeTags.some((t) => resourceTagIds.includes(t))) {
-          // Fallback: look up the task's parent project and check project tags
-          const taskRows = await db
-            .select({ projectId: tasks.projectId })
-            .from(tasks)
-            .where(eq(tasks.id, taskId));
+    const resolver = TAG_RESOLVERS[resourceType];
+    if (!resolver) return next();
 
-          const taskRow = taskRows[0];
-          if (taskRow?.projectId) {
-            const parentProjectTagRows = await db
-              .select({ tagId: projectTags.tagId })
-              .from(projectTags)
-              .where(eq(projectTags.projectId, taskRow.projectId));
+    const resourceTags = await resolver(resourceId, db);
 
-            const parentTagIds = parentProjectTagRows.map((r) => r.tagId);
-
-            if (!scopeTags.some((t) => parentTagIds.includes(t))) {
-              return c.json(
-                {
-                  ok: false,
-                  error: {
-                    code: 'FORBIDDEN',
-                    message: 'Token tags do not match task or project tags',
-                  },
-                },
-                403
-              );
-            }
-          } else {
-            // Task not found or has no projectId — deny access
-            return c.json(
-              {
-                ok: false,
-                error: { code: 'FORBIDDEN', message: 'Token tags do not match task tags' },
-              },
-              403
-            );
-          }
-        }
-      }
+    // Deny if resource has no tags (invisible to tag-restricted tokens)
+    if (resourceTags.length === 0) {
+      return c.json(
+        { ok: false, error: { code: 'FORBIDDEN', message: 'Resource not accessible with tag-restricted token' } },
+        403
+      );
     }
 
-    // For session routes: check task tags (via session.taskId), fallback to project tags (via session.projectId)
-    if (path.startsWith('/api/sessions/')) {
-      const sessionId = c.req.param('id');
-      if (sessionId) {
-        const sessionRows = await db
-          .select({ taskId: sessions.taskId, projectId: sessions.projectId })
-          .from(sessions)
-          .where(eq(sessions.id, sessionId));
-
-        const sessionRow = sessionRows[0];
-        if (sessionRow) {
-          let tagMatch = false;
-
-          // First: check task tags if session has a taskId
-          if (sessionRow.taskId) {
-            const sessionTaskTagRows = await db
-              .select({ tagId: taskTags.tagId })
-              .from(taskTags)
-              .where(eq(taskTags.taskId, sessionRow.taskId));
-
-            const sessionTaskTagIds = sessionTaskTagRows.map((r) => r.tagId);
-            if (scopeTags.some((t) => sessionTaskTagIds.includes(t))) {
-              tagMatch = true;
-            }
-          }
-
-          // Fallback: check project tags via session.projectId
-          if (!tagMatch && sessionRow.projectId) {
-            const sessionProjectTagRows = await db
-              .select({ tagId: projectTags.tagId })
-              .from(projectTags)
-              .where(eq(projectTags.projectId, sessionRow.projectId));
-
-            const sessionProjectTagIds = sessionProjectTagRows.map((r) => r.tagId);
-            if (scopeTags.some((t) => sessionProjectTagIds.includes(t))) {
-              tagMatch = true;
-            }
-          }
-
-          if (!tagMatch) {
-            return c.json(
-              {
-                ok: false,
-                error: {
-                  code: 'FORBIDDEN',
-                  message: 'Token tags do not match session resource tags',
-                },
-              },
-              403
-            );
-          }
-        } else {
-          // Session not found — deny access for tag-restricted tokens
-          return c.json(
-            {
-              ok: false,
-              error: { code: 'FORBIDDEN', message: 'Session not found' },
-            },
-            403
-          );
-        }
-      }
-    }
-
-    // For agent routes: check project tags via agent.projectId
-    if (path.startsWith('/api/agents/')) {
-      const agentId = c.req.param('id');
-      if (agentId) {
-        const agentRows = await db
-          .select({ projectId: agents.projectId })
-          .from(agents)
-          .where(eq(agents.id, agentId));
-
-        const agentRow = agentRows[0];
-        if (agentRow?.projectId) {
-          const agentProjectTagRows = await db
-            .select({ tagId: projectTags.tagId })
-            .from(projectTags)
-            .where(eq(projectTags.projectId, agentRow.projectId));
-
-          const agentProjectTagIds = agentProjectTagRows.map((r) => r.tagId);
-
-          if (!scopeTags.some((t) => agentProjectTagIds.includes(t))) {
-            return c.json(
-              {
-                ok: false,
-                error: { code: 'FORBIDDEN', message: 'Token tags do not match agent project tags' },
-              },
-              403
-            );
-          }
-        } else {
-          // Agent not found — deny access for tag-restricted tokens
-          return c.json(
-            {
-              ok: false,
-              error: { code: 'FORBIDDEN', message: 'Agent not found' },
-            },
-            403
-          );
-        }
-      }
+    if (!scopeTags.some(t => resourceTags.includes(t))) {
+      return c.json(
+        { ok: false, error: { code: 'FORBIDDEN', message: 'Token tags do not match resource tags' } },
+        403
+      );
     }
 
     return next();

--- a/src/lib/api/rbac-middleware.ts
+++ b/src/lib/api/rbac-middleware.ts
@@ -21,6 +21,14 @@ import type { Database } from '../../types/database';
 import { createLogger } from '../logging/logger';
 import type { AuthContext } from './auth-middleware';
 
+interface CachedApiToken {
+  id: string;
+  role: string;
+  scopeProjectId: string | null;
+  scopeTags: string[] | null;
+  expiresAt: string | null;
+}
+
 const log = createLogger('RbacMiddleware');
 
 /**
@@ -48,7 +56,7 @@ export function enrichAuthContext(db: Database) {
     if (auth.authMethod === 'dev') {
       // Dev-mode should be unreachable in production (auth middleware gates on NODE_ENV).
       // Block here as defense-in-depth in case the auth layer is misconfigured.
-      if (process.env.NODE_ENV === 'production') {
+      if (process.env.NODE_ENV !== 'development') {
         log.error('SECURITY: Dev-mode authentication detected in production', {
           data: { userId: auth.userId, path: c.req.path },
         });
@@ -111,9 +119,7 @@ export function enrichAuthContext(db: Database) {
       // Load token scope for API token auth
       if (auth.authMethod === 'api_token') {
         // H1: Use cached token from createAuthMiddleware to avoid duplicate hash+query
-        const token = c.get('_resolvedApiToken') as
-          | { id: string; role: string; scopeProjectId: string | null; scopeTags: unknown; expiresAt: string | null }
-          | undefined;
+        const token = c.get('_resolvedApiToken') as CachedApiToken | undefined;
 
         if (token) {
           // Check if token has expired
@@ -123,7 +129,7 @@ export function enrichAuthContext(db: Database) {
               .update(apiTokens)
               .set({ status: 'expired' })
               .where(eq(apiTokens.id, token.id))
-              .catch((err) => log.warn('Failed to update expired token status', { error: err }));
+              .catch((err) => log.error('Failed to update expired token status', { error: err }));
             return c.json(
               { ok: false, error: { code: 'UNAUTHORIZED', message: 'API token has expired' } },
               401
@@ -157,7 +163,7 @@ export function enrichAuthContext(db: Database) {
               useCount: sql`COALESCE(${apiTokens.useCount}, 0) + 1`,
             })
             .where(eq(apiTokens.id, token.id))
-            .catch((err) => log.error('Failed to update token usage tracking', { error: err }));
+            .catch((err) => log.warn('Failed to update token usage tracking', { error: err }));
         } else {
           // Token not found in cache — deny access
           log.warn('API token not found or inactive', { data: { path: c.req.path } });
@@ -244,8 +250,13 @@ export function requireRole(minimumRole: RbacRole, rbacService: RbacService) {
         if (body && typeof body === 'object' && typeof body.projectId === 'string') {
           projectId = body.projectId;
         }
-      } catch {
-        // Body is not JSON or not available — continue without projectId
+      } catch (parseError) {
+        if (!(parseError instanceof SyntaxError)) {
+          log.error('Unexpected error parsing request body for projectId', {
+            error: parseError,
+            data: { path: c.req.path },
+          });
+        }
       }
     }
 
@@ -391,7 +402,12 @@ export function requireTagAccess(db: Database) {
       }
     }
 
-    if (!resourceType) return next();
+    if (!resourceType) {
+      log.warn('Tag-restricted token accessing unrecognized resource path', {
+        data: { path, tokenId: auth.tokenScope.tokenId },
+      });
+      return next();
+    }
 
     const resourceId = c.req.param('id');
     if (!resourceId) return next();

--- a/src/lib/api/rbac-middleware.ts
+++ b/src/lib/api/rbac-middleware.ts
@@ -46,10 +46,16 @@ export function enrichAuthContext(db: Database) {
 
     // Dev-mode users get owner role automatically
     if (auth.authMethod === 'dev') {
+      // Dev-mode should be unreachable in production (auth middleware gates on NODE_ENV).
+      // Block here as defense-in-depth in case the auth layer is misconfigured.
       if (process.env.NODE_ENV === 'production') {
         log.error('SECURITY: Dev-mode authentication detected in production', {
           data: { userId: auth.userId, path: c.req.path },
         });
+        return c.json(
+          { ok: false, error: { code: 'UNAUTHORIZED', message: 'Authentication required' } },
+          401
+        );
       }
       rbacAuth.resolvedRole = 'owner';
       rbacAuth.roleLevel = RBAC_ROLE_LEVEL.owner;
@@ -299,7 +305,7 @@ export function requireRole(minimumRole: RbacRole, rbacService: RbacService) {
  */
 type TagResolver = (id: string, db: Database) => Promise<string[]>;
 
-const TAG_RESOLVERS: Record<string, TagResolver> = {
+const TAG_RESOLVERS: { [K in 'project' | 'task' | 'session' | 'agent']: TagResolver } = {
   project: async (id, db) => {
     const rows = await db.select({ tagId: projectTags.tagId })
       .from(projectTags).where(eq(projectTags.projectId, id));
@@ -363,8 +369,8 @@ export function requireTagAccess(db: Database) {
       );
     }
 
-    // Skip for non-token auth or dev mode
-    if (auth.authMethod === 'dev' || auth.authMethod !== 'api_token') {
+    // Only API tokens can have tag restrictions; skip for all other auth methods
+    if (auth.authMethod !== 'api_token') {
       return next();
     }
 
@@ -377,10 +383,10 @@ export function requireTagAccess(db: Database) {
     const path = c.req.path;
 
     // Determine resource type from path
-    let resourceType: string | null = null;
+    let resourceType: keyof typeof TAG_RESOLVERS | null = null;
     for (const [prefix, type] of PATH_TO_RESOURCE) {
       if (path.startsWith(prefix)) {
-        resourceType = type;
+        resourceType = type as keyof typeof TAG_RESOLVERS;
         break;
       }
     }
@@ -391,9 +397,17 @@ export function requireTagAccess(db: Database) {
     if (!resourceId) return next();
 
     const resolver = TAG_RESOLVERS[resourceType];
-    if (!resolver) return next();
 
-    const resourceTags = await resolver(resourceId, db);
+    let resourceTags: string[];
+    try {
+      resourceTags = await resolver(resourceId, db);
+    } catch (error) {
+      log.error('Failed to resolve resource tags', { error, data: { resourceType, resourceId } });
+      return c.json(
+        { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to check tag access' } },
+        500
+      );
+    }
 
     // Deny if resource has no tags (invisible to tag-restricted tokens)
     if (resourceTags.length === 0) {

--- a/src/lib/api/rbac-middleware.ts
+++ b/src/lib/api/rbac-middleware.ts
@@ -23,7 +23,7 @@ import type { AuthContext } from './auth-middleware';
 
 interface CachedApiToken {
   id: string;
-  role: string;
+  role: RbacRole;
   scopeProjectId: string | null;
   scopeTags: string[] | null;
   expiresAt: string | null;
@@ -135,24 +135,35 @@ export function enrichAuthContext(db: Database) {
               401
             );
           }
+          // Validate that the token's role is a recognized RBAC role
+          const tokenLevel = RBAC_ROLE_LEVEL[token.role];
+          if (tokenLevel === undefined) {
+            log.error('API token has invalid role in database', {
+              data: { tokenId: token.id, role: token.role },
+            });
+            return c.json(
+              { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Token configuration error' } },
+              500
+            );
+          }
+
           rbacAuth.tokenScope = {
             tokenId: token.id,
-            role: token.role as RbacRole,
+            role: token.role,
             projectId: token.scopeProjectId,
             tags: token.scopeTags as string[] | null,
           };
 
           // Cap the resolved role at the token's role ceiling
           if (rbacAuth.resolvedRole) {
-            const tokenLevel = RBAC_ROLE_LEVEL[token.role as RbacRole];
             if (rbacAuth.roleLevel && rbacAuth.roleLevel > tokenLevel) {
-              rbacAuth.resolvedRole = token.role as RbacRole;
+              rbacAuth.resolvedRole = token.role;
               rbacAuth.roleLevel = tokenLevel;
             }
           } else {
             // User has no membership role — use token role as effective role
-            rbacAuth.resolvedRole = token.role as RbacRole;
-            rbacAuth.roleLevel = RBAC_ROLE_LEVEL[token.role as RbacRole];
+            rbacAuth.resolvedRole = token.role;
+            rbacAuth.roleLevel = tokenLevel;
           }
 
           // Update lastUsedAt and useCount asynchronously (fire-and-forget to avoid blocking the request)
@@ -206,8 +217,7 @@ export function enrichAuthContext(db: Database) {
  * Middleware factory that requires a minimum RBAC role for the route.
  *
  * Resolves the effective role based on:
- * - Project context (from :id param or body.projectId)
- * - Team context (from :id param on team routes)
+ * - Project context (from :id param, ?projectId query, or body.projectId)
  * - Global context (highest role across all teams)
  *
  * Dev-mode users always pass (owner role).
@@ -256,6 +266,14 @@ export function requireRole(minimumRole: RbacRole, rbacService: RbacService) {
             error: parseError,
             data: { path: c.req.path },
           });
+          // If we couldn't extract a projectId from URL and body parsing failed unexpectedly,
+          // deny rather than falling back to potentially less-restrictive global role
+          if (!projectId) {
+            return c.json(
+              { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to verify permissions' } },
+              500
+            );
+          }
         }
       }
     }
@@ -359,7 +377,8 @@ const TAG_RESOLVERS: { [K in 'project' | 'task' | 'session' | 'agent']: TagResol
 };
 
 /** Map URL path prefixes to resource types */
-const PATH_TO_RESOURCE: Array<[string, string]> = [
+type TagResourceType = keyof typeof TAG_RESOLVERS;
+const PATH_TO_RESOURCE: Array<[string, TagResourceType]> = [
   ['/api/projects/', 'project'],
   ['/api/tasks/', 'task'],
   ['/api/sessions/', 'session'],
@@ -394,23 +413,34 @@ export function requireTagAccess(db: Database) {
     const path = c.req.path;
 
     // Determine resource type from path
-    let resourceType: keyof typeof TAG_RESOLVERS | null = null;
+    let resourceType: TagResourceType | null = null;
     for (const [prefix, type] of PATH_TO_RESOURCE) {
       if (path.startsWith(prefix)) {
-        resourceType = type as keyof typeof TAG_RESOLVERS;
+        resourceType = type;
         break;
       }
     }
 
     if (!resourceType) {
-      log.warn('Tag-restricted token accessing unrecognized resource path', {
+      log.warn('Tag-restricted token denied on unrecognized resource path', {
         data: { path, tokenId: auth.tokenScope.tokenId },
       });
-      return next();
+      return c.json(
+        { ok: false, error: { code: 'FORBIDDEN', message: 'Tag-restricted tokens cannot access this resource type' } },
+        403
+      );
     }
 
     const resourceId = c.req.param('id');
-    if (!resourceId) return next();
+    if (!resourceId) {
+      log.warn('Tag-restricted token denied on collection endpoint (no resource ID)', {
+        data: { path, resourceType, tokenId: auth.tokenScope.tokenId },
+      });
+      return c.json(
+        { ok: false, error: { code: 'FORBIDDEN', message: 'Tag-restricted tokens must specify a resource ID' } },
+        403
+      );
+    }
 
     const resolver = TAG_RESOLVERS[resourceType];
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -123,6 +123,8 @@ function createAuthMiddleware(db: Database) {
         if (!apiToken) return null;
         // Check expiration if set
         if (apiToken.expiresAt && new Date(apiToken.expiresAt) < new Date()) return null;
+        // H1: Cache the resolved token record so enrichAuthContext doesn't re-query
+        c.set('_resolvedApiToken', apiToken);
         return apiToken.userId;
       },
     });

--- a/src/server/routes/invitation-accept.ts
+++ b/src/server/routes/invitation-accept.ts
@@ -6,6 +6,7 @@ import { and, eq, gt } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { teamInvitations } from '../../db/schema/sqlite/team-invitations';
 import { teamMembers } from '../../db/schema/sqlite/team-members';
+import { teams } from '../../db/schema/sqlite/teams';
 import type { AuthContext } from '../../lib/api/auth-middleware';
 import { createLogger } from '../../lib/logging/logger';
 import type { Database } from '../../types/database';
@@ -90,11 +91,18 @@ export function createInvitationAcceptRoutes({ db }: InvitationAcceptDeps) {
           role: claimed.role,
         });
 
+        // Get the team name
+        const team = await tx.query.teams.findFirst({
+          where: eq(teams.id, claimed.teamId),
+          columns: { name: true },
+        });
+
         return {
           status: 'ok',
           teamId: claimed.teamId,
           role: claimed.role,
           joinedAt: new Date().toISOString(),
+          teamName: team?.name ?? null,
         } as const;
       });
 
@@ -143,7 +151,7 @@ export function createInvitationAcceptRoutes({ db }: InvitationAcceptDeps) {
         case 'ok':
           return json({
             ok: true,
-            data: { teamId: result.teamId, role: result.role, joinedAt: result.joinedAt },
+            data: { teamId: result.teamId, role: result.role, joinedAt: result.joinedAt, teamName: result.teamName },
           });
       }
     } catch (error) {

--- a/src/server/routes/invitation-accept.ts
+++ b/src/server/routes/invitation-accept.ts
@@ -152,7 +152,7 @@ export function createInvitationAcceptRoutes({ db }: InvitationAcceptDeps) {
           return json({
             ok: true,
             data: { teamId: result.teamId, role: result.role, joinedAt: result.joinedAt, teamName: result.teamName },
-          });
+          }, 201);
       }
     } catch (error) {
       log.error('Failed to accept invitation', { error });

--- a/src/server/routes/me.ts
+++ b/src/server/routes/me.ts
@@ -2,7 +2,7 @@
  * Current user profile routes
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { teamMembers } from '../../db/schema/sqlite/team-members';
 import { teams } from '../../db/schema/sqlite/teams';
@@ -74,6 +74,8 @@ export function createMeRoutes({ db }: MeDeps) {
           email: user.email,
           avatarUrl: user.avatarUrl,
           authMethod: auth.authMethod,
+          createdAt: user.createdAt,
+          updatedAt: user.updatedAt,
           teams: memberships.map((m) => ({
             teamId: m.teamId,
             role: m.role,
@@ -107,6 +109,20 @@ export function createMeRoutes({ db }: MeDeps) {
     if (!parsed.ok) return parsed.response;
 
     try {
+      // H9: Check email uniqueness before update
+      if (parsed.data.email) {
+        const existingEmail = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(and(eq(users.email, parsed.data.email), ne(users.id, auth.userId)));
+        if (existingEmail.length > 0) {
+          return json(
+            { ok: false, error: { code: 'EMAIL_ALREADY_EXISTS', message: 'Email already in use' } },
+            409
+          );
+        }
+      }
+
       const [updated] = await db
         .update(users)
         .set({ ...parsed.data, updatedAt: new Date().toISOString() })

--- a/src/server/routes/me.ts
+++ b/src/server/routes/me.ts
@@ -109,25 +109,31 @@ export function createMeRoutes({ db }: MeDeps) {
     if (!parsed.ok) return parsed.response;
 
     try {
-      // H9: Check email uniqueness before update
-      if (parsed.data.email) {
-        const existingEmail = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(and(eq(users.email, parsed.data.email), ne(users.id, auth.userId)));
-        if (existingEmail.length > 0) {
-          return json(
-            { ok: false, error: { code: 'EMAIL_ALREADY_EXISTS', message: 'Email already in use' } },
-            409
-          );
+      // H9: Check email uniqueness before update (in transaction to avoid TOCTOU race)
+      const [updated, txError] = await db.transaction(async (tx) => {
+        if (parsed.data.email) {
+          const existingEmail = await tx
+            .select({ id: users.id })
+            .from(users)
+            .where(and(eq(users.email, parsed.data.email), ne(users.id, auth.userId)));
+          if (existingEmail.length > 0) {
+            return [null, 'EMAIL_ALREADY_EXISTS'] as const;
+          }
         }
-      }
+        const result = await tx
+          .update(users)
+          .set({ ...parsed.data, updatedAt: new Date().toISOString() })
+          .where(eq(users.id, auth.userId))
+          .returning();
+        return [result[0], null] as const;
+      });
 
-      const [updated] = await db
-        .update(users)
-        .set({ ...parsed.data, updatedAt: new Date().toISOString() })
-        .where(eq(users.id, auth.userId))
-        .returning();
+      if (txError === 'EMAIL_ALREADY_EXISTS') {
+        return json(
+          { ok: false, error: { code: 'EMAIL_ALREADY_EXISTS', message: 'Email already in use' } },
+          409
+        );
+      }
 
       if (!updated) {
         return json({ ok: false, error: { code: 'NOT_FOUND', message: 'User not found' } }, 404);

--- a/src/server/routes/project-members.ts
+++ b/src/server/routes/project-members.ts
@@ -87,7 +87,7 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
           effectiveRole: parsed.data.role,
           grantedAt: new Date().toISOString(),
         },
-      });
+      }, 201);
     } catch (error) {
       log.error('Failed to add member', { error });
       return json({ ok: false, error: { code: 'DB_ERROR', message: 'Failed to add member' } }, 500);

--- a/src/server/routes/project-members.ts
+++ b/src/server/routes/project-members.ts
@@ -127,7 +127,22 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
         .leftJoin(users, eq(projectMembers.userId, users.id))
         .where(eq(projectMembers.projectId, projectId));
 
-      return json({ ok: true, data: { items: members } });
+      // H4: Enrich with effectiveRole and source
+      const enrichedMembers = await Promise.all(
+        members.map(async (m) => {
+          const effectiveRole = m.userId
+            ? await rbacService.resolveUserRole(m.userId, projectId)
+            : null;
+          return {
+            ...m,
+            projectRole: m.role,
+            effectiveRole: effectiveRole ?? m.role,
+            source: 'direct' as const,
+          };
+        })
+      );
+
+      return json({ ok: true, data: { items: enrichedMembers } });
     } catch (error) {
       log.error('Failed to list members', { error });
       return json(

--- a/src/server/routes/rbac-tokens.ts
+++ b/src/server/routes/rbac-tokens.ts
@@ -126,91 +126,112 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
     }
 
     try {
-      // E4: Check token name uniqueness per user (non-revoked tokens only)
-      const existingWithName = await db
-        .select({ id: apiTokens.id })
-        .from(apiTokens)
-        .where(
-          and(
-            eq(apiTokens.userId, auth.userId),
-            eq(apiTokens.name, parsed.data.name),
-            ne(apiTokens.status, 'revoked')
-          )
-        );
+      // M1: Wrap all checks + insert in a transaction to prevent TOCTOU races
+      const result = await db.transaction(async (tx) => {
+        // E4: Check token name uniqueness per user (non-revoked tokens only)
+        const existingWithName = await tx
+          .select({ id: apiTokens.id })
+          .from(apiTokens)
+          .where(
+            and(
+              eq(apiTokens.userId, auth.userId),
+              eq(apiTokens.name, parsed.data.name),
+              ne(apiTokens.status, 'revoked')
+            )
+          );
 
-      if (existingWithName.length > 0) {
-        return json(
-          {
-            ok: false,
-            error: {
-              code: 'TOKEN_NAME_EXISTS',
-              message: 'A non-revoked token with this name already exists',
+        if (existingWithName.length > 0) {
+          return { error: 'TOKEN_NAME_EXISTS' as const };
+        }
+
+        // Check token limit (max 25)
+        const [countResult] = await tx
+          .select({ total: count() })
+          .from(apiTokens)
+          .where(and(eq(apiTokens.userId, auth.userId), ne(apiTokens.status, 'revoked')));
+
+        if ((countResult?.total ?? 0) >= 25) {
+          return { error: 'LIMIT_EXCEEDED' as const };
+        }
+
+        const rawToken = generateToken();
+        const tokenHash = hashToken(rawToken);
+        const tokenPrefix = rawToken.substring(0, 12);
+
+        const expiresAt = parsed.data.expiresInDays
+          ? new Date(Date.now() + parsed.data.expiresInDays * 24 * 60 * 60 * 1000).toISOString()
+          : null;
+
+        const [created] = await tx
+          .insert(apiTokens)
+          .values({
+            userId: auth.userId,
+            teamId: parsed.data.teamId,
+            name: parsed.data.name,
+            tokenHash,
+            tokenPrefix,
+            role: parsed.data.role,
+            scopeTags: parsed.data.scopeTags ?? null,
+            scopeProjectId: parsed.data.scopeProjectId ?? null,
+            expiresAt,
+          })
+          .returning();
+
+        if (!created) {
+          return { error: 'DB_ERROR' as const };
+        }
+
+        return { created, rawToken, tokenPrefix };
+      });
+
+      if ('error' in result) {
+        if (result.error === 'TOKEN_NAME_EXISTS') {
+          return json(
+            {
+              ok: false,
+              error: {
+                code: 'TOKEN_NAME_EXISTS',
+                message: 'A non-revoked token with this name already exists',
+              },
             },
-          },
-          409
-        );
-      }
-
-      // Check token limit (max 25)
-      const existingTokens = await db
-        .select({ id: apiTokens.id })
-        .from(apiTokens)
-        .where(and(eq(apiTokens.userId, auth.userId), ne(apiTokens.status, 'revoked')));
-
-      if (existingTokens.length >= 25) {
-        return json(
-          { ok: false, error: { code: 'LIMIT_EXCEEDED', message: 'Max 25 active tokens' } },
-          400
-        );
-      }
-
-      const rawToken = generateToken();
-      const tokenHash = hashToken(rawToken);
-      const tokenPrefix = rawToken.substring(0, 12);
-
-      const expiresAt = parsed.data.expiresInDays
-        ? new Date(Date.now() + parsed.data.expiresInDays * 24 * 60 * 60 * 1000).toISOString()
-        : null;
-
-      const [created] = await db
-        .insert(apiTokens)
-        .values({
-          userId: auth.userId,
-          teamId: parsed.data.teamId,
-          name: parsed.data.name,
-          tokenHash,
-          tokenPrefix,
-          role: parsed.data.role,
-          scopeTags: parsed.data.scopeTags ?? null,
-          scopeProjectId: parsed.data.scopeProjectId ?? null,
-          expiresAt,
-        })
-        .returning();
-
-      if (!created) {
+            409
+          );
+        }
+        if (result.error === 'LIMIT_EXCEEDED') {
+          return json(
+            { ok: false, error: { code: 'LIMIT_EXCEEDED', message: 'Max 25 active tokens' } },
+            400
+          );
+        }
         return json(
           { ok: false, error: { code: 'DB_ERROR', message: 'Failed to create token' } },
           500
         );
       }
 
+      const { created, rawToken, tokenPrefix } = result;
+
       // E2: Include teamId, scopeTags, scopeProjectId in creation response
-      return json({
-        ok: true,
-        data: {
-          id: created.id,
-          name: created.name,
-          tokenPrefix,
-          role: created.role,
-          teamId: created.teamId,
-          scopeTags: created.scopeTags,
-          scopeProjectId: created.scopeProjectId,
-          // Return raw token ONCE - never retrievable again
-          token: rawToken,
-          expiresAt: created.expiresAt,
-          createdAt: created.createdAt,
+      // M2: Return 201 for resource creation
+      return json(
+        {
+          ok: true,
+          data: {
+            id: created.id,
+            name: created.name,
+            tokenPrefix,
+            role: created.role,
+            teamId: created.teamId,
+            scopeTags: created.scopeTags,
+            scopeProjectId: created.scopeProjectId,
+            // Return raw token ONCE - never retrievable again
+            token: rawToken,
+            expiresAt: created.expiresAt,
+            createdAt: created.createdAt,
+          },
         },
-      });
+        201
+      );
     } catch (error) {
       log.error('Failed to create token', { error });
       return json(
@@ -276,6 +297,7 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
             status: apiTokens.status,
             expiresAt: apiTokens.expiresAt,
             lastUsedAt: apiTokens.lastUsedAt,
+            useCount: apiTokens.useCount,
             createdAt: apiTokens.createdAt,
             teamName: teams.name,
           })
@@ -328,6 +350,7 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
           status: apiTokens.status,
           expiresAt: apiTokens.expiresAt,
           lastUsedAt: apiTokens.lastUsedAt,
+          useCount: apiTokens.useCount,
           createdAt: apiTokens.createdAt,
           teamName: teams.name,
         })

--- a/src/server/routes/rbac-tokens.ts
+++ b/src/server/routes/rbac-tokens.ts
@@ -244,7 +244,20 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
   // GET /api/tokens - List user's tokens
   app.get('/', async (c) => {
     const auth = c.get('auth');
-    const showAll = c.req.query('status') === 'all';
+    const statusParam = c.req.query('status');
+    if (statusParam && statusParam !== 'all') {
+      return json(
+        {
+          ok: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid status filter. Use "all" to include revoked tokens',
+          },
+        },
+        400
+      );
+    }
+    const showAll = statusParam === 'all';
     const teamId = c.req.query('teamId');
     const allTeam = c.req.query('allTeam') === 'true';
     const { cursor, limit } = parsePagination(c);
@@ -309,7 +322,7 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
 
         const teamHasMore = teamTokens.length > limit;
         const teamItems = teamHasMore ? teamTokens.slice(0, limit) : teamTokens;
-        const teamNextCursor = teamHasMore ? teamItems[teamItems.length - 1]?.id : undefined;
+        const teamNextCursor = teamHasMore ? teamItems[teamItems.length - 1]?.id ?? null : null;
 
         return json({
           ok: true,
@@ -362,7 +375,7 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
 
       const hasMore = tokens.length > limit;
       const items = hasMore ? tokens.slice(0, limit) : tokens;
-      const nextCursor = hasMore ? items[items.length - 1]?.id : undefined;
+      const nextCursor = hasMore ? items[items.length - 1]?.id ?? null : null;
 
       return json({
         ok: true,

--- a/src/server/routes/rbac-tokens.ts
+++ b/src/server/routes/rbac-tokens.ts
@@ -451,31 +451,26 @@ export function createRbacTokensRoutes({ db, rbacService }: TokensDeps) {
     }
 
     try {
-      // First check current status
-      const tokenRows = await db
-        .select({ id: apiTokens.id, status: apiTokens.status })
-        .from(apiTokens)
-        .where(and(eq(apiTokens.id, id), eq(apiTokens.userId, auth.userId)));
-
-      if (tokenRows.length === 0) {
-        return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Token not found' } }, 404);
-      }
-
-      if (tokenRows[0]?.status === 'revoked') {
-        return json(
-          { ok: false, error: { code: 'ALREADY_REVOKED', message: 'Token is already revoked' } },
-          409
-        );
-      }
-
-      // E1: Set revokedAt timestamp when revoking
+      // Atomic revoke: only update non-revoked tokens to avoid TOCTOU race
       const result = await db
         .update(apiTokens)
         .set({ status: 'revoked', revokedAt: new Date().toISOString() })
-        .where(and(eq(apiTokens.id, id), eq(apiTokens.userId, auth.userId)))
+        .where(and(eq(apiTokens.id, id), eq(apiTokens.userId, auth.userId), ne(apiTokens.status, 'revoked')))
         .returning();
 
       if (result.length === 0) {
+        // Distinguish not-found from already-revoked
+        const existing = await db
+          .select({ status: apiTokens.status })
+          .from(apiTokens)
+          .where(and(eq(apiTokens.id, id), eq(apiTokens.userId, auth.userId)));
+
+        if (existing.length > 0) {
+          return json(
+            { ok: false, error: { code: 'ALREADY_REVOKED', message: 'Token is already revoked' } },
+            409
+          );
+        }
         return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Token not found' } }, 404);
       }
 

--- a/src/server/routes/tags.ts
+++ b/src/server/routes/tags.ts
@@ -141,17 +141,14 @@ export function createTagsRoutes({ db, rbacService }: TagsDeps) {
         return json({ ok: false, error: { code: 'TAG_NOT_FOUND', message: 'Tag not found' } }, 404);
       }
 
-      // Auth check (skip for dev mode)
-      if (auth.authMethod !== 'dev') {
-        const denied = await requireTeamRole(
-          auth,
-          rbacService,
-          foundTag.teamId,
-          'admin',
-          'Requires admin role in team'
-        );
-        if (denied) return denied;
-      }
+      const denied = await requireTeamRole(
+        auth,
+        rbacService,
+        foundTag.teamId,
+        'admin',
+        'Requires admin role in team'
+      );
+      if (denied) return denied;
 
       await db.delete(tags).where(eq(tags.id, id));
       return json({ ok: true, data: { deleted: true } });
@@ -241,7 +238,7 @@ export function createProjectTagRoutes({
       return json({
         ok: true,
         data: { projectId, tagId: parsed.data.tagId, assignedAt: new Date().toISOString() },
-      });
+      }, 201);
     } catch (error) {
       log.error('Failed to assign tag to project', { error });
       return json({ ok: false, error: { code: 'DB_ERROR', message: 'Failed to assign tag' } }, 500);
@@ -365,7 +362,7 @@ export function createTaskTagRoutes({
       return json({
         ok: true,
         data: { taskId, tagId: parsed.data.tagId, assignedAt: new Date().toISOString() },
-      });
+      }, 201);
     } catch (error) {
       log.error('Failed to assign tag to task', { error });
       return json({ ok: false, error: { code: 'DB_ERROR', message: 'Failed to assign tag' } }, 500);
@@ -382,24 +379,22 @@ export function createTaskTagRoutes({
     }
 
     const auth = c.get('auth');
-    if (auth.authMethod !== 'dev') {
-      const taskRows = await db
-        .select({ projectId: tasks.projectId })
-        .from(tasks)
-        .where(eq(tasks.id, taskId as string));
-      const foundTask = taskRows[0];
-      if (!foundTask) {
-        return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Task not found' } }, 404);
-      }
-      const denied = await requireProjectRole(
-        auth,
-        rbacService,
-        foundTask.projectId,
-        'agent_operator',
-        'Requires agent_operator role on project'
-      );
-      if (denied) return denied;
+    const taskRows = await db
+      .select({ projectId: tasks.projectId })
+      .from(tasks)
+      .where(eq(tasks.id, taskId as string));
+    const foundTask = taskRows[0];
+    if (!foundTask) {
+      return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Task not found' } }, 404);
     }
+    const denied = await requireProjectRole(
+      auth,
+      rbacService,
+      foundTask.projectId,
+      'agent_operator',
+      'Requires agent_operator role on project'
+    );
+    if (denied) return denied;
 
     try {
       await db.delete(taskTags).where(and(eq(taskTags.taskId, taskId), eq(taskTags.tagId, tagId)));

--- a/src/server/routes/tags.ts
+++ b/src/server/routes/tags.ts
@@ -2,7 +2,7 @@
  * Tag routes
  */
 
-import { and, count, eq } from 'drizzle-orm';
+import { and, count, eq, inArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { projectTags } from '../../db/schema/sqlite/project-tags';
 import { tags } from '../../db/schema/sqlite/tags';
@@ -94,21 +94,27 @@ export function createTagsRoutes({ db, rbacService }: TagsDeps) {
     try {
       const teamTags = await db.select().from(tags).where(eq(tags.teamId, teamId));
 
-      // Enrich each tag with projectCount and taskCount
-      const enrichedTags = await Promise.all(
-        teamTags.map(async (tag) => {
-          const [projectCountResult, taskCountResult] = await Promise.all([
-            db.select({ total: count() }).from(projectTags).where(eq(projectTags.tagId, tag.id)),
-            db.select({ total: count() }).from(taskTags).where(eq(taskTags.tagId, tag.id)),
-          ]);
+      // H3: Batch-fetch counts with GROUP BY instead of 2N queries
+      const tagIds = teamTags.map(t => t.id);
+      let projectCountMap = new Map<string, number>();
+      let taskCountMap = new Map<string, number>();
 
-          return {
-            ...tag,
-            projectCount: projectCountResult[0]?.total ?? 0,
-            taskCount: taskCountResult[0]?.total ?? 0,
-          };
-        })
-      );
+      if (tagIds.length > 0) {
+        const [projectCounts, taskCounts] = await Promise.all([
+          db.select({ tagId: projectTags.tagId, total: count() })
+            .from(projectTags).where(inArray(projectTags.tagId, tagIds)).groupBy(projectTags.tagId),
+          db.select({ tagId: taskTags.tagId, total: count() })
+            .from(taskTags).where(inArray(taskTags.tagId, tagIds)).groupBy(taskTags.tagId),
+        ]);
+        projectCountMap = new Map(projectCounts.map(r => [r.tagId, r.total]));
+        taskCountMap = new Map(taskCounts.map(r => [r.tagId, r.total]));
+      }
+
+      const enrichedTags = teamTags.map(tag => ({
+        ...tag,
+        projectCount: projectCountMap.get(tag.id) ?? 0,
+        taskCount: taskCountMap.get(tag.id) ?? 0,
+      }));
 
       return json({ ok: true, data: { items: enrichedTags } });
     } catch (error) {

--- a/src/server/routes/tags.ts
+++ b/src/server/routes/tags.ts
@@ -51,7 +51,7 @@ export function createTagsRoutes({ db, rbacService }: TagsDeps) {
         })
         .returning();
 
-      return json({ ok: true, data: created });
+      return json({ ok: true, data: created }, 201);
     } catch (error: unknown) {
       if (error instanceof Error && error.message.includes('UNIQUE constraint')) {
         return json(
@@ -133,26 +133,26 @@ export function createTagsRoutes({ db, rbacService }: TagsDeps) {
 
     const auth = c.get('auth');
 
-    // Always check tag existence first
-    const tagRows = await db.select({ teamId: tags.teamId }).from(tags).where(eq(tags.id, id));
-    const foundTag = tagRows[0];
-    if (!foundTag) {
-      return json({ ok: false, error: { code: 'TAG_NOT_FOUND', message: 'Tag not found' } }, 404);
-    }
-
-    // Auth check (skip for dev mode)
-    if (auth.authMethod !== 'dev') {
-      const denied = await requireTeamRole(
-        auth,
-        rbacService,
-        foundTag.teamId,
-        'admin',
-        'Requires admin role in team'
-      );
-      if (denied) return denied;
-    }
-
     try {
+      // Check tag existence
+      const tagRows = await db.select({ teamId: tags.teamId }).from(tags).where(eq(tags.id, id));
+      const foundTag = tagRows[0];
+      if (!foundTag) {
+        return json({ ok: false, error: { code: 'TAG_NOT_FOUND', message: 'Tag not found' } }, 404);
+      }
+
+      // Auth check (skip for dev mode)
+      if (auth.authMethod !== 'dev') {
+        const denied = await requireTeamRole(
+          auth,
+          rbacService,
+          foundTag.teamId,
+          'admin',
+          'Requires admin role in team'
+        );
+        if (denied) return denied;
+      }
+
       await db.delete(tags).where(eq(tags.id, id));
       return json({ ok: true, data: { deleted: true } });
     } catch (error) {
@@ -251,7 +251,7 @@ export function createProjectTagRoutes({
   // DELETE /api/projects/:id/tags/:tagId - Remove tag from project
   app.delete('/:tagId', async (c) => {
     const projectId = c.req.param('id') as string;
-    const tagId = c.req.param('tagId');
+    const tagId = c.req.param('tagId') as string;
 
     if (!isValidId(projectId) || !isValidId(tagId)) {
       return json({ ok: false, error: { code: 'INVALID_ID', message: 'Invalid ID' } }, 400);
@@ -375,7 +375,7 @@ export function createTaskTagRoutes({
   // DELETE /api/tasks/:id/tags/:tagId - Remove tag from task
   app.delete('/:tagId', async (c) => {
     const taskId = c.req.param('id') as string;
-    const tagId = c.req.param('tagId');
+    const tagId = c.req.param('tagId') as string;
 
     if (!isValidId(taskId) || !isValidId(tagId)) {
       return json({ ok: false, error: { code: 'INVALID_ID', message: 'Invalid ID' } }, 400);
@@ -386,7 +386,7 @@ export function createTaskTagRoutes({
       const taskRows = await db
         .select({ projectId: tasks.projectId })
         .from(tasks)
-        .where(eq(tasks.id, taskId));
+        .where(eq(tasks.id, taskId as string));
       const foundTask = taskRows[0];
       if (!foundTask) {
         return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Task not found' } }, 404);

--- a/src/server/routes/team-invitations.ts
+++ b/src/server/routes/team-invitations.ts
@@ -129,6 +129,7 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
           id: teamInvitations.id,
           teamId: teamInvitations.teamId,
           invitedBy: teamInvitations.invitedBy,
+          invitedByName: users.name,
           email: teamInvitations.email,
           role: teamInvitations.role,
           status: teamInvitations.status,
@@ -136,9 +137,16 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
           createdAt: teamInvitations.createdAt,
         })
         .from(teamInvitations)
+        .leftJoin(users, eq(teamInvitations.invitedBy, users.id))
         .where(and(eq(teamInvitations.teamId, teamId), eq(teamInvitations.status, 'pending')));
 
-      return json({ ok: true, data: { items: invitations } });
+      const enrichedInvitations = invitations.map(inv => ({
+        ...inv,
+        invitedBy: { userId: inv.invitedBy, name: inv.invitedByName },
+        invitedByName: undefined,
+      }));
+
+      return json({ ok: true, data: { items: enrichedInvitations } });
     } catch (error) {
       log.error('Failed to list invitations', { error });
       return json(

--- a/src/server/routes/team-invitations.ts
+++ b/src/server/routes/team-invitations.ts
@@ -41,39 +41,61 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
     if (!parsed.ok) return parsed.response;
 
     try {
-      // Check for existing pending invitation
-      const existing = await db
-        .select()
-        .from(teamInvitations)
-        .where(
-          and(
-            eq(teamInvitations.teamId, teamId),
-            eq(teamInvitations.email, parsed.data.email),
-            eq(teamInvitations.status, 'pending')
-          )
-        );
+      const result = await db.transaction(async (tx) => {
+        // Check for existing pending invitation
+        const existing = await tx
+          .select()
+          .from(teamInvitations)
+          .where(
+            and(
+              eq(teamInvitations.teamId, teamId),
+              eq(teamInvitations.email, parsed.data.email),
+              eq(teamInvitations.status, 'pending')
+            )
+          );
 
-      if (existing.length > 0) {
-        return json(
-          {
-            ok: false,
-            error: {
-              code: 'INVITATION_ALREADY_EXISTS',
-              message: 'Pending invitation already exists',
+        if (existing.length > 0) return { error: 'INVITATION_ALREADY_EXISTS' as const };
+
+        // Check if user with this email is already a member
+        const existingMember = await tx
+          .select({ userId: users.id })
+          .from(users)
+          .innerJoin(teamMembers, eq(teamMembers.userId, users.id))
+          .where(and(eq(teamMembers.teamId, teamId), eq(users.email, parsed.data.email)));
+
+        if (existingMember.length > 0) return { error: 'MEMBER_ALREADY_EXISTS' as const };
+
+        const token = randomBytes(32).toString('base64url');
+        const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+        const [invitation] = await tx
+          .insert(teamInvitations)
+          .values({
+            teamId,
+            invitedBy: auth.userId,
+            email: parsed.data.email,
+            role: parsed.data.role,
+            token,
+            expiresAt,
+          })
+          .returning();
+
+        return { ok: true as const, invitation };
+      });
+
+      if ('error' in result) {
+        if (result.error === 'INVITATION_ALREADY_EXISTS') {
+          return json(
+            {
+              ok: false,
+              error: {
+                code: 'INVITATION_ALREADY_EXISTS',
+                message: 'Pending invitation already exists',
+              },
             },
-          },
-          409
-        );
-      }
-
-      // Check if user with this email is already a member
-      const existingMember = await db
-        .select({ userId: users.id })
-        .from(users)
-        .innerJoin(teamMembers, eq(teamMembers.userId, users.id))
-        .where(and(eq(teamMembers.teamId, teamId), eq(users.email, parsed.data.email)));
-
-      if (existingMember.length > 0) {
+            409
+          );
+        }
         return json(
           {
             ok: false,
@@ -86,22 +108,7 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
         );
       }
 
-      const token = randomBytes(32).toString('base64url');
-      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-
-      const [invitation] = await db
-        .insert(teamInvitations)
-        .values({
-          teamId,
-          invitedBy: auth.userId,
-          email: parsed.data.email,
-          role: parsed.data.role,
-          token,
-          expiresAt,
-        })
-        .returning();
-
-      return json({ ok: true, data: invitation }, 201);
+      return json({ ok: true, data: result.invitation }, 201);
     } catch (error) {
       log.error('Failed to create invitation', { error });
       return json(

--- a/src/server/routes/team-invitations.ts
+++ b/src/server/routes/team-invitations.ts
@@ -101,7 +101,7 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
         })
         .returning();
 
-      return json({ ok: true, data: invitation });
+      return json({ ok: true, data: invitation }, 201);
     } catch (error) {
       log.error('Failed to create invitation', { error });
       return json(
@@ -140,10 +140,9 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
         .leftJoin(users, eq(teamInvitations.invitedBy, users.id))
         .where(and(eq(teamInvitations.teamId, teamId), eq(teamInvitations.status, 'pending')));
 
-      const enrichedInvitations = invitations.map(inv => ({
-        ...inv,
-        invitedBy: { userId: inv.invitedBy, name: inv.invitedByName },
-        invitedByName: undefined,
+      const enrichedInvitations = invitations.map(({ invitedByName, invitedBy, ...rest }) => ({
+        ...rest,
+        invitedBy: { userId: invitedBy, name: invitedByName },
       }));
 
       return json({ ok: true, data: { items: enrichedInvitations } });
@@ -190,8 +189,13 @@ export function createTeamInvitationsRoutes({ db, rbacService }: InvitationsDeps
       }
 
       // Verify the declining user is the invitee (check email match)
-      // In dev mode, skip this check
-      if (auth.authMethod !== 'dev' && auth.user?.email) {
+      if (auth.authMethod !== 'dev') {
+        if (!auth.user?.email) {
+          return json(
+            { ok: false, error: { code: 'FORBIDDEN', message: 'Cannot verify identity without email' } },
+            403
+          );
+        }
         if (invitation[0]?.email !== auth.user.email) {
           return json(
             { ok: false, error: { code: 'FORBIDDEN', message: 'Only the invitee can decline' } },

--- a/src/server/routes/team-members.ts
+++ b/src/server/routes/team-members.ts
@@ -39,6 +39,17 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
     const parsed = await parseJsonBody(c, addTeamMemberSchema);
     if (!parsed.ok) return parsed.response;
 
+    // Only owners can add members with admin role
+    if (parsed.data.role === 'admin' && auth.authMethod !== 'dev') {
+      const callerRole = await rbacService.resolveTeamRole(auth.userId, teamId);
+      if (callerRole !== 'owner') {
+        return json(
+          { ok: false, error: { code: 'INSUFFICIENT_ROLE', message: 'Only owners can add members with admin role' } },
+          403
+        );
+      }
+    }
+
     try {
       const result = await db.transaction(async (tx) => {
         const existing = await tx
@@ -119,21 +130,24 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
         ? (rawRoleFilter as RbacRole)
         : undefined;
 
+    if (rawRoleFilter && !roleFilter) {
+      return json(
+        { ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid role filter. Must be one of: ${RBAC_ROLES.join(', ')}` } },
+        400
+      );
+    }
+
     try {
-      // Total count of members matching current filter
-      const countWhere = roleFilter
+      // Build base where clause (used for both count and query)
+      const baseWhere = roleFilter
         ? and(eq(teamMembers.teamId, teamId), eq(teamMembers.role, roleFilter))
         : eq(teamMembers.teamId, teamId);
       const [countResult] = await db
         .select({ total: count() })
         .from(teamMembers)
-        .where(countWhere);
+        .where(baseWhere);
       const totalCount = countResult?.total ?? 0;
 
-      // Build where clause with cursor support (cursor is userId)
-      const baseWhere = roleFilter
-        ? and(eq(teamMembers.teamId, teamId), eq(teamMembers.role, roleFilter))
-        : eq(teamMembers.teamId, teamId);
       const whereClause = cursor ? and(baseWhere, gt(teamMembers.userId, cursor)) : baseWhere;
 
       const members = await db

--- a/src/server/routes/team-members.ts
+++ b/src/server/routes/team-members.ts
@@ -168,7 +168,7 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
 
       const hasMore = members.length > limit;
       const items = hasMore ? members.slice(0, limit) : members;
-      const nextCursor = hasMore ? items[items.length - 1]?.userId : undefined;
+      const nextCursor = hasMore ? items[items.length - 1]?.userId ?? null : null;
 
       return json({
         ok: true,

--- a/src/server/routes/team-members.ts
+++ b/src/server/routes/team-members.ts
@@ -4,6 +4,7 @@
 
 import { and, count, eq, gt } from 'drizzle-orm';
 import { Hono } from 'hono';
+import { RBAC_ROLES, type RbacRole } from '../../db/schema/shared/enums';
 import { teamMembers } from '../../db/schema/sqlite/team-members';
 import { users } from '../../db/schema/sqlite/users';
 import type { AuthContext } from '../../lib/api/auth-middleware';
@@ -85,7 +86,7 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
           role: parsed.data.role,
           joinedAt: new Date().toISOString(),
         },
-      });
+      }, 201);
     } catch (error) {
       log.error('Failed to add member', { error });
       return json({ ok: false, error: { code: 'DB_ERROR', message: 'Failed to add member' } }, 500);
@@ -112,14 +113,21 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
     }
 
     const { cursor, limit } = parsePagination(c);
-    const roleFilter = c.req.query('role');
+    const rawRoleFilter = c.req.query('role');
+    const roleFilter: RbacRole | undefined =
+      rawRoleFilter && (RBAC_ROLES as readonly string[]).includes(rawRoleFilter)
+        ? (rawRoleFilter as RbacRole)
+        : undefined;
 
     try {
-      // Total count of members in this team
+      // Total count of members matching current filter
+      const countWhere = roleFilter
+        ? and(eq(teamMembers.teamId, teamId), eq(teamMembers.role, roleFilter))
+        : eq(teamMembers.teamId, teamId);
       const [countResult] = await db
         .select({ total: count() })
         .from(teamMembers)
-        .where(eq(teamMembers.teamId, teamId));
+        .where(countWhere);
       const totalCount = countResult?.total ?? 0;
 
       // Build where clause with cursor support (cursor is userId)
@@ -288,7 +296,7 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
             message: 'Cannot remove yourself. Transfer ownership first.',
           },
         },
-        403
+        400
       );
     }
 

--- a/src/server/routes/team-members.ts
+++ b/src/server/routes/team-members.ts
@@ -112,6 +112,7 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
     }
 
     const { cursor, limit } = parsePagination(c);
+    const roleFilter = c.req.query('role');
 
     try {
       // Total count of members in this team
@@ -122,7 +123,9 @@ export function createTeamMembersRoutes({ db, rbacService }: TeamMembersDeps) {
       const totalCount = countResult?.total ?? 0;
 
       // Build where clause with cursor support (cursor is userId)
-      const baseWhere = eq(teamMembers.teamId, teamId);
+      const baseWhere = roleFilter
+        ? and(eq(teamMembers.teamId, teamId), eq(teamMembers.role, roleFilter))
+        : eq(teamMembers.teamId, teamId);
       const whereClause = cursor ? and(baseWhere, gt(teamMembers.userId, cursor)) : baseWhere;
 
       const members = await db

--- a/src/server/routes/team-projects.ts
+++ b/src/server/routes/team-projects.ts
@@ -38,7 +38,7 @@ export function createTeamProjectsRoutes({ db, rbacService }: TeamProjectsDeps) 
     try {
       body = await c.req.json();
     } catch {
-      return json({ ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON' } }, 400);
+      return json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid JSON' } }, 400);
     }
 
     const { projectId } = body as { projectId?: string };
@@ -66,14 +66,14 @@ export function createTeamProjectsRoutes({ db, rbacService }: TeamProjectsDeps) 
 
       if (existing.length > 0) {
         return json(
-          { ok: false, error: { code: 'DUPLICATE', message: 'Project already assigned to team' } },
+          { ok: false, error: { code: 'PROJECT_ALREADY_ASSIGNED', message: 'Project already assigned to team' } },
           409
         );
       }
 
       await db.insert(teamProjects).values({ teamId, projectId });
 
-      return json({ ok: true, data: { teamId, projectId } });
+      return json({ ok: true, data: { teamId, projectId } }, 201);
     } catch (error) {
       log.error('Failed to assign project to team', { error });
       return json(

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -426,7 +426,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
         const teamProjectIds = await tx.select({ projectId: teamProjects.projectId }).from(teamProjects).where(eq(teamProjects.teamId, id));
         if (teamProjectIds.length > 0) {
           const pIds = teamProjectIds.map(r => r.projectId);
-          await tx.delete(projectMembers).where(inArray(projectMembers.projectId, pIds));
+          await tx.delete(projectMembers).where(and(inArray(projectMembers.projectId, pIds), eq(projectMembers.grantedByTeamId, id)));
         }
         await tx.delete(teamProjects).where(eq(teamProjects.teamId, id));
         await tx.delete(teamMembers).where(eq(teamMembers.teamId, id));

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -11,6 +11,7 @@ import { teamInvitations } from '../../db/schema/sqlite/team-invitations';
 import { teamMembers } from '../../db/schema/sqlite/team-members';
 import { teamProjects } from '../../db/schema/sqlite/team-projects';
 import { teams } from '../../db/schema/sqlite/teams';
+import { projectMembers } from '../../db/schema/sqlite/project-members';
 import type { AuthContext } from '../../lib/api/auth-middleware';
 import { createLogger } from '../../lib/logging/logger';
 import type { RbacService } from '../../services/rbac.service';
@@ -36,6 +37,10 @@ function slugify(name: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
     .substring(0, 100);
+}
+
+function escapeLike(s: string): string {
+  return s.replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
@@ -92,7 +97,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
           ...created,
           membership: { userId: auth.userId, role: 'owner', joinedAt: created?.createdAt },
         },
-      });
+      }, 201);
     } catch (error) {
       log.error('Failed to create team', { error });
       return json(
@@ -130,11 +135,11 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
         // Build where filters
         const filters = [];
         if (cursor) filters.push(gt(teams.id, cursor));
-        if (search) filters.push(like(teams.name, `%${search}%`));
+        if (search) filters.push(like(teams.name, `%${escapeLike(search)}%`));
         const whereClause = filters.length > 0 ? and(...filters) : undefined;
 
         // Total count (with search filter)
-        const countWhere = search ? like(teams.name, `%${search}%`) : undefined;
+        const countWhere = search ? like(teams.name, `%${escapeLike(search)}%`) : undefined;
         const [countResult] = await db.select({ total: count() }).from(teams).where(countWhere);
         const totalCount = countResult?.total ?? 0;
 
@@ -184,12 +189,12 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
       // Build where clause with cursor + search support
       const filters = [inArray(teams.id, teamIds)];
       if (cursor) filters.push(gt(teams.id, cursor));
-      if (search) filters.push(like(teams.name, `%${search}%`));
+      if (search) filters.push(like(teams.name, `%${escapeLike(search)}%`));
       const whereClause = and(...filters);
 
       // Total count (with search filter)
       const countFilters = [inArray(teams.id, teamIds)];
-      if (search) countFilters.push(like(teams.name, `%${search}%`));
+      if (search) countFilters.push(like(teams.name, `%${escapeLike(search)}%`));
       const [countResult] = await db.select({ total: count() }).from(teams).where(and(...countFilters));
       const totalCount = countResult?.total ?? 0;
 
@@ -417,6 +422,12 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
         await tx.delete(teamInvitations).where(eq(teamInvitations.teamId, id));
         await tx.delete(apiTokens).where(eq(apiTokens.teamId, id));
         await tx.delete(tags).where(eq(tags.teamId, id)); // cascades to project_tags and task_tags
+        // Clean up project member overrides granted by this team
+        const teamProjectIds = await tx.select({ projectId: teamProjects.projectId }).from(teamProjects).where(eq(teamProjects.teamId, id));
+        if (teamProjectIds.length > 0) {
+          const pIds = teamProjectIds.map(r => r.projectId);
+          await tx.delete(projectMembers).where(inArray(projectMembers.projectId, pIds));
+        }
         await tx.delete(teamProjects).where(eq(teamProjects.teamId, id));
         await tx.delete(teamMembers).where(eq(teamMembers.teamId, id));
         await tx.delete(teams).where(eq(teams.id, id));

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -3,7 +3,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { and, count, eq, gt, inArray, like } from 'drizzle-orm';
+import { and, count, eq, gt, inArray, like, ne } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { apiTokens } from '../../db/schema/sqlite/api-tokens';
 import { tags } from '../../db/schema/sqlite/tags';
@@ -12,6 +12,7 @@ import { teamMembers } from '../../db/schema/sqlite/team-members';
 import { teamProjects } from '../../db/schema/sqlite/team-projects';
 import { teams } from '../../db/schema/sqlite/teams';
 import { projectMembers } from '../../db/schema/sqlite/project-members';
+import type { RbacRole } from '../../db/schema/shared/enums';
 import type { AuthContext } from '../../lib/api/auth-middleware';
 import { createLogger } from '../../lib/logging/logger';
 import type { RbacService } from '../../services/rbac.service';
@@ -152,7 +153,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
 
         const hasMore = allTeams.length > limit;
         const pagedTeams = hasMore ? allTeams.slice(0, limit) : allTeams;
-        const nextCursor = hasMore ? pagedTeams[pagedTeams.length - 1]?.id : undefined;
+        const nextCursor = hasMore ? pagedTeams[pagedTeams.length - 1]?.id ?? null : null;
 
         // H2+H7: Batch-fetch counts with GROUP BY instead of N+1
         const teamIds = pagedTeams.map(t => t.id);
@@ -162,7 +163,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
           ...team,
           memberCount: memberMap.get(team.id) ?? 0,
           projectCount: projectMap.get(team.id) ?? 0,
-          myRole: null as string | null,
+          myRole: null as RbacRole | null,
         }));
 
         return json({
@@ -180,7 +181,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
       if (memberships.length === 0) {
         return json({
           ok: true,
-          data: { items: [], nextCursor: undefined, hasMore: false, totalCount: 0 },
+          data: { items: [], nextCursor: null, hasMore: false, totalCount: 0 },
         });
       }
 
@@ -207,7 +208,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
 
       const hasMore = teamRows.length > limit;
       const pagedRows = hasMore ? teamRows.slice(0, limit) : teamRows;
-      const nextCursor = hasMore ? pagedRows[pagedRows.length - 1]?.id : undefined;
+      const nextCursor = hasMore ? pagedRows[pagedRows.length - 1]?.id ?? null : null;
 
       const roleByTeamId = new Map(memberships.map((m) => [m.teamId, m.role]));
 
@@ -258,7 +259,7 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
       ]);
 
       // Get caller's role
-      let myRole: string | null = null;
+      let myRole: RbacRole | null = null;
       if (auth.authMethod !== 'dev') {
         myRole = await rbacService.resolveTeamRole(auth.userId, id);
       }
@@ -294,17 +295,38 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
     if (!parsed.ok) return parsed.response;
 
     try {
-      const [updated] = await db
-        .update(teams)
-        .set({ ...parsed.data, updatedAt: new Date().toISOString() })
-        .where(eq(teams.id, id))
-        .returning();
+      const result = await db.transaction(async (tx) => {
+        // Check slug uniqueness if slug is being updated
+        if (parsed.data.slug) {
+          const existingSlug = await tx.query.teams.findFirst({
+            where: and(eq(teams.slug, parsed.data.slug), ne(teams.id, id)),
+          });
+          if (existingSlug) {
+            return 'SLUG_EXISTS' as const;
+          }
+        }
 
-      if (!updated) {
+        const [updated] = await tx
+          .update(teams)
+          .set({ ...parsed.data, updatedAt: new Date().toISOString() })
+          .where(eq(teams.id, id))
+          .returning();
+
+        return updated ?? null;
+      });
+
+      if (result === 'SLUG_EXISTS') {
+        return json(
+          { ok: false, error: { code: 'TEAM_SLUG_EXISTS', message: 'Team slug already exists' } },
+          409
+        );
+      }
+
+      if (!result) {
         return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Team not found' } }, 404);
       }
 
-      return json({ ok: true, data: updated });
+      return json({ ok: true, data: result });
     } catch (error) {
       log.error('Failed to update team', { error });
       return json(

--- a/src/server/routes/teams.ts
+++ b/src/server/routes/teams.ts
@@ -3,7 +3,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { and, count, eq, gt, inArray } from 'drizzle-orm';
+import { and, count, eq, gt, inArray, like } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { apiTokens } from '../../db/schema/sqlite/api-tokens';
 import { tags } from '../../db/schema/sqlite/tags';
@@ -106,16 +106,37 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
   app.get('/', async (c) => {
     const auth = c.get('auth');
     const { cursor, limit } = parsePagination(c);
+    // H5: Support search query parameter
+    const search = c.req.query('search');
 
     try {
+      // Helper: batch-fetch member and project counts for a set of team IDs (H2+H7)
+      async function enrichTeamCounts(teamIds: string[]) {
+        if (teamIds.length === 0) return { memberMap: new Map<string, number>(), projectMap: new Map<string, number>() };
+        const [memberCounts, projectCounts] = await Promise.all([
+          db.select({ teamId: teamMembers.teamId, total: count() })
+            .from(teamMembers).where(inArray(teamMembers.teamId, teamIds)).groupBy(teamMembers.teamId),
+          db.select({ teamId: teamProjects.teamId, total: count() })
+            .from(teamProjects).where(inArray(teamProjects.teamId, teamIds)).groupBy(teamProjects.teamId),
+        ]);
+        return {
+          memberMap: new Map(memberCounts.map(r => [r.teamId, r.total])),
+          projectMap: new Map(projectCounts.map(r => [r.teamId, r.total])),
+        };
+      }
+
       // For dev mode, return all teams
       if (auth.authMethod === 'dev') {
-        // Total count
-        const [countResult] = await db.select({ total: count() }).from(teams);
-        const totalCount = countResult?.total ?? 0;
+        // Build where filters
+        const filters = [];
+        if (cursor) filters.push(gt(teams.id, cursor));
+        if (search) filters.push(like(teams.name, `%${search}%`));
+        const whereClause = filters.length > 0 ? and(...filters) : undefined;
 
-        // Build cursor filter
-        const whereClause = cursor ? gt(teams.id, cursor) : undefined;
+        // Total count (with search filter)
+        const countWhere = search ? like(teams.name, `%${search}%`) : undefined;
+        const [countResult] = await db.select({ total: count() }).from(teams).where(countWhere);
+        const totalCount = countResult?.total ?? 0;
 
         const allTeams = await db
           .select()
@@ -128,20 +149,16 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
         const pagedTeams = hasMore ? allTeams.slice(0, limit) : allTeams;
         const nextCursor = hasMore ? pagedTeams[pagedTeams.length - 1]?.id : undefined;
 
-        // Enrich each team with memberCount (myRole is null in dev mode)
-        const items = await Promise.all(
-          pagedTeams.map(async (team) => {
-            const [memberCountResult] = await db
-              .select({ total: count() })
-              .from(teamMembers)
-              .where(eq(teamMembers.teamId, team.id));
-            return {
-              ...team,
-              memberCount: memberCountResult?.total ?? 0,
-              myRole: null as string | null,
-            };
-          })
-        );
+        // H2+H7: Batch-fetch counts with GROUP BY instead of N+1
+        const teamIds = pagedTeams.map(t => t.id);
+        const { memberMap, projectMap } = await enrichTeamCounts(teamIds);
+
+        const items = pagedTeams.map(team => ({
+          ...team,
+          memberCount: memberMap.get(team.id) ?? 0,
+          projectCount: projectMap.get(team.id) ?? 0,
+          myRole: null as string | null,
+        }));
 
         return json({
           ok: true,
@@ -163,11 +180,18 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
       }
 
       const teamIds = memberships.map((m) => m.teamId);
-      const totalCount = teamIds.length;
 
-      // Build where clause with cursor support
-      const baseWhere = inArray(teams.id, teamIds);
-      const whereClause = cursor ? and(baseWhere, gt(teams.id, cursor)) : baseWhere;
+      // Build where clause with cursor + search support
+      const filters = [inArray(teams.id, teamIds)];
+      if (cursor) filters.push(gt(teams.id, cursor));
+      if (search) filters.push(like(teams.name, `%${search}%`));
+      const whereClause = and(...filters);
+
+      // Total count (with search filter)
+      const countFilters = [inArray(teams.id, teamIds)];
+      if (search) countFilters.push(like(teams.name, `%${search}%`));
+      const [countResult] = await db.select({ total: count() }).from(teams).where(and(...countFilters));
+      const totalCount = countResult?.total ?? 0;
 
       const teamRows = await db
         .select()
@@ -182,21 +206,16 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
 
       const roleByTeamId = new Map(memberships.map((m) => [m.teamId, m.role]));
 
-      // Enrich each team with memberCount and myRole
-      const items = await Promise.all(
-        pagedRows.map(async (team) => {
-          const [memberCountResult] = await db
-            .select({ total: count() })
-            .from(teamMembers)
-            .where(eq(teamMembers.teamId, team.id));
-          return {
-            ...team,
-            memberRole: roleByTeamId.get(team.id),
-            memberCount: memberCountResult?.total ?? 0,
-            myRole: roleByTeamId.get(team.id) ?? null,
-          };
-        })
-      );
+      // H2+H7: Batch-fetch counts with GROUP BY instead of N+1
+      const pagedTeamIds = pagedRows.map(t => t.id);
+      const { memberMap, projectMap } = await enrichTeamCounts(pagedTeamIds);
+
+      const items = pagedRows.map(team => ({
+        ...team,
+        memberCount: memberMap.get(team.id) ?? 0,
+        projectCount: projectMap.get(team.id) ?? 0,
+        myRole: roleByTeamId.get(team.id) ?? null,
+      }));
 
       return json({
         ok: true,
@@ -227,10 +246,11 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
         return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Team not found' } }, 404);
       }
 
-      const memberRows = await db
-        .select({ userId: teamMembers.userId })
-        .from(teamMembers)
-        .where(eq(teamMembers.teamId, id));
+      // H7: Fetch both memberCount and projectCount
+      const [[memberCountResult], [projectCountResult]] = await Promise.all([
+        db.select({ total: count() }).from(teamMembers).where(eq(teamMembers.teamId, id)),
+        db.select({ total: count() }).from(teamProjects).where(eq(teamProjects.teamId, id)),
+      ]);
 
       // Get caller's role
       let myRole: string | null = null;
@@ -238,7 +258,15 @@ export function createTeamsRoutes({ db, rbacService }: TeamsDeps) {
         myRole = await rbacService.resolveTeamRole(auth.userId, id);
       }
 
-      return json({ ok: true, data: { ...team, memberCount: memberRows.length, myRole } });
+      return json({
+        ok: true,
+        data: {
+          ...team,
+          memberCount: memberCountResult?.total ?? 0,
+          projectCount: projectCountResult?.total ?? 0,
+          myRole,
+        },
+      });
     } catch (error) {
       log.error('Failed to get team', { error });
       return json({ ok: false, error: { code: 'DB_ERROR', message: 'Failed to get team' } }, 500);

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -108,7 +108,10 @@ export function requireTeamRole(
 ): Promise<Response | null> {
   if (auth.authMethod === 'dev') return Promise.resolve(null);
   return rbacService.resolveTeamRole(auth.userId, teamId).then((role) => {
-    if (!role || !rbacService.hasMinimumRole(role, minimumRole)) {
+    if (!role) {
+      return json({ ok: false, error: { code: 'NOT_FOUND', message: 'Team not found' } }, 404);
+    }
+    if (!rbacService.hasMinimumRole(role, minimumRole)) {
       return json({ ok: false, error: { code: 'INSUFFICIENT_ROLE', message } }, 403);
     }
     return null;

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -30,7 +30,7 @@ export function parsePagination(c: Context): PaginationParams {
   return { cursor, limit };
 }
 
-// CORS headers for dev
+// CORS headers for SSE endpoints that bypass Hono middleware
 export const corsHeaders = {
   'Access-Control-Allow-Origin': 'http://localhost:3000',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
@@ -141,34 +141,3 @@ export function requireProjectRole(
   });
 }
 
-/**
- * Standard API error structure
- */
-export interface ApiError {
-  code: string;
-  message: string;
-  status?: number;
-}
-
-/**
- * Create an error response with consistent structure
- */
-export function errorResponse(error: ApiError, status?: number): Response {
-  return json(
-    { ok: false, error: { code: error.code, message: error.message } },
-    status ?? error.status ?? 400
-  );
-}
-
-/**
- * Handle service result and return appropriate response
- * Returns null if result is ok, otherwise returns error Response
- */
-export function handleServiceError<T>(
-  result: { ok: false; error: ApiError } | { ok: true; value: T }
-): Response | null {
-  if (!result.ok) {
-    return errorResponse(result.error, result.error.status);
-  }
-  return null;
-}

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -101,7 +101,7 @@ export function isValidGitHubUrl(url: string): boolean {
  * Dev-mode users always pass. Returns null if authorized, a 404 Response if user has no team membership, or a 403 Response if role is insufficient.
  */
 export function requireTeamRole(
-  auth: { authMethod: string; userId: string },
+  auth: { authMethod: 'session' | 'api_token' | 'dev'; userId: string },
   rbacService: {
     resolveTeamRole(userId: string, teamId: string): Promise<RbacRole | null>;
     hasMinimumRole(userRole: RbacRole, minimumRole: RbacRole): boolean;
@@ -130,7 +130,7 @@ export function requireTeamRole(
  * Dev-mode users always pass. Returns null if authorized, or a 403 Response if the user lacks the required role (or has no project access).
  */
 export function requireProjectRole(
-  auth: { authMethod: string; userId: string },
+  auth: { authMethod: 'session' | 'api_token' | 'dev'; userId: string },
   rbacService: {
     resolveUserRole(userId: string, projectId: string): Promise<RbacRole | null>;
     hasMinimumRole(userRole: RbacRole, minimumRole: RbacRole): boolean;

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -3,6 +3,10 @@
  */
 
 import type { Context } from 'hono';
+import type { RbacRole } from '../db/schema/shared/enums';
+import { createLogger } from '../lib/logging/logger';
+
+const log = createLogger('SharedHelpers');
 
 /**
  * Cursor-based pagination parameters
@@ -94,16 +98,16 @@ export function isValidGitHubUrl(url: string): boolean {
 
 /**
  * Require that the authenticated user has at least the given team role.
- * Dev-mode users always pass. Returns a 403 Response if unauthorized, or null if authorized.
+ * Dev-mode users always pass. Returns null if authorized, a 404 Response if user has no team membership, or a 403 Response if role is insufficient.
  */
 export function requireTeamRole(
   auth: { authMethod: string; userId: string },
   rbacService: {
-    resolveTeamRole(userId: string, teamId: string): Promise<string | null>;
-    hasMinimumRole(userRole: string, minimumRole: string): boolean;
+    resolveTeamRole(userId: string, teamId: string): Promise<RbacRole | null>;
+    hasMinimumRole(userRole: RbacRole, minimumRole: RbacRole): boolean;
   },
   teamId: string,
-  minimumRole: string,
+  minimumRole: RbacRole,
   message = `Requires ${minimumRole} role`
 ): Promise<Response | null> {
   if (auth.authMethod === 'dev') return Promise.resolve(null);
@@ -115,21 +119,24 @@ export function requireTeamRole(
       return json({ ok: false, error: { code: 'INSUFFICIENT_ROLE', message } }, 403);
     }
     return null;
+  }).catch((error) => {
+    log.error('Failed to resolve team role', { error, data: { userId: auth.userId, teamId } });
+    return json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to verify permissions' } }, 500);
   });
 }
 
 /**
  * Require that the authenticated user has at least the given project role.
- * Dev-mode users always pass. Returns a 403 Response if unauthorized, or null if authorized.
+ * Dev-mode users always pass. Returns null if authorized, or a 403 Response if the user lacks the required role (or has no project access).
  */
 export function requireProjectRole(
   auth: { authMethod: string; userId: string },
   rbacService: {
-    resolveUserRole(userId: string, projectId: string): Promise<string | null>;
-    hasMinimumRole(userRole: string, minimumRole: string): boolean;
+    resolveUserRole(userId: string, projectId: string): Promise<RbacRole | null>;
+    hasMinimumRole(userRole: RbacRole, minimumRole: RbacRole): boolean;
   },
   projectId: string,
-  minimumRole: string,
+  minimumRole: RbacRole,
   message = `Requires ${minimumRole} role`
 ): Promise<Response | null> {
   if (auth.authMethod === 'dev') return Promise.resolve(null);
@@ -138,6 +145,9 @@ export function requireProjectRole(
       return json({ ok: false, error: { code: 'INSUFFICIENT_ROLE', message } }, 403);
     }
     return null;
+  }).catch((error) => {
+    log.error('Failed to resolve project role', { error, data: { userId: auth.userId, projectId } });
+    return json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to verify permissions' } }, 500);
   });
 }
 

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -102,9 +102,7 @@ export const commitWorktreeSchema = z.object({
 export const rbacRoleSchema = z.enum(['owner', 'admin', 'agent_operator', 'viewer']);
 
 /** Role schema that excludes 'owner' -- used for assignable roles */
-const assignableRoleSchema = rbacRoleSchema.refine((r) => r !== 'owner', {
-  message: 'Cannot assign owner role directly',
-});
+const assignableRoleSchema = z.enum(['admin', 'agent_operator', 'viewer']);
 
 export const createTeamSchema = z.object({
   name: z.string().min(1, 'Team name is required').max(100),

--- a/src/services/rbac-token.service.ts
+++ b/src/services/rbac-token.service.ts
@@ -162,9 +162,9 @@ export class RbacTokenService {
             id: created.id,
             name: created.name,
             tokenPrefix,
-            role: created.role as RbacRole,
+            role: created.role,
             teamId: created.teamId,
-            scopeTags: created.scopeTags as string[] | null,
+            scopeTags: created.scopeTags,
             scopeProjectId: created.scopeProjectId,
             token: rawToken,
             expiresAt: created.expiresAt,
@@ -204,10 +204,10 @@ export class RbacTokenService {
       id: record.id,
       userId: record.userId,
       teamId: record.teamId,
-      role: record.role as RbacRole,
+      role: record.role,
       scopeProjectId: record.scopeProjectId,
-      scopeTags: record.scopeTags as string[] | null,
-      status: record.status as ApiTokenStatus,
+      scopeTags: record.scopeTags,
+      status: record.status,
       expiresAt: record.expiresAt,
     };
   }
@@ -253,7 +253,7 @@ export class RbacTokenService {
   /**
    * Enrich token scope tags with full tag details.
    */
-  async enrichScopeTags(scopeTags: string[] | null): Promise<Array<{ id: string; name: string; color: string | null }>> {
+  async enrichScopeTags(scopeTags: string[] | null): Promise<Array<{ id: string; name: string; color: string }>> {
     if (!scopeTags || scopeTags.length === 0) return [];
 
     const tagRecords = await this.db

--- a/src/services/rbac-token.service.ts
+++ b/src/services/rbac-token.service.ts
@@ -1,0 +1,253 @@
+/**
+ * RBAC Token Service (A1)
+ *
+ * Encapsulates API token operations:
+ * - Token generation, hashing, validation
+ * - CRUD operations (create, list, get, revoke)
+ * - Token resolution from raw value
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { and, count, eq, gt, ne } from 'drizzle-orm';
+import { RBAC_ROLE_LEVEL, type RbacRole } from '../db/schema/shared/enums';
+import { apiTokens } from '../db/schema/sqlite/api-tokens';
+import { tags } from '../db/schema/sqlite/tags';
+import { teams } from '../db/schema/sqlite/teams';
+import { createLogger } from '../lib/logging/logger';
+import type { Database } from '../types/database';
+
+const log = createLogger('RbacTokenService');
+
+/** Token format: ap_ + 32 bytes base64url */
+const TOKEN_PREFIX = 'ap_';
+const TOKEN_FORMAT = /^ap_[A-Za-z0-9_-]{42,44}$/;
+const DISPLAY_PREFIX_LENGTH = 12;
+const MAX_TOKENS_PER_USER = 25;
+
+export interface CreateTokenParams {
+  userId: string;
+  teamId: string;
+  name: string;
+  role: RbacRole;
+  scopeTags?: string[] | null;
+  scopeProjectId?: string | null;
+  expiresInDays?: number;
+}
+
+export interface CreateTokenResult {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  role: RbacRole;
+  teamId: string;
+  scopeTags: string[] | null;
+  scopeProjectId: string | null;
+  token: string;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export interface TokenListItem {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  role: string;
+  scopeTags: unknown;
+  scopeProjectId: string | null;
+  status: string;
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+  useCount: number | null;
+  createdAt: string;
+  teamName: string | null;
+}
+
+export interface ResolvedToken {
+  id: string;
+  userId: string;
+  teamId: string;
+  role: RbacRole;
+  scopeProjectId: string | null;
+  scopeTags: string[] | null;
+  status: string;
+  expiresAt: string | null;
+}
+
+export class RbacTokenService {
+  constructor(private db: Database) {}
+
+  /** Generate a new raw token string */
+  generateToken(): string {
+    return TOKEN_PREFIX + randomBytes(32).toString('base64url');
+  }
+
+  /** Hash a raw token for storage */
+  hashToken(raw: string): string {
+    return createHash('sha256').update(raw).digest('hex');
+  }
+
+  /** Validate raw token format */
+  isValidFormat(raw: string): boolean {
+    return TOKEN_FORMAT.test(raw);
+  }
+
+  /** Get display prefix for a token */
+  getPrefix(raw: string): string {
+    return raw.substring(0, DISPLAY_PREFIX_LENGTH);
+  }
+
+  /**
+   * Create a new API token (within a transaction).
+   * Returns the created token with raw value, or error code.
+   */
+  async create(
+    params: CreateTokenParams
+  ): Promise<{ ok: true; data: CreateTokenResult } | { ok: false; error: string; message: string }> {
+    try {
+      const result = await this.db.transaction(async (tx) => {
+        // Check name uniqueness
+        const existing = await tx
+          .select({ id: apiTokens.id })
+          .from(apiTokens)
+          .where(
+            and(
+              eq(apiTokens.userId, params.userId),
+              eq(apiTokens.name, params.name),
+              ne(apiTokens.status, 'revoked')
+            )
+          );
+
+        if (existing.length > 0) {
+          return { error: 'TOKEN_NAME_EXISTS' as const, message: 'A non-revoked token with this name already exists' };
+        }
+
+        // Check limit
+        const [countResult] = await tx
+          .select({ total: count() })
+          .from(apiTokens)
+          .where(and(eq(apiTokens.userId, params.userId), ne(apiTokens.status, 'revoked')));
+
+        if ((countResult?.total ?? 0) >= MAX_TOKENS_PER_USER) {
+          return { error: 'LIMIT_EXCEEDED' as const, message: `Max ${MAX_TOKENS_PER_USER} active tokens` };
+        }
+
+        const rawToken = this.generateToken();
+        const tokenHash = this.hashToken(rawToken);
+        const tokenPrefix = this.getPrefix(rawToken);
+
+        const expiresAt = params.expiresInDays
+          ? new Date(Date.now() + params.expiresInDays * 24 * 60 * 60 * 1000).toISOString()
+          : null;
+
+        const [created] = await tx
+          .insert(apiTokens)
+          .values({
+            userId: params.userId,
+            teamId: params.teamId,
+            name: params.name,
+            tokenHash,
+            tokenPrefix,
+            role: params.role,
+            scopeTags: params.scopeTags ?? null,
+            scopeProjectId: params.scopeProjectId ?? null,
+            expiresAt,
+          })
+          .returning();
+
+        if (!created) {
+          return { error: 'DB_ERROR' as const, message: 'Failed to create token' };
+        }
+
+        return {
+          created: {
+            id: created.id,
+            name: created.name,
+            tokenPrefix,
+            role: created.role as RbacRole,
+            teamId: created.teamId,
+            scopeTags: created.scopeTags as string[] | null,
+            scopeProjectId: created.scopeProjectId,
+            token: rawToken,
+            expiresAt: created.expiresAt,
+            createdAt: created.createdAt,
+          },
+        };
+      });
+
+      if ('error' in result) {
+        return { ok: false, error: result.error, message: result.message };
+      }
+
+      return { ok: true, data: result.created };
+    } catch (error) {
+      log.error('Failed to create token', { error });
+      return { ok: false, error: 'DB_ERROR', message: 'Failed to create token' };
+    }
+  }
+
+  /**
+   * Resolve a raw token to its stored record.
+   * Returns null if not found or not active.
+   */
+  async resolveToken(rawToken: string): Promise<ResolvedToken | null> {
+    if (!this.isValidFormat(rawToken)) return null;
+
+    const tokenHash = this.hashToken(rawToken);
+    const record = await this.db.query.apiTokens.findFirst({
+      where: and(eq(apiTokens.tokenHash, tokenHash), eq(apiTokens.status, 'active')),
+    });
+
+    if (!record) return null;
+    if (record.expiresAt && new Date(record.expiresAt) < new Date()) return null;
+
+    return {
+      id: record.id,
+      userId: record.userId,
+      teamId: record.teamId,
+      role: record.role as RbacRole,
+      scopeProjectId: record.scopeProjectId,
+      scopeTags: record.scopeTags as string[] | null,
+      status: record.status,
+      expiresAt: record.expiresAt,
+    };
+  }
+
+  /**
+   * Revoke a token (idempotent).
+   */
+  async revoke(
+    tokenId: string,
+    userId: string
+  ): Promise<{ ok: true } | { ok: false; error: string; message: string; status: number }> {
+    const [revoked] = await this.db
+      .update(apiTokens)
+      .set({ status: 'revoked', revokedAt: new Date().toISOString() })
+      .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)))
+      .returning();
+
+    if (!revoked) {
+      return { ok: false, error: 'TOKEN_NOT_FOUND', message: 'Token not found', status: 404 };
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * Enrich token scope tags with full tag details.
+   */
+  async enrichScopeTags(scopeTags: string[] | null): Promise<Array<{ id: string; name: string; color: string | null }>> {
+    if (!scopeTags || scopeTags.length === 0) return [];
+
+    const tagRecords = await this.db
+      .select({ id: tags.id, name: tags.name, color: tags.color })
+      .from(tags)
+      .where(
+        // Use inArray if available, otherwise filter in JS
+        scopeTags.length === 1
+          ? eq(tags.id, scopeTags[0] as string)
+          : eq(tags.id, scopeTags[0] as string) // Simplified - routes handle multiple
+      );
+
+    return tagRecords;
+  }
+}

--- a/src/services/rbac-token.service.ts
+++ b/src/services/rbac-token.service.ts
@@ -186,40 +186,35 @@ export class RbacTokenService {
 
   /**
    * Resolve a raw token to its stored record.
-   * Returns null if not found, not active, or on DB error.
+   * Returns null if not found or not active.
+   * Throws on DB errors so callers can distinguish auth failures from outages.
    */
   async resolveToken(rawToken: string): Promise<ResolvedToken | null> {
     if (!this.isValidFormat(rawToken)) return null;
 
-    try {
-      const tokenHash = this.hashToken(rawToken);
-      const record = await this.db.query.apiTokens.findFirst({
-        where: and(eq(apiTokens.tokenHash, tokenHash), eq(apiTokens.status, 'active')),
-      });
+    const tokenHash = this.hashToken(rawToken);
+    const record = await this.db.query.apiTokens.findFirst({
+      where: and(eq(apiTokens.tokenHash, tokenHash), eq(apiTokens.status, 'active')),
+    });
 
-      if (!record) return null;
-      if (record.expiresAt && new Date(record.expiresAt) < new Date()) return null;
+    if (!record) return null;
+    if (record.expiresAt && new Date(record.expiresAt) < new Date()) return null;
 
-      return {
-        id: record.id,
-        userId: record.userId,
-        teamId: record.teamId,
-        role: record.role as RbacRole,
-        scopeProjectId: record.scopeProjectId,
-        scopeTags: record.scopeTags as string[] | null,
-        status: record.status as ApiTokenStatus,
-        expiresAt: record.expiresAt,
-      };
-    } catch (error) {
-      log.error('Failed to resolve token', { error });
-      return null;
-    }
+    return {
+      id: record.id,
+      userId: record.userId,
+      teamId: record.teamId,
+      role: record.role as RbacRole,
+      scopeProjectId: record.scopeProjectId,
+      scopeTags: record.scopeTags as string[] | null,
+      status: record.status as ApiTokenStatus,
+      expiresAt: record.expiresAt,
+    };
   }
 
   /**
    * Revoke a token.
-   * Note: re-revoking an already-revoked token overwrites `revokedAt`.
-   * Use the route handler's status check if you need to detect duplicates.
+   * Returns ALREADY_REVOKED if the token was previously revoked.
    */
   async revoke(
     tokenId: string,
@@ -229,10 +224,22 @@ export class RbacTokenService {
       const [revoked] = await this.db
         .update(apiTokens)
         .set({ status: 'revoked', revokedAt: new Date().toISOString() })
-        .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)))
+        .where(and(
+          eq(apiTokens.id, tokenId),
+          eq(apiTokens.userId, userId),
+          ne(apiTokens.status, 'revoked')
+        ))
         .returning();
 
       if (!revoked) {
+        // Check if token exists but is already revoked
+        const existing = await this.db
+          .select({ status: apiTokens.status })
+          .from(apiTokens)
+          .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)));
+        if (existing.length > 0 && existing[0]?.status === 'revoked') {
+          return { ok: false, error: 'ALREADY_REVOKED', message: 'Token is already revoked', status: 409 };
+        }
         return { ok: false, error: 'TOKEN_NOT_FOUND', message: 'Token not found', status: 404 };
       }
 
@@ -252,12 +259,7 @@ export class RbacTokenService {
     const tagRecords = await this.db
       .select({ id: tags.id, name: tags.name, color: tags.color })
       .from(tags)
-      .where(
-        scopeTags.length === 1
-          // biome-ignore lint/style/noNonNullAssertion: length checked above
-          ? eq(tags.id, scopeTags[0]!)
-          : inArray(tags.id, scopeTags)
-      );
+      .where(inArray(tags.id, scopeTags));
 
     return tagRecords;
   }

--- a/src/services/rbac-token.service.ts
+++ b/src/services/rbac-token.service.ts
@@ -1,5 +1,5 @@
 /**
- * RBAC Token Service (A1)
+ * RBAC Token Service
  *
  * Encapsulates API token operations:
  * - Token generation, hashing, validation
@@ -8,11 +8,10 @@
  */
 
 import { createHash, randomBytes } from 'node:crypto';
-import { and, count, eq, gt, ne } from 'drizzle-orm';
-import { RBAC_ROLE_LEVEL, type RbacRole } from '../db/schema/shared/enums';
+import { and, count, eq, inArray, ne } from 'drizzle-orm';
+import type { ApiTokenStatus, RbacRole } from '../db/schema/shared/enums';
 import { apiTokens } from '../db/schema/sqlite/api-tokens';
 import { tags } from '../db/schema/sqlite/tags';
-import { teams } from '../db/schema/sqlite/teams';
 import { createLogger } from '../lib/logging/logger';
 import type { Database } from '../types/database';
 
@@ -51,10 +50,10 @@ export interface TokenListItem {
   id: string;
   name: string;
   tokenPrefix: string;
-  role: string;
-  scopeTags: unknown;
+  role: RbacRole;
+  scopeTags: string[] | null;
   scopeProjectId: string | null;
-  status: string;
+  status: ApiTokenStatus;
   expiresAt: string | null;
   lastUsedAt: string | null;
   useCount: number | null;
@@ -69,7 +68,7 @@ export interface ResolvedToken {
   role: RbacRole;
   scopeProjectId: string | null;
   scopeTags: string[] | null;
-  status: string;
+  status: ApiTokenStatus;
   expiresAt: string | null;
 }
 
@@ -175,7 +174,7 @@ export class RbacTokenService {
       });
 
       if ('error' in result) {
-        return { ok: false, error: result.error, message: result.message };
+        return { ok: false, error: result.error as string, message: result.message as string };
       }
 
       return { ok: true, data: result.created };
@@ -187,49 +186,61 @@ export class RbacTokenService {
 
   /**
    * Resolve a raw token to its stored record.
-   * Returns null if not found or not active.
+   * Returns null if not found, not active, or on DB error.
    */
   async resolveToken(rawToken: string): Promise<ResolvedToken | null> {
     if (!this.isValidFormat(rawToken)) return null;
 
-    const tokenHash = this.hashToken(rawToken);
-    const record = await this.db.query.apiTokens.findFirst({
-      where: and(eq(apiTokens.tokenHash, tokenHash), eq(apiTokens.status, 'active')),
-    });
+    try {
+      const tokenHash = this.hashToken(rawToken);
+      const record = await this.db.query.apiTokens.findFirst({
+        where: and(eq(apiTokens.tokenHash, tokenHash), eq(apiTokens.status, 'active')),
+      });
 
-    if (!record) return null;
-    if (record.expiresAt && new Date(record.expiresAt) < new Date()) return null;
+      if (!record) return null;
+      if (record.expiresAt && new Date(record.expiresAt) < new Date()) return null;
 
-    return {
-      id: record.id,
-      userId: record.userId,
-      teamId: record.teamId,
-      role: record.role as RbacRole,
-      scopeProjectId: record.scopeProjectId,
-      scopeTags: record.scopeTags as string[] | null,
-      status: record.status,
-      expiresAt: record.expiresAt,
-    };
+      return {
+        id: record.id,
+        userId: record.userId,
+        teamId: record.teamId,
+        role: record.role as RbacRole,
+        scopeProjectId: record.scopeProjectId,
+        scopeTags: record.scopeTags as string[] | null,
+        status: record.status as ApiTokenStatus,
+        expiresAt: record.expiresAt,
+      };
+    } catch (error) {
+      log.error('Failed to resolve token', { error });
+      return null;
+    }
   }
 
   /**
-   * Revoke a token (idempotent).
+   * Revoke a token.
+   * Note: re-revoking an already-revoked token overwrites `revokedAt`.
+   * Use the route handler's status check if you need to detect duplicates.
    */
   async revoke(
     tokenId: string,
     userId: string
   ): Promise<{ ok: true } | { ok: false; error: string; message: string; status: number }> {
-    const [revoked] = await this.db
-      .update(apiTokens)
-      .set({ status: 'revoked', revokedAt: new Date().toISOString() })
-      .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)))
-      .returning();
+    try {
+      const [revoked] = await this.db
+        .update(apiTokens)
+        .set({ status: 'revoked', revokedAt: new Date().toISOString() })
+        .where(and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, userId)))
+        .returning();
 
-    if (!revoked) {
-      return { ok: false, error: 'TOKEN_NOT_FOUND', message: 'Token not found', status: 404 };
+      if (!revoked) {
+        return { ok: false, error: 'TOKEN_NOT_FOUND', message: 'Token not found', status: 404 };
+      }
+
+      return { ok: true };
+    } catch (error) {
+      log.error('Failed to revoke token', { error });
+      return { ok: false, error: 'DB_ERROR', message: 'Failed to revoke token', status: 500 };
     }
-
-    return { ok: true };
   }
 
   /**
@@ -242,10 +253,10 @@ export class RbacTokenService {
       .select({ id: tags.id, name: tags.name, color: tags.color })
       .from(tags)
       .where(
-        // Use inArray if available, otherwise filter in JS
         scopeTags.length === 1
-          ? eq(tags.id, scopeTags[0] as string)
-          : eq(tags.id, scopeTags[0] as string) // Simplified - routes handle multiple
+          // biome-ignore lint/style/noNonNullAssertion: length checked above
+          ? eq(tags.id, scopeTags[0]!)
+          : inArray(tags.id, scopeTags)
       );
 
     return tagRecords;

--- a/tests/helpers/database.ts
+++ b/tests/helpers/database.ts
@@ -1,7 +1,11 @@
 import Database, { type Database as SQLiteDatabase } from 'better-sqlite3';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../../src/db/schema/sqlite';
-import { MIGRATION_SQL } from '../../src/lib/bootstrap/phases/schema';
+import {
+  MIGRATION_SQL,
+  RBAC_GITHUB_TOKEN_MIGRATION_SQL,
+  RBAC_MIGRATION_SQL,
+} from '../../src/lib/bootstrap/phases/schema';
 import { createTestAgent } from '../factories/agent.factory';
 import { createTestProject } from '../factories/project.factory';
 import { createTestTask } from '../factories/task.factory';
@@ -46,8 +50,20 @@ export async function setupTestDatabase(): Promise<TestDatabase> {
 
   testDb = drizzle(testSqlite, { schema });
 
-  // Run migrations using inline SQL
+  // Run base migrations
   testSqlite.exec(MIGRATION_SQL);
+
+  // Add team_id column to github_tokens before running RBAC migration.
+  // RBAC_MIGRATION_SQL creates an index on github_tokens(team_id), so the
+  // column must exist first. Ignore errors in case the column already exists.
+  try {
+    testSqlite.exec(RBAC_GITHUB_TOKEN_MIGRATION_SQL);
+  } catch {
+    // column may already exist — safe to ignore
+  }
+
+  // Run RBAC migrations (creates teams, task_tags, api_tokens, etc.)
+  testSqlite.exec(RBAC_MIGRATION_SQL);
 
   return testDb;
 }
@@ -96,6 +112,16 @@ export async function clearTestDatabase(): Promise<void> {
   await testDb.delete(schema.repositoryConfigs);
   await testDb.delete(schema.githubInstallations);
   await testDb.delete(schema.githubTokens);
+  // RBAC tables (FK-safe order)
+  await testDb.delete(schema.taskTags);
+  await testDb.delete(schema.projectTags);
+  await testDb.delete(schema.apiTokens);
+  await testDb.delete(schema.teamInvitations);
+  await testDb.delete(schema.projectMembers);
+  await testDb.delete(schema.teamProjects);
+  await testDb.delete(schema.teamMembers);
+  await testDb.delete(schema.tags);
+  await testDb.delete(schema.teams);
   await testDb.delete(schema.projects);
   await testDb.delete(schema.sandboxConfigs);
   await testDb.delete(schema.marketplaces);

--- a/tests/lib/api/rbac-middleware.test.ts
+++ b/tests/lib/api/rbac-middleware.test.ts
@@ -1,0 +1,1002 @@
+/**
+ * Tests for RBAC Middleware
+ *
+ * Covers:
+ * - enrichAuthContext(db): enriches auth context with RBAC information
+ * - requireRole(minimumRole, rbacService): enforces minimum role on routes
+ * - requireTagAccess(db): tag-based access control for API tokens
+ * - C4 token format validation patterns
+ */
+
+import { Hono } from 'hono';
+import type { Context, Next } from 'hono';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { RBAC_ROLE_LEVEL } from '../../../src/db/schema/shared/enums';
+import type { RbacRole } from '../../../src/db/schema/shared/enums';
+import type { AuthContext } from '../../../src/lib/api/auth-middleware';
+import {
+  enrichAuthContext,
+  requireRole,
+  requireTagAccess,
+} from '../../../src/lib/api/rbac-middleware';
+
+// =============================================================================
+// Mock Database Factory
+// =============================================================================
+
+function buildSelectChain(resolvedValue: unknown) {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockResolvedValue(resolvedValue);
+  return chain;
+}
+
+function buildUpdateChain() {
+  const chain = {
+    set: vi.fn(),
+    where: vi.fn(),
+    catch: vi.fn(),
+  };
+  chain.set.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.catch.mockResolvedValue(undefined);
+  // Return a thenable that resolves, so void ... works
+  (chain.where as ReturnType<typeof vi.fn>).mockReturnValue(
+    Object.assign(Promise.resolve(undefined), { catch: vi.fn().mockResolvedValue(undefined) })
+  );
+  return chain;
+}
+
+function createMockDb() {
+  const updateChain = {
+    set: vi.fn(),
+    where: vi.fn(),
+  };
+  updateChain.set.mockReturnValue(updateChain);
+  updateChain.where.mockReturnValue(
+    Object.assign(Promise.resolve(undefined), {
+      catch: vi.fn().mockResolvedValue(undefined),
+    })
+  );
+
+  return {
+    query: {
+      users: {
+        findFirst: vi.fn(),
+      },
+    },
+    select: vi.fn(),
+    update: vi.fn().mockReturnValue(updateChain),
+  };
+}
+
+type MockDb = ReturnType<typeof createMockDb>;
+
+// =============================================================================
+// Mock RbacService Factory
+// =============================================================================
+
+function createMockRbacService() {
+  return {
+    hasMinimumRole: vi.fn(),
+    resolveUserRole: vi.fn(),
+    resolveTeamRole: vi.fn(),
+    resolveGlobalRole: vi.fn(),
+    applyTokenCeiling: vi.fn(),
+    checkProjectScope: vi.fn(),
+    checkTagAccess: vi.fn(),
+    canPerformAction: vi.fn(),
+  };
+}
+
+// =============================================================================
+// Test App Helper
+// =============================================================================
+
+/**
+ * Creates a Hono test app with the given middleware pre-applied.
+ * The GET /test route sets auth context and returns 200 on success.
+ */
+function createTestApp(
+  ...middlewares: Array<(c: Context, next: Next) => Promise<Response | void>>
+) {
+  const app = new Hono();
+  for (const mw of middlewares) {
+    app.use('*', mw as never);
+  }
+  app.get('/test', (c) => c.json({ ok: true }));
+  app.get('/api/projects/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
+  app.get('/api/tasks/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
+  app.get('/api/sessions/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
+  app.get('/api/agents/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
+  return app;
+}
+
+/**
+ * Creates a request with the auth context pre-set in the Hono app.
+ */
+function createAuthMiddleware(auth: AuthContext | undefined, resolvedToken?: object) {
+  return async (c: Context, next: Next) => {
+    if (auth !== undefined) {
+      c.set('auth', auth);
+    }
+    if (resolvedToken !== undefined) {
+      c.set('_resolvedApiToken', resolvedToken);
+    }
+    await next();
+  };
+}
+
+// =============================================================================
+// enrichAuthContext Tests
+// =============================================================================
+
+describe('enrichAuthContext', () => {
+  let mockDb: MockDb;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when no auth context is present', async () => {
+    const app = new Hono();
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('skips DB lookup for dev auth method and grants owner role', async () => {
+    const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
+    const app = createTestApp(
+      createAuthMiddleware(auth),
+      enrichAuthContext(mockDb as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+    // DB should not have been queried
+    expect(mockDb.query.users.findFirst).not.toHaveBeenCalled();
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('grants owner role to dev auth method users', async () => {
+    const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
+    let capturedAuth: AuthContext | undefined;
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => {
+      capturedAuth = c.get('auth') as AuthContext;
+      return c.json({ ok: true });
+    });
+
+    await app.request('/test');
+    expect(capturedAuth?.resolvedRole).toBe('owner');
+    expect(capturedAuth?.roleLevel).toBe(RBAC_ROLE_LEVEL.owner);
+  });
+
+  it('skips token enrichment for session auth method', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'session' };
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatarUrl: null,
+    });
+
+    const selectChain = buildSelectChain([]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth),
+      enrichAuthContext(mockDb as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+    // No token update should have occurred
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('populates tokenScope from cached _resolvedApiToken (H1)', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
+    const cachedToken = {
+      id: 'token-abc',
+      role: 'admin',
+      scopeProjectId: 'proj-1',
+      scopeTags: ['tag-a', 'tag-b'],
+      expiresAt: null,
+    };
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: 'Test User',
+      email: null,
+      avatarUrl: null,
+    });
+    const selectChain = buildSelectChain([{ teamId: 'team-1', role: 'admin' }]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    let capturedAuth: AuthContext | undefined;
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth, cachedToken) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => {
+      capturedAuth = c.get('auth') as AuthContext;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+    expect(capturedAuth?.tokenScope).toEqual({
+      tokenId: 'token-abc',
+      role: 'admin',
+      projectId: 'proj-1',
+      tags: ['tag-a', 'tag-b'],
+    });
+  });
+
+  it('applies token ceiling when token role is lower than membership role', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
+    const cachedToken = {
+      id: 'token-abc',
+      role: 'viewer', // token caps at viewer
+      scopeProjectId: null,
+      scopeTags: null,
+      expiresAt: null,
+    };
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: null,
+      email: null,
+      avatarUrl: null,
+    });
+    // User is admin via team membership
+    const selectChain = buildSelectChain([{ teamId: 'team-1', role: 'owner' }]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    let capturedAuth: AuthContext | undefined;
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth, cachedToken) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => {
+      capturedAuth = c.get('auth') as AuthContext;
+      return c.json({ ok: true });
+    });
+
+    await app.request('/test');
+    // Token ceiling: owner(4) > viewer(1) → capped to viewer
+    expect(capturedAuth?.resolvedRole).toBe('viewer');
+    expect(capturedAuth?.roleLevel).toBe(RBAC_ROLE_LEVEL.viewer);
+  });
+
+  it('returns 401 for expired API token', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
+    const expiredToken = {
+      id: 'token-expired',
+      role: 'admin',
+      scopeProjectId: null,
+      scopeTags: null,
+      expiresAt: new Date(Date.now() - 60_000).toISOString(), // expired 1 minute ago
+    };
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: null,
+      email: null,
+      avatarUrl: null,
+    });
+    const selectChain = buildSelectChain([]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth, expiredToken),
+      enrichAuthContext(mockDb as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+    expect(body.error.message).toContain('expired');
+  });
+
+  it('accepts a token with a future expiry date', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
+    const validToken = {
+      id: 'token-valid',
+      role: 'admin',
+      scopeProjectId: null,
+      scopeTags: null,
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(), // expires in 1 hour
+    };
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: null,
+      email: null,
+      avatarUrl: null,
+    });
+    const selectChain = buildSelectChain([]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth, validToken),
+      enrichAuthContext(mockDb as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 when API token is not in cache (_resolvedApiToken missing)', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
+    // No cached token passed
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: null,
+      email: null,
+      avatarUrl: null,
+    });
+    const selectChain = buildSelectChain([]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth, undefined), // no cached token
+      enrichAuthContext(mockDb as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('fires update for lastUsedAt and useCount asynchronously', async () => {
+    const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
+    const cachedToken = {
+      id: 'token-track',
+      role: 'viewer',
+      scopeProjectId: null,
+      scopeTags: null,
+      expiresAt: null,
+    };
+
+    mockDb.query.users.findFirst.mockResolvedValue({
+      id: 'user-123',
+      githubId: 1,
+      githubLogin: 'testuser',
+      name: null,
+      email: null,
+      avatarUrl: null,
+    });
+    const selectChain = buildSelectChain([]);
+    mockDb.select.mockReturnValue(selectChain);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth, cachedToken),
+      enrichAuthContext(mockDb as never) as never
+    );
+
+    await app.request('/test');
+
+    // update() should have been called for usage tracking
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// requireRole Tests
+// =============================================================================
+
+describe('requireRole', () => {
+  let mockRbacService: ReturnType<typeof createMockRbacService>;
+
+  beforeEach(() => {
+    mockRbacService = createMockRbacService();
+    vi.clearAllMocks();
+  });
+
+  it('allows dev mode users to pass without role check', async () => {
+    const auth: AuthContext = {
+      userId: 'dev-user',
+      authMethod: 'dev',
+      resolvedRole: 'owner',
+      roleLevel: RBAC_ROLE_LEVEL.owner,
+    };
+
+    const app = createTestApp(
+      createAuthMiddleware(auth),
+      requireRole('admin', mockRbacService as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+    expect(mockRbacService.hasMinimumRole).not.toHaveBeenCalled();
+    expect(mockRbacService.resolveUserRole).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when there is no auth context', async () => {
+    const app = new Hono();
+    // No auth middleware — no auth context set
+    app.use('*', requireRole('viewer', mockRbacService as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 403 when user has no resolved role', async () => {
+    const auth: AuthContext = {
+      userId: 'user-norole',
+      authMethod: 'session',
+      // resolvedRole intentionally omitted
+    };
+
+    const app = createTestApp(
+      createAuthMiddleware(auth),
+      requireRole('viewer', mockRbacService as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('allows users with sufficient global role (no project context)', async () => {
+    const auth: AuthContext = {
+      userId: 'user-admin',
+      authMethod: 'session',
+      resolvedRole: 'admin',
+      roleLevel: RBAC_ROLE_LEVEL.admin,
+    };
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth),
+      requireRole('viewer', mockRbacService as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('denies users with insufficient global role (no project context)', async () => {
+    const auth: AuthContext = {
+      userId: 'user-viewer',
+      authMethod: 'session',
+      resolvedRole: 'viewer',
+      roleLevel: RBAC_ROLE_LEVEL.viewer,
+    };
+    mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+    const app = createTestApp(
+      createAuthMiddleware(auth),
+      requireRole('admin', mockRbacService as never) as never
+    );
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.message).toContain('admin');
+  });
+
+  it('resolves project-scoped role when project :id param is present', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'session',
+      resolvedRole: 'admin',
+      roleLevel: RBAC_ROLE_LEVEL.admin,
+    };
+    mockRbacService.resolveUserRole.mockResolvedValue('admin' as RbacRole);
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireRole('viewer', mockRbacService as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(200);
+    expect(mockRbacService.resolveUserRole).toHaveBeenCalledWith('user-123', 'proj-1');
+  });
+
+  it('denies project-scoped access when user has no project role', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'session',
+      resolvedRole: 'viewer',
+      roleLevel: RBAC_ROLE_LEVEL.viewer,
+    };
+    mockRbacService.resolveUserRole.mockResolvedValue(null);
+    mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireRole('viewer', mockRbacService as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(403);
+  });
+});
+
+// =============================================================================
+// requireTagAccess Tests
+// =============================================================================
+
+describe('requireTagAccess', () => {
+  let mockDb: MockDb;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    vi.clearAllMocks();
+  });
+
+  it('skips tag check for dev auth method', async () => {
+    const auth: AuthContext = {
+      userId: 'dev-user',
+      authMethod: 'dev',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['restricted-tag'],
+      },
+    };
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(200);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('skips tag check for session auth method', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'session',
+    };
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(200);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('skips tag check when api_token has no tag restrictions', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: null, // no tag restriction
+      },
+    };
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(200);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('skips tag check when api_token has empty tag array', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: [], // empty = no restriction
+      },
+    };
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(200);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('allows access when tag-restricted token has matching tags on project resource', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['production'],
+      },
+    };
+
+    // First select: projectTags query returns matching tag
+    const projectTagsChain = {
+      from: vi.fn(),
+      where: vi.fn(),
+    };
+    projectTagsChain.from.mockReturnValue(projectTagsChain);
+    projectTagsChain.where.mockResolvedValue([{ tagId: 'production' }]);
+    mockDb.select.mockReturnValue(projectTagsChain);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(200);
+  });
+
+  it('denies access when tag-restricted token has no tag overlap with project resource', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['production'],
+      },
+    };
+
+    // Project has 'staging' tag, token requires 'production'
+    const projectTagsChain = {
+      from: vi.fn(),
+      where: vi.fn(),
+    };
+    projectTagsChain.from.mockReturnValue(projectTagsChain);
+    projectTagsChain.where.mockResolvedValue([{ tagId: 'staging' }]);
+    mockDb.select.mockReturnValue(projectTagsChain);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('denies access when resource has no tags (invisible to tag-restricted token)', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['production'],
+      },
+    };
+
+    // Project has no tags
+    const projectTagsChain = {
+      from: vi.fn(),
+      where: vi.fn(),
+    };
+    projectTagsChain.from.mockReturnValue(projectTagsChain);
+    projectTagsChain.where.mockResolvedValue([]); // no tags
+    mockDb.select.mockReturnValue(projectTagsChain);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.message).toContain('tag-restricted token');
+  });
+
+  it('applies tag access check for task resource type', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['production'],
+      },
+    };
+
+    // taskTags returns matching tag
+    const taskTagsChain = {
+      from: vi.fn(),
+      where: vi.fn(),
+    };
+    taskTagsChain.from.mockReturnValue(taskTagsChain);
+    taskTagsChain.where.mockResolvedValue([{ tagId: 'production' }]);
+    mockDb.select.mockReturnValue(taskTagsChain);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/tasks/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/tasks/task-1');
+    expect(res.status).toBe(200);
+  });
+
+  it('task resource falls back to parent project tags when task has no tags', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['production'],
+      },
+    };
+
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      const chain = {
+        from: vi.fn(),
+        where: vi.fn(),
+      };
+      chain.from.mockReturnValue(chain);
+      if (callCount === 1) {
+        // First call: taskTags query returns empty (no task-level tags)
+        chain.where.mockResolvedValue([]);
+      } else if (callCount === 2) {
+        // Second call: tasks query to get projectId
+        chain.where.mockResolvedValue([{ projectId: 'proj-fallback' }]);
+      } else {
+        // Third call: projectTags for the parent project → matching tag
+        chain.where.mockResolvedValue([{ tagId: 'production' }]);
+      }
+      return chain;
+    });
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/tasks/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/tasks/task-1');
+    expect(res.status).toBe(200);
+    // select was called 3 times: taskTags, tasks (for projectId), projectTags
+    expect(callCount).toBe(3);
+  });
+
+  it('applies tag access check for session resource type', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['team-alpha'],
+      },
+    };
+
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      const chain = { from: vi.fn(), where: vi.fn() };
+      chain.from.mockReturnValue(chain);
+      if (callCount === 1) {
+        // sessions query returns session with projectId
+        chain.where.mockResolvedValue([{ taskId: null, projectId: 'proj-1' }]);
+      } else {
+        // projectTags for the project → matching tag
+        chain.where.mockResolvedValue([{ tagId: 'team-alpha' }]);
+      }
+      return chain;
+    });
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/sessions/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/sessions/sess-1');
+    expect(res.status).toBe(200);
+  });
+
+  it('applies tag access check for agent resource type', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['infra'],
+      },
+    };
+
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      const chain = { from: vi.fn(), where: vi.fn() };
+      chain.from.mockReturnValue(chain);
+      if (callCount === 1) {
+        // agents query returns agent with projectId
+        chain.where.mockResolvedValue([{ projectId: 'proj-infra' }]);
+      } else {
+        // projectTags for the project → matching tag
+        chain.where.mockResolvedValue([{ tagId: 'infra' }]);
+      }
+      return chain;
+    });
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/agents/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/agents/agent-1');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 when called with no auth context', async () => {
+    const app = new Hono();
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/projects/proj-1');
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('skips tag check for paths not matching any resource prefix', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        projectId: null,
+        tags: ['restricted'],
+      },
+    };
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/health', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/health');
+    expect(res.status).toBe(200);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// C4 Token Format Validation Tests
+// =============================================================================
+
+describe('C4 token format validation', () => {
+  /**
+   * Valid AgentPane API tokens must match:
+   *   ap_[A-Za-z0-9_-]{42,44}
+   * These tests validate that regex pattern against various inputs.
+   */
+  const AP_TOKEN_REGEX = /^ap_[A-Za-z0-9_-]{42,44}$/;
+
+  it('accepts a valid token with exactly 42 characters after the prefix', () => {
+    const token = 'ap_' + 'a'.repeat(42);
+    expect(AP_TOKEN_REGEX.test(token)).toBe(true);
+  });
+
+  it('accepts a valid token with 43 characters after the prefix', () => {
+    const token = 'ap_' + 'b'.repeat(43);
+    expect(AP_TOKEN_REGEX.test(token)).toBe(true);
+  });
+
+  it('accepts a valid token with 44 characters after the prefix', () => {
+    const token = 'ap_' + 'c'.repeat(44);
+    expect(AP_TOKEN_REGEX.test(token)).toBe(true);
+  });
+
+  it('accepts tokens with mixed alphanumeric, underscore, and hyphen characters', () => {
+    const token = 'ap_' + 'aB3-xY_z9'.repeat(4) + 'aB34';
+    // 'aB3-xY_z9'.repeat(4) = 40 chars, plus 'aB34' = 44 chars
+    expect(token.length).toBe(47); // 3 + 44
+    expect(AP_TOKEN_REGEX.test(token)).toBe(true);
+  });
+
+  it('rejects short tokens with fewer than 42 characters after the prefix', () => {
+    const token = 'ap_' + 'a'.repeat(41); // one too short
+    expect(AP_TOKEN_REGEX.test(token)).toBe(false);
+  });
+
+  it('rejects tokens with more than 44 characters after the prefix', () => {
+    const token = 'ap_' + 'a'.repeat(45); // one too long
+    expect(AP_TOKEN_REGEX.test(token)).toBe(false);
+  });
+
+  it('rejects tokens without the ap_ prefix', () => {
+    const token = 'sk_' + 'a'.repeat(42);
+    expect(AP_TOKEN_REGEX.test(token)).toBe(false);
+  });
+
+  it('rejects tokens with no prefix at all', () => {
+    const token = 'a'.repeat(45);
+    expect(AP_TOKEN_REGEX.test(token)).toBe(false);
+  });
+
+  it('rejects tokens containing special characters like @ or #', () => {
+    const tokenAt = 'ap_' + 'a'.repeat(41) + '@';
+    const tokenHash = 'ap_' + 'a'.repeat(41) + '#';
+    expect(AP_TOKEN_REGEX.test(tokenAt)).toBe(false);
+    expect(AP_TOKEN_REGEX.test(tokenHash)).toBe(false);
+  });
+
+  it('rejects tokens containing spaces', () => {
+    const token = 'ap_' + 'a'.repeat(41) + ' ';
+    expect(AP_TOKEN_REGEX.test(token)).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(AP_TOKEN_REGEX.test('')).toBe(false);
+  });
+
+  it('rejects the prefix alone with no suffix', () => {
+    expect(AP_TOKEN_REGEX.test('ap_')).toBe(false);
+  });
+});

--- a/tests/lib/api/rbac-middleware.test.ts
+++ b/tests/lib/api/rbac-middleware.test.ts
@@ -124,35 +124,47 @@ describe('enrichAuthContext', () => {
   });
 
   it('skips DB lookup for dev auth method and proceeds immediately', async () => {
-    const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    try {
+      const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
 
-    const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', enrichAuthContext(mockDb as never) as never);
-    app.get('/test', (c) => c.json({ ok: true }));
+      const app = new Hono();
+      app.use('*', createAuthMiddleware(auth) as never);
+      app.use('*', enrichAuthContext(mockDb as never) as never);
+      app.get('/test', (c) => c.json({ ok: true }));
 
-    const res = await app.request('/test');
-    expect(res.status).toBe(200);
-    // DB should not have been queried for dev users
-    expect(mockDb.query.users.findFirst).not.toHaveBeenCalled();
-    expect(mockDb.select).not.toHaveBeenCalled();
+      const res = await app.request('/test');
+      expect(res.status).toBe(200);
+      // DB should not have been queried for dev users
+      expect(mockDb.query.users.findFirst).not.toHaveBeenCalled();
+      expect(mockDb.select).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('grants owner role to dev auth method users', async () => {
-    const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
-    let capturedAuth: AuthContext | undefined;
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    try {
+      const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
+      let capturedAuth: AuthContext | undefined;
 
-    const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', enrichAuthContext(mockDb as never) as never);
-    app.get('/test', (c) => {
-      capturedAuth = c.get('auth') as AuthContext;
-      return c.json({ ok: true });
-    });
+      const app = new Hono();
+      app.use('*', createAuthMiddleware(auth) as never);
+      app.use('*', enrichAuthContext(mockDb as never) as never);
+      app.get('/test', (c) => {
+        capturedAuth = c.get('auth') as AuthContext;
+        return c.json({ ok: true });
+      });
 
-    await app.request('/test');
-    expect(capturedAuth?.resolvedRole).toBe('owner');
-    expect(capturedAuth?.roleLevel).toBe(RBAC_ROLE_LEVEL.owner);
+      await app.request('/test');
+      expect(capturedAuth?.resolvedRole).toBe('owner');
+      expect(capturedAuth?.roleLevel).toBe(RBAC_ROLE_LEVEL.owner);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('skips token update for session auth method (no api_token path)', async () => {

--- a/tests/lib/api/rbac-middleware.test.ts
+++ b/tests/lib/api/rbac-middleware.test.ts
@@ -24,34 +24,6 @@ import {
 // Mock Database Factory
 // =============================================================================
 
-function buildSelectChain(resolvedValue: unknown) {
-  const chain = {
-    from: vi.fn(),
-    innerJoin: vi.fn(),
-    where: vi.fn(),
-  };
-  chain.from.mockReturnValue(chain);
-  chain.innerJoin.mockReturnValue(chain);
-  chain.where.mockResolvedValue(resolvedValue);
-  return chain;
-}
-
-function buildUpdateChain() {
-  const chain = {
-    set: vi.fn(),
-    where: vi.fn(),
-    catch: vi.fn(),
-  };
-  chain.set.mockReturnValue(chain);
-  chain.where.mockReturnValue(chain);
-  chain.catch.mockResolvedValue(undefined);
-  // Return a thenable that resolves, so void ... works
-  (chain.where as ReturnType<typeof vi.fn>).mockReturnValue(
-    Object.assign(Promise.resolve(undefined), { catch: vi.fn().mockResolvedValue(undefined) })
-  );
-  return chain;
-}
-
 function createMockDb() {
   const updateChain = {
     set: vi.fn(),
@@ -95,30 +67,11 @@ function createMockRbacService() {
 }
 
 // =============================================================================
-// Test App Helper
+// Helpers
 // =============================================================================
 
 /**
- * Creates a Hono test app with the given middleware pre-applied.
- * The GET /test route sets auth context and returns 200 on success.
- */
-function createTestApp(
-  ...middlewares: Array<(c: Context, next: Next) => Promise<Response | void>>
-) {
-  const app = new Hono();
-  for (const mw of middlewares) {
-    app.use('*', mw as never);
-  }
-  app.get('/test', (c) => c.json({ ok: true }));
-  app.get('/api/projects/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
-  app.get('/api/tasks/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
-  app.get('/api/sessions/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
-  app.get('/api/agents/:id', (c) => c.json({ ok: true, id: c.req.param('id') }));
-  return app;
-}
-
-/**
- * Creates a request with the auth context pre-set in the Hono app.
+ * Creates a middleware that pre-sets auth context (and optional cached token).
  */
 function createAuthMiddleware(auth: AuthContext | undefined, resolvedToken?: object) {
   return async (c: Context, next: Next) => {
@@ -130,6 +83,20 @@ function createAuthMiddleware(auth: AuthContext | undefined, resolvedToken?: obj
     }
     await next();
   };
+}
+
+/**
+ * Creates a simple select chain mock: select({...}).from(table).where(cond)
+ * resolves with `resolvedValue`.
+ */
+function buildSelectChain(resolvedValue: unknown) {
+  const chain = {
+    from: vi.fn(),
+    where: vi.fn(),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.where.mockResolvedValue(resolvedValue);
+  return chain;
 }
 
 // =============================================================================
@@ -156,16 +123,17 @@ describe('enrichAuthContext', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('skips DB lookup for dev auth method and grants owner role', async () => {
+  it('skips DB lookup for dev auth method and proceeds immediately', async () => {
     const auth: AuthContext = { userId: 'dev-user', authMethod: 'dev' };
-    const app = createTestApp(
-      createAuthMiddleware(auth),
-      enrichAuthContext(mockDb as never) as never
-    );
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(200);
-    // DB should not have been queried
+    // DB should not have been queried for dev users
     expect(mockDb.query.users.findFirst).not.toHaveBeenCalled();
     expect(mockDb.select).not.toHaveBeenCalled();
   });
@@ -187,7 +155,7 @@ describe('enrichAuthContext', () => {
     expect(capturedAuth?.roleLevel).toBe(RBAC_ROLE_LEVEL.owner);
   });
 
-  it('skips token enrichment for session auth method', async () => {
+  it('skips token update for session auth method (no api_token path)', async () => {
     const auth: AuthContext = { userId: 'user-123', authMethod: 'session' };
 
     mockDb.query.users.findFirst.mockResolvedValue({
@@ -198,18 +166,17 @@ describe('enrichAuthContext', () => {
       email: 'test@example.com',
       avatarUrl: null,
     });
-
     const selectChain = buildSelectChain([]);
     mockDb.select.mockReturnValue(selectChain);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth),
-      enrichAuthContext(mockDb as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(200);
-    // No token update should have occurred
+    // No token update should have occurred for session auth
     expect(mockDb.update).not.toHaveBeenCalled();
   });
 
@@ -271,7 +238,7 @@ describe('enrichAuthContext', () => {
       email: null,
       avatarUrl: null,
     });
-    // User is admin via team membership
+    // User is owner via team membership
     const selectChain = buildSelectChain([{ teamId: 'team-1', role: 'owner' }]);
     mockDb.select.mockReturnValue(selectChain);
 
@@ -290,7 +257,7 @@ describe('enrichAuthContext', () => {
     expect(capturedAuth?.roleLevel).toBe(RBAC_ROLE_LEVEL.viewer);
   });
 
-  it('returns 401 for expired API token', async () => {
+  it('returns 401 for an expired API token', async () => {
     const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
     const expiredToken = {
       id: 'token-expired',
@@ -311,10 +278,10 @@ describe('enrichAuthContext', () => {
     const selectChain = buildSelectChain([]);
     mockDb.select.mockReturnValue(selectChain);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth, expiredToken),
-      enrichAuthContext(mockDb as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth, expiredToken) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(401);
@@ -345,16 +312,16 @@ describe('enrichAuthContext', () => {
     const selectChain = buildSelectChain([]);
     mockDb.select.mockReturnValue(selectChain);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth, validToken),
-      enrichAuthContext(mockDb as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth, validToken) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(200);
   });
 
-  it('returns 401 when API token is not in cache (_resolvedApiToken missing)', async () => {
+  it('returns 401 when API token is not cached (_resolvedApiToken missing)', async () => {
     const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
     // No cached token passed
 
@@ -369,10 +336,10 @@ describe('enrichAuthContext', () => {
     const selectChain = buildSelectChain([]);
     mockDb.select.mockReturnValue(selectChain);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth, undefined), // no cached token
-      enrichAuthContext(mockDb as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth, undefined) as never); // no cached token
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(401);
@@ -381,7 +348,7 @@ describe('enrichAuthContext', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('fires update for lastUsedAt and useCount asynchronously', async () => {
+  it('fires update for lastUsedAt and useCount asynchronously for api_token', async () => {
     const auth: AuthContext = { userId: 'user-123', authMethod: 'api_token' };
     const cachedToken = {
       id: 'token-track',
@@ -402,14 +369,14 @@ describe('enrichAuthContext', () => {
     const selectChain = buildSelectChain([]);
     mockDb.select.mockReturnValue(selectChain);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth, cachedToken),
-      enrichAuthContext(mockDb as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth, cachedToken) as never);
+    app.use('*', enrichAuthContext(mockDb as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     await app.request('/test');
 
-    // update() should have been called for usage tracking
+    // db.update() should have been called for usage tracking (fire-and-forget)
     expect(mockDb.update).toHaveBeenCalled();
   });
 });
@@ -426,7 +393,7 @@ describe('requireRole', () => {
     vi.clearAllMocks();
   });
 
-  it('allows dev mode users to pass without role check', async () => {
+  it('allows dev mode users to pass without performing a role check', async () => {
     const auth: AuthContext = {
       userId: 'dev-user',
       authMethod: 'dev',
@@ -434,10 +401,10 @@ describe('requireRole', () => {
       roleLevel: RBAC_ROLE_LEVEL.owner,
     };
 
-    const app = createTestApp(
-      createAuthMiddleware(auth),
-      requireRole('admin', mockRbacService as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireRole('admin', mockRbacService as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(200);
@@ -458,17 +425,17 @@ describe('requireRole', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('returns 403 when user has no resolved role', async () => {
+  it('returns 403 when user has no resolved role (no team membership)', async () => {
     const auth: AuthContext = {
       userId: 'user-norole',
       authMethod: 'session',
       // resolvedRole intentionally omitted
     };
 
-    const app = createTestApp(
-      createAuthMiddleware(auth),
-      requireRole('viewer', mockRbacService as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireRole('viewer', mockRbacService as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(403);
@@ -477,7 +444,7 @@ describe('requireRole', () => {
     expect(body.error.code).toBe('FORBIDDEN');
   });
 
-  it('allows users with sufficient global role (no project context)', async () => {
+  it('allows users with sufficient global role when no project context is present', async () => {
     const auth: AuthContext = {
       userId: 'user-admin',
       authMethod: 'session',
@@ -486,10 +453,10 @@ describe('requireRole', () => {
     };
     mockRbacService.hasMinimumRole.mockReturnValue(true);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth),
-      requireRole('viewer', mockRbacService as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireRole('viewer', mockRbacService as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(200);
@@ -504,10 +471,10 @@ describe('requireRole', () => {
     };
     mockRbacService.hasMinimumRole.mockReturnValue(false);
 
-    const app = createTestApp(
-      createAuthMiddleware(auth),
-      requireRole('admin', mockRbacService as never) as never
-    );
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('*', requireRole('admin', mockRbacService as never) as never);
+    app.get('/test', (c) => c.json({ ok: true }));
 
     const res = await app.request('/test');
     expect(res.status).toBe(403);
@@ -517,7 +484,7 @@ describe('requireRole', () => {
     expect(body.error.message).toContain('admin');
   });
 
-  it('resolves project-scoped role when project :id param is present', async () => {
+  it('resolves project-scoped role when project :id param is present (route-level middleware)', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'session',
@@ -527,10 +494,15 @@ describe('requireRole', () => {
     mockRbacService.resolveUserRole.mockResolvedValue('admin' as RbacRole);
     mockRbacService.hasMinimumRole.mockReturnValue(true);
 
+    // Mount middleware at route level so c.req.param('id') is resolved
+    const mw = requireRole('viewer', mockRbacService as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireRole('viewer', mockRbacService as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(200);
@@ -547,10 +519,14 @@ describe('requireRole', () => {
     mockRbacService.resolveUserRole.mockResolvedValue(null);
     mockRbacService.hasMinimumRole.mockReturnValue(false);
 
+    const mw = requireRole('viewer', mockRbacService as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireRole('viewer', mockRbacService as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(403);
@@ -581,10 +557,14 @@ describe('requireTagAccess', () => {
       },
     };
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(200);
@@ -597,17 +577,21 @@ describe('requireTagAccess', () => {
       authMethod: 'session',
     };
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(200);
     expect(mockDb.select).not.toHaveBeenCalled();
   });
 
-  it('skips tag check when api_token has no tag restrictions', async () => {
+  it('skips tag check when api_token has no tag restrictions (null tags)', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -619,10 +603,14 @@ describe('requireTagAccess', () => {
       },
     };
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(200);
@@ -641,10 +629,14 @@ describe('requireTagAccess', () => {
       },
     };
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(200);
@@ -663,19 +655,18 @@ describe('requireTagAccess', () => {
       },
     };
 
-    // First select: projectTags query returns matching tag
-    const projectTagsChain = {
-      from: vi.fn(),
-      where: vi.fn(),
-    };
-    projectTagsChain.from.mockReturnValue(projectTagsChain);
-    projectTagsChain.where.mockResolvedValue([{ tagId: 'production' }]);
-    mockDb.select.mockReturnValue(projectTagsChain);
+    // projectTags query returns matching tag
+    const chain = buildSelectChain([{ tagId: 'production' }]);
+    mockDb.select.mockReturnValue(chain);
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(200);
@@ -694,18 +685,17 @@ describe('requireTagAccess', () => {
     };
 
     // Project has 'staging' tag, token requires 'production'
-    const projectTagsChain = {
-      from: vi.fn(),
-      where: vi.fn(),
-    };
-    projectTagsChain.from.mockReturnValue(projectTagsChain);
-    projectTagsChain.where.mockResolvedValue([{ tagId: 'staging' }]);
-    mockDb.select.mockReturnValue(projectTagsChain);
+    const chain = buildSelectChain([{ tagId: 'staging' }]);
+    mockDb.select.mockReturnValue(chain);
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(403);
@@ -727,18 +717,17 @@ describe('requireTagAccess', () => {
     };
 
     // Project has no tags
-    const projectTagsChain = {
-      from: vi.fn(),
-      where: vi.fn(),
-    };
-    projectTagsChain.from.mockReturnValue(projectTagsChain);
-    projectTagsChain.where.mockResolvedValue([]); // no tags
-    mockDb.select.mockReturnValue(projectTagsChain);
+    const chain = buildSelectChain([]); // no tags
+    mockDb.select.mockReturnValue(chain);
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/projects/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(403);
@@ -746,7 +735,7 @@ describe('requireTagAccess', () => {
     expect(body.error.message).toContain('tag-restricted token');
   });
 
-  it('applies tag access check for task resource type', async () => {
+  it('allows access for task resource type when tags match', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -759,24 +748,23 @@ describe('requireTagAccess', () => {
     };
 
     // taskTags returns matching tag
-    const taskTagsChain = {
-      from: vi.fn(),
-      where: vi.fn(),
-    };
-    taskTagsChain.from.mockReturnValue(taskTagsChain);
-    taskTagsChain.where.mockResolvedValue([{ tagId: 'production' }]);
-    mockDb.select.mockReturnValue(taskTagsChain);
+    const chain = buildSelectChain([{ tagId: 'production' }]);
+    mockDb.select.mockReturnValue(chain);
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/tasks/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/tasks/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/tasks/task-1');
     expect(res.status).toBe(200);
   });
 
-  it('task resource falls back to parent project tags when task has no tags', async () => {
+  it('task resource falls back to parent project tags when task has no direct tags', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -791,28 +779,28 @@ describe('requireTagAccess', () => {
     let callCount = 0;
     mockDb.select.mockImplementation(() => {
       callCount++;
-      const chain = {
-        from: vi.fn(),
-        where: vi.fn(),
-      };
-      chain.from.mockReturnValue(chain);
+      const chain = buildSelectChain(undefined); // placeholder
       if (callCount === 1) {
-        // First call: taskTags query returns empty (no task-level tags)
+        // taskTags query returns empty (no task-level tags)
         chain.where.mockResolvedValue([]);
       } else if (callCount === 2) {
-        // Second call: tasks query to get projectId
+        // tasks query to get projectId
         chain.where.mockResolvedValue([{ projectId: 'proj-fallback' }]);
       } else {
-        // Third call: projectTags for the parent project → matching tag
+        // projectTags for the parent project → matching tag
         chain.where.mockResolvedValue([{ tagId: 'production' }]);
       }
       return chain;
     });
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/tasks/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/tasks/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/tasks/task-1');
     expect(res.status).toBe(200);
@@ -820,7 +808,7 @@ describe('requireTagAccess', () => {
     expect(callCount).toBe(3);
   });
 
-  it('applies tag access check for session resource type', async () => {
+  it('allows access for session resource type when project tags match', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -835,10 +823,9 @@ describe('requireTagAccess', () => {
     let callCount = 0;
     mockDb.select.mockImplementation(() => {
       callCount++;
-      const chain = { from: vi.fn(), where: vi.fn() };
-      chain.from.mockReturnValue(chain);
+      const chain = buildSelectChain(undefined);
       if (callCount === 1) {
-        // sessions query returns session with projectId
+        // sessions query returns session with projectId (no taskId)
         chain.where.mockResolvedValue([{ taskId: null, projectId: 'proj-1' }]);
       } else {
         // projectTags for the project → matching tag
@@ -847,16 +834,20 @@ describe('requireTagAccess', () => {
       return chain;
     });
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/sessions/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/sessions/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/sessions/sess-1');
     expect(res.status).toBe(200);
   });
 
-  it('applies tag access check for agent resource type', async () => {
+  it('allows access for agent resource type when project tags match', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -871,8 +862,7 @@ describe('requireTagAccess', () => {
     let callCount = 0;
     mockDb.select.mockImplementation(() => {
       callCount++;
-      const chain = { from: vi.fn(), where: vi.fn() };
-      chain.from.mockReturnValue(chain);
+      const chain = buildSelectChain(undefined);
       if (callCount === 1) {
         // agents query returns agent with projectId
         chain.where.mockResolvedValue([{ projectId: 'proj-infra' }]);
@@ -883,19 +873,23 @@ describe('requireTagAccess', () => {
       return chain;
     });
 
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', createAuthMiddleware(auth) as never);
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/agents/:id', (c) => c.json({ ok: true }));
+    app.get(
+      '/api/agents/:id',
+      createAuthMiddleware(auth) as never,
+      mw,
+      (c) => c.json({ ok: true })
+    );
 
     const res = await app.request('/api/agents/agent-1');
     expect(res.status).toBe(200);
   });
 
   it('returns 401 when called with no auth context', async () => {
+    const mw = requireTagAccess(mockDb as never) as never;
     const app = new Hono();
-    app.use('*', requireTagAccess(mockDb as never) as never);
-    app.get('/api/projects/:id', (c) => c.json({ ok: true }));
+    app.get('/api/projects/:id', mw, (c) => c.json({ ok: true }));
 
     const res = await app.request('/api/projects/proj-1');
     expect(res.status).toBe(401);
@@ -903,7 +897,7 @@ describe('requireTagAccess', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('skips tag check for paths not matching any resource prefix', async () => {
+  it('skips tag check for paths not matching any known resource prefix', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -915,6 +909,7 @@ describe('requireTagAccess', () => {
       },
     };
 
+    // Global middleware for a non-resource path
     const app = new Hono();
     app.use('*', createAuthMiddleware(auth) as never);
     app.use('*', requireTagAccess(mockDb as never) as never);
@@ -954,9 +949,10 @@ describe('C4 token format validation', () => {
   });
 
   it('accepts tokens with mixed alphanumeric, underscore, and hyphen characters', () => {
-    const token = 'ap_' + 'aB3-xY_z9'.repeat(4) + 'aB34';
-    // 'aB3-xY_z9'.repeat(4) = 40 chars, plus 'aB34' = 44 chars
-    expect(token.length).toBe(47); // 3 + 44
+    // 'aB3-xY_z9' = 9 chars, repeat(4) = 36 chars, plus '---aB3456' = 9 chars → total = 45 chars
+    // Use a simpler construction: 42 alphanum + special chars
+    const token = 'ap_' + 'aB3-xY_z'.repeat(5) + 'aB'; // 8*5=40 + 2 = 42 chars
+    expect(token.length).toBe(45); // 3 + 42
     expect(AP_TOKEN_REGEX.test(token)).toBe(true);
   });
 
@@ -980,7 +976,7 @@ describe('C4 token format validation', () => {
     expect(AP_TOKEN_REGEX.test(token)).toBe(false);
   });
 
-  it('rejects tokens containing special characters like @ or #', () => {
+  it('rejects tokens containing special characters such as @ or #', () => {
     const tokenAt = 'ap_' + 'a'.repeat(41) + '@';
     const tokenHash = 'ap_' + 'a'.repeat(41) + '#';
     expect(AP_TOKEN_REGEX.test(tokenAt)).toBe(false);
@@ -992,11 +988,11 @@ describe('C4 token format validation', () => {
     expect(AP_TOKEN_REGEX.test(token)).toBe(false);
   });
 
-  it('rejects empty string', () => {
+  it('rejects an empty string', () => {
     expect(AP_TOKEN_REGEX.test('')).toBe(false);
   });
 
-  it('rejects the prefix alone with no suffix', () => {
+  it('rejects the prefix alone with no suffix characters', () => {
     expect(AP_TOKEN_REGEX.test('ap_')).toBe(false);
   });
 });

--- a/tests/lib/api/rbac-middleware.test.ts
+++ b/tests/lib/api/rbac-middleware.test.ts
@@ -909,7 +909,7 @@ describe('requireTagAccess', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('skips tag check for paths not matching any known resource prefix', async () => {
+  it('denies tag-restricted token on unrecognized resource paths', async () => {
     const auth: AuthContext = {
       userId: 'user-123',
       authMethod: 'api_token',
@@ -928,8 +928,11 @@ describe('requireTagAccess', () => {
     app.get('/api/health', (c) => c.json({ ok: true }));
 
     const res = await app.request('/api/health');
-    expect(res.status).toBe(200);
-    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.message).toBe('Tag-restricted tokens cannot access this resource type');
   });
 });
 

--- a/tests/routes/rbac-tokens.test.ts
+++ b/tests/routes/rbac-tokens.test.ts
@@ -711,12 +711,7 @@ describe('DELETE /tokens/:id', () => {
   it('revokes an active token and returns success', async () => {
     const db = createMockDb();
 
-    // Initial status check: active token
-    db.select.mockReturnValueOnce({
-      from: vi.fn().mockReturnThis(),
-      where: vi.fn().mockResolvedValue([{ id: 'token-abc123', status: 'active' }]),
-    });
-    // Update call
+    // Atomic update: ne(status, 'revoked') matches, returns the updated row
     mockUpdateChain(db, [{ id: 'token-abc123', status: 'revoked' }]);
 
     const rbacService = createMockRbacService();
@@ -732,10 +727,7 @@ describe('DELETE /tokens/:id', () => {
   it('sets status to revoked and revokedAt timestamp on update', async () => {
     const db = createMockDb();
 
-    db.select.mockReturnValueOnce({
-      from: vi.fn().mockReturnThis(),
-      where: vi.fn().mockResolvedValue([{ id: 'token-abc123', status: 'active' }]),
-    });
+    // Atomic update returns the updated row
     const updateChain = mockUpdateChain(db, [{ id: 'token-abc123', status: 'revoked' }]);
 
     const rbacService = createMockRbacService();
@@ -751,9 +743,12 @@ describe('DELETE /tokens/:id', () => {
   it('returns 409 when token is already revoked', async () => {
     const db = createMockDb();
 
+    // Atomic update: ne(status, 'revoked') doesn't match → returns empty
+    mockUpdateChain(db, []);
+    // Follow-up select to distinguish not-found vs already-revoked: token exists
     db.select.mockReturnValueOnce({
       from: vi.fn().mockReturnThis(),
-      where: vi.fn().mockResolvedValue([{ id: 'token-abc123', status: 'revoked' }]),
+      where: vi.fn().mockResolvedValue([{ status: 'revoked' }]),
     });
 
     const rbacService = createMockRbacService();
@@ -768,6 +763,9 @@ describe('DELETE /tokens/:id', () => {
   it('returns 404 when token not found', async () => {
     const db = createMockDb();
 
+    // Atomic update: no matching row → returns empty
+    mockUpdateChain(db, []);
+    // Follow-up select: token does not exist for this user
     db.select.mockReturnValueOnce({
       from: vi.fn().mockReturnThis(),
       where: vi.fn().mockResolvedValue([]),
@@ -784,7 +782,9 @@ describe('DELETE /tokens/:id', () => {
 
   it('can only revoke own tokens (userId filter applied)', async () => {
     const db = createMockDb();
-    // Token belongs to a different user — status check returns empty
+    // Atomic update: userId filter doesn't match → returns empty
+    mockUpdateChain(db, []);
+    // Follow-up select: token doesn't belong to this user
     db.select.mockReturnValueOnce({
       from: vi.fn().mockReturnThis(),
       where: vi.fn().mockResolvedValue([]),

--- a/tests/routes/rbac-tokens.test.ts
+++ b/tests/routes/rbac-tokens.test.ts
@@ -1,0 +1,810 @@
+/**
+ * Tests for RBAC API token routes.
+ *
+ * Covers:
+ * - POST /tokens: creation, 201 status, role ceiling validation, name uniqueness (409), max limit (400), raw token in response, expiresInDays
+ * - GET /tokens: list active tokens, showAll=true includes revoked, teamId filter, pagination with cursor/totalCount, useCount in response, allTeam admin-only listing
+ * - GET /tokens/:id: returns enriched scope tags, 404 for non-existent, own tokens only
+ * - DELETE /tokens/:id: revoke sets status and revokedAt, already-revoked returns 409, own tokens only
+ */
+
+// Mock the test database helpers to prevent the global setup from attempting
+// to run RBAC_MIGRATION_SQL (which has a pre-existing schema dependency issue).
+vi.mock('../helpers/database', () => ({
+  setupTestDatabase: vi.fn().mockResolvedValue(undefined),
+  clearTestDatabase: vi.fn().mockResolvedValue(undefined),
+  closeTestDatabase: vi.fn().mockResolvedValue(undefined),
+  getTestDb: vi.fn(),
+  seedTestDatabase: vi.fn().mockResolvedValue([]),
+}));
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRbacTokensRoutes } from '../../src/server/routes/rbac-tokens';
+import type { AuthContext } from '../../src/lib/api/auth-middleware';
+import type { RbacService } from '../../src/services/rbac.service';
+
+// ─── Mock factory helpers ─────────────────────────────────────────────────────
+
+function makeAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    userId: 'user-001',
+    authMethod: 'session',
+    ...overrides,
+  };
+}
+
+function makeToken(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'token-abc123',
+    name: 'my-token',
+    tokenPrefix: 'ap_abc12345',
+    role: 'agent_operator',
+    teamId: 'team-001',
+    scopeTags: null,
+    scopeProjectId: null,
+    status: 'active',
+    expiresAt: null,
+    lastUsedAt: null,
+    useCount: 0,
+    createdAt: new Date().toISOString(),
+    tokenHash: 'deadbeef',
+    userId: 'user-001',
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function createMockRbacService(overrides: Partial<RbacService> = {}): RbacService {
+  return {
+    resolveUserRole: vi.fn().mockResolvedValue('admin'),
+    resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    hasMinimumRole: vi.fn().mockReturnValue(true),
+    can: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  } as unknown as RbacService;
+}
+
+// ─── DB mock builder ──────────────────────────────────────────────────────────
+
+function createMockDb(overrides: Record<string, unknown> = {}) {
+  const mockTx = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(async (cb: (tx: typeof mockTx) => Promise<unknown>) => cb(mockTx)),
+    query: {},
+    _mockTx: mockTx,
+    ...overrides,
+  };
+
+  return mockDb;
+}
+
+// ─── App builder ──────────────────────────────────────────────────────────────
+
+function buildApp(
+  auth: AuthContext,
+  db: ReturnType<typeof createMockDb>,
+  rbacService: RbacService
+) {
+  const routes = createRbacTokensRoutes({
+    db: db as unknown as Parameters<typeof createRbacTokensRoutes>[0]['db'],
+    rbacService,
+  });
+
+  const app = new Hono<{ Variables: { auth: AuthContext } }>();
+  app.use('*', async (c, next) => {
+    c.set('auth', auth);
+    await next();
+  });
+  app.route('/tokens', routes);
+  return app;
+}
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+/** Wire up db.select().from().where()...returning().limit() chain returning `rows` */
+function mockSelectChain(db: ReturnType<typeof createMockDb>, rows: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+    then: undefined as unknown,
+  };
+  // Make the chain thenable so `await db.select(...).from(...).where(...)` (no .limit) also works
+  chain.then = (resolve: (v: unknown[]) => unknown) => Promise.resolve(rows).then(resolve);
+  db.select.mockReturnValue(chain);
+  return chain;
+}
+
+function mockTxSelectChain(tx: ReturnType<typeof createMockDb>['_mockTx'], rows: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+    then: undefined as unknown,
+  };
+  chain.then = (resolve: (v: unknown[]) => unknown) => Promise.resolve(rows).then(resolve);
+  tx.select.mockReturnValue(chain);
+  return chain;
+}
+
+function mockTxInsertChain(
+  tx: ReturnType<typeof createMockDb>['_mockTx'],
+  rows: unknown[]
+) {
+  const chain = {
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+  };
+  tx.insert.mockReturnValue(chain);
+  return chain;
+}
+
+function mockUpdateChain(
+  db: ReturnType<typeof createMockDb>,
+  rows: unknown[]
+) {
+  const chain = {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+  };
+  db.update.mockReturnValue(chain);
+  return chain;
+}
+
+// ─── POST /tokens ─────────────────────────────────────────────────────────────
+
+describe('POST /tokens', () => {
+  const validBody = {
+    name: 'ci-token',
+    teamId: 'team-001',
+    role: 'agent_operator',
+  };
+
+  it('M2: returns 201 on successful token creation', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+
+    // scopeProjectId not provided, no scopeTags
+    // transaction internals: name uniqueness check → [], count check → [{total:0}], insert → [token]
+    const createdToken = makeToken({ name: 'ci-token', role: 'agent_operator' });
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]), // no existing name
+    });
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]), // count = 0
+    });
+    mockTxInsertChain(tx, [createdToken]);
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty('token');
+    expect(typeof body.data.token).toBe('string');
+  });
+
+  it('M1: token creation is wrapped in a transaction', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]),
+    });
+    mockTxInsertChain(tx, [makeToken()]);
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(db.transaction).toHaveBeenCalledOnce();
+  });
+
+  it('returns 403 when token role exceeds user team role', async () => {
+    const db = createMockDb();
+    // user is viewer, wants admin token
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, role: 'admin' }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(body.error.message).toMatch(/cannot exceed/i);
+  });
+
+  it('returns 403 when user is not a member of the team', async () => {
+    const db = createMockDb();
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue(null),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 409 on duplicate token name (TOKEN_NAME_EXISTS)', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+
+    // Existing token with same name
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ id: 'existing-token' }]),
+    });
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe('TOKEN_NAME_EXISTS');
+  });
+
+  it('returns 400 when user has 25 active tokens (LIMIT_EXCEEDED)', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+
+    // No name conflict
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+    // Count = 25
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 25 }]),
+    });
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('LIMIT_EXCEEDED');
+  });
+
+  it('converts expiresInDays to an ISO date in the response', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+    const expectedExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const createdToken = makeToken({ expiresAt: expectedExpiry });
+
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]),
+    });
+    mockTxInsertChain(tx, [createdToken]);
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, expiresInDays: 7 }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.data.expiresAt).toBeTruthy();
+    // Should be a valid ISO date string
+    expect(() => new Date(body.data.expiresAt)).not.toThrow();
+  });
+
+  it('dev authMethod bypasses role ceiling check', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+    const createdToken = makeToken({ role: 'admin' });
+
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]),
+    });
+    mockTxInsertChain(tx, [createdToken]);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth({ authMethod: 'dev' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, role: 'admin' }),
+    });
+
+    expect(res.status).toBe(201);
+    // resolveTeamRole should NOT have been called
+    expect(rbacService.resolveTeamRole).not.toHaveBeenCalled();
+  });
+
+  it('returns raw token only on creation (not a hash prefix)', async () => {
+    const db = createMockDb();
+    const tx = db._mockTx;
+    const createdToken = makeToken();
+
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+    tx.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]),
+    });
+    mockTxInsertChain(tx, [createdToken]);
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    const body = await res.json();
+    expect(body.data.token).toMatch(/^ap_/);
+  });
+});
+
+// ─── GET /tokens ──────────────────────────────────────────────────────────────
+
+describe('GET /tokens', () => {
+  it('lists only active tokens by default', async () => {
+    const db = createMockDb();
+    const activeToken = makeToken();
+
+    // count query
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 1 }]),
+    });
+    // list query
+    const listChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([activeToken]),
+    };
+    db.select.mockReturnValueOnce(listChain);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.totalCount).toBe(1);
+  });
+
+  it('M3: includes useCount in each item', async () => {
+    const db = createMockDb();
+    const tokenWithUseCount = makeToken({ useCount: 42 });
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 1 }]),
+    });
+    const listChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([tokenWithUseCount]),
+    };
+    db.select.mockReturnValueOnce(listChain);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens');
+    const body = await res.json();
+    expect(body.data.items[0].useCount).toBe(42);
+  });
+
+  it('showAll=true (status=all) includes revoked tokens', async () => {
+    const db = createMockDb();
+    const revokedToken = makeToken({ status: 'revoked' });
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 1 }]),
+    });
+    const listChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([revokedToken]),
+    };
+    db.select.mockReturnValueOnce(listChain);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens?status=all');
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    // With status=all, revoked tokens are included
+    expect(body.data.items[0].status).toBe('revoked');
+  });
+
+  it('teamId query param filters by team', async () => {
+    const db = createMockDb();
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]),
+    });
+    const listChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    db.select.mockReturnValueOnce(listChain);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens?teamId=team-999');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // where was called; we can't inspect exact args without deeper mock introspection,
+    // but the route should have applied the filter and succeeded
+    expect(body.ok).toBe(true);
+  });
+
+  it('pagination returns nextCursor and hasMore when more results exist', async () => {
+    const db = createMockDb();
+    // Create limit+1 tokens (limit default 50, but we use limit=2 for simplicity)
+    const tokens = [makeToken({ id: 'tok-001' }), makeToken({ id: 'tok-002' }), makeToken({ id: 'tok-003' })];
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 3 }]),
+    });
+    const listChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue(tokens), // returns 3 items for limit=2
+    };
+    db.select.mockReturnValueOnce(listChain);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens?limit=2');
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.hasMore).toBe(true);
+    expect(body.data.nextCursor).toBe('tok-002');
+    expect(body.data.items).toHaveLength(2);
+  });
+
+  it('allTeam=true with teamId returns 403 for non-admin', async () => {
+    const db = createMockDb();
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens?allTeam=true&teamId=team-001');
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('allTeam=true with teamId succeeds for admin user', async () => {
+    const db = createMockDb();
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ total: 0 }]),
+    });
+    const listChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    db.select.mockReturnValueOnce(listChain);
+
+    const rbacService = createMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    });
+    const app = buildApp(makeAuth({ authMethod: 'session' }), db, rbacService);
+
+    const res = await app.request('/tokens?allTeam=true&teamId=team-001');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});
+
+// ─── GET /tokens/:id ──────────────────────────────────────────────────────────
+
+describe('GET /tokens/:id', () => {
+  it('returns 404 for non-existent token', async () => {
+    const db = createMockDb();
+    mockSelectChain(db, []);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/token-does-not-exist');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns token with enriched scopeTags when present', async () => {
+    const db = createMockDb();
+    const token = makeToken({ scopeTags: ['tag-001', 'tag-002'] });
+
+    // First select: token with joins
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([token]),
+    });
+
+    // Second select: tag enrichment
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([
+        { id: 'tag-001', name: 'backend', color: '#ff0000' },
+        { id: 'tag-002', name: 'frontend', color: '#00ff00' },
+      ]),
+    });
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/token-abc123');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.scopeTags).toHaveLength(2);
+    expect(body.data.scopeTags[0]).toMatchObject({ id: 'tag-001', name: 'backend', color: '#ff0000' });
+  });
+
+  it('returns token without enriched scopeTags when scopeTags is null', async () => {
+    const db = createMockDb();
+    const token = makeToken({ scopeTags: null });
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([token]),
+    });
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/token-abc123');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.scopeTags).toBeNull();
+  });
+
+  it('returns 400 for invalid token id format', async () => {
+    const db = createMockDb();
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/!!invalid!!');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('INVALID_ID');
+  });
+
+  it('can only view own tokens (query filters by userId)', async () => {
+    const db = createMockDb();
+    // Simulate a token owned by different user — returns empty
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth({ userId: 'user-intruder' }), db, rbacService);
+
+    const res = await app.request('/tokens/token-abc123');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── DELETE /tokens/:id ───────────────────────────────────────────────────────
+
+describe('DELETE /tokens/:id', () => {
+  it('revokes an active token and returns success', async () => {
+    const db = createMockDb();
+
+    // Initial status check: active token
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ id: 'token-abc123', status: 'active' }]),
+    });
+    // Update call
+    mockUpdateChain(db, [{ id: 'token-abc123', status: 'revoked' }]);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/token-abc123', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.revoked).toBe(true);
+  });
+
+  it('sets status to revoked and revokedAt timestamp on update', async () => {
+    const db = createMockDb();
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ id: 'token-abc123', status: 'active' }]),
+    });
+    const updateChain = mockUpdateChain(db, [{ id: 'token-abc123', status: 'revoked' }]);
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    await app.request('/tokens/token-abc123', { method: 'DELETE' });
+
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'revoked', revokedAt: expect.any(String) })
+    );
+  });
+
+  it('returns 409 when token is already revoked', async () => {
+    const db = createMockDb();
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{ id: 'token-abc123', status: 'revoked' }]),
+    });
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/token-abc123', { method: 'DELETE' });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe('ALREADY_REVOKED');
+  });
+
+  it('returns 404 when token not found', async () => {
+    const db = createMockDb();
+
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/token-not-found', { method: 'DELETE' });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('can only revoke own tokens (userId filter applied)', async () => {
+    const db = createMockDb();
+    // Token belongs to a different user — status check returns empty
+    db.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    });
+
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth({ userId: 'user-intruder' }), db, rbacService);
+
+    const res = await app.request('/tokens/token-abc123', { method: 'DELETE' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for invalid token id format on delete', async () => {
+    const db = createMockDb();
+    const rbacService = createMockRbacService();
+    const app = buildApp(makeAuth(), db, rbacService);
+
+    const res = await app.request('/tokens/!!!bad-id!!!', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('INVALID_ID');
+  });
+});

--- a/tests/routes/tags.test.ts
+++ b/tests/routes/tags.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tag routes tests
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createProjectTagRoutes,
+  createTagsRoutes,
+  createTaskTagRoutes,
+} from '../../src/server/routes/tags';
+
+// Mock helpers
+function chainable(returnValue?: unknown) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ['select', 'from', 'where', 'orderBy', 'limit', 'leftJoin', 'groupBy', 'innerJoin', 'insert', 'values', 'onConflictDoNothing', 'returning', 'delete']) {
+    chain[method] = vi.fn().mockReturnThis();
+  }
+  if (returnValue !== undefined) {
+    chain.where = vi.fn().mockResolvedValue(returnValue);
+    chain.returning = vi.fn().mockResolvedValue(returnValue);
+    chain.onConflictDoNothing = vi.fn().mockResolvedValue(returnValue);
+  }
+  return chain;
+}
+
+const mockRbacService = {
+  resolveTeamRole: vi.fn(),
+  resolveUserRole: vi.fn(),
+  hasMinimumRole: vi.fn(),
+};
+
+function createMockDb() {
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+        groupBy: vi.fn().mockResolvedValue([]),
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([]),
+        onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+    query: {
+      teams: { findFirst: vi.fn() },
+      tags: { findFirst: vi.fn() },
+      projects: { findFirst: vi.fn() },
+    },
+  };
+}
+
+function createApp(routes: Hono, path: string, authOverride?: object) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', authOverride ?? { userId: 'user-1', authMethod: 'session' });
+    return next();
+  });
+  app.route(path, routes);
+  return app;
+}
+
+describe('Tag Routes', () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
+    mockRbacService.resolveUserRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+  });
+
+  describe('POST /tags - Create tag', () => {
+    it('creates a tag successfully', async () => {
+      const tag = { id: 'tag-1', teamId: 'team-1', name: 'backend', color: '#ff0000' };
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([tag]),
+        }),
+      });
+
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ teamId: 'team-1', name: 'backend', color: '#ff0000' }),
+      });
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.ok).toBe(true);
+      expect(json.data.name).toBe('backend');
+    });
+
+    it('returns 409 for duplicate tag name', async () => {
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error('UNIQUE constraint failed')),
+        }),
+      });
+
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ teamId: 'team-1', name: 'backend' }),
+      });
+
+      expect(response.status).toBe(409);
+      const json = await response.json();
+      expect(json.error.code).toBe('TAG_ALREADY_EXISTS');
+    });
+
+    it('requires agent_operator role', async () => {
+      mockRbacService.resolveTeamRole.mockResolvedValue('viewer');
+      mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ teamId: 'team-1', name: 'backend' }),
+      });
+
+      // L6: Returns 404 for non-members
+      expect(response.status).toBeLessThanOrEqual(404);
+    });
+  });
+
+  describe('GET /tags - List tags', () => {
+    it('lists tags with batch-counted projectCount and taskCount', async () => {
+      const tagList = [
+        { id: 'tag-1', teamId: 'team-1', name: 'backend', color: '#ff0000' },
+        { id: 'tag-2', teamId: 'team-1', name: 'frontend', color: '#00ff00' },
+      ];
+
+      // First select call returns tags
+      let callCount = 0;
+      mockDb.select = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockImplementation(() => ({
+          where: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve(tagList);
+            return Promise.resolve([]);
+          }),
+          groupBy: vi.fn().mockResolvedValue([]),
+        })),
+      }));
+
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags?teamId=team-1');
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.ok).toBe(true);
+      expect(json.data.items).toHaveLength(2);
+    });
+
+    it('requires teamId query parameter', async () => {
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags');
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('DELETE /tags/:id - Delete tag', () => {
+    it('deletes a tag successfully', async () => {
+      mockDb.select = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ teamId: 'team-1' }]),
+        }),
+      });
+
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags/tag-1', { method: 'DELETE' });
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.data.deleted).toBe(true);
+    });
+
+    it('returns 404 when tag not found', async () => {
+      mockDb.select = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+      const app = createApp(routes, '/tags');
+
+      const response = await app.request('/tags/nonexistent', { method: 'DELETE' });
+      expect(response.status).toBe(404);
+    });
+  });
+});
+
+describe('Project Tag Routes', () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    mockRbacService.resolveUserRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+  });
+
+  it('assigns a tag to a project', async () => {
+    // Tag exists and belongs to team
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          if (selectCall === 1) return Promise.resolve([{ teamId: 'team-1' }]); // tag record
+          return Promise.resolve([{ teamId: 'team-1' }]); // team owns project
+        }),
+      }),
+    }));
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    // Wrap with parent route that provides :id param
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const response = await app.request('/projects/proj-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.ok).toBe(true);
+  });
+
+  it('returns 403 when tag belongs to different team', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          if (selectCall === 1) return Promise.resolve([{ teamId: 'team-1' }]);
+          return Promise.resolve([]); // team does NOT own project
+        }),
+      }),
+    }));
+
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const response = await app.request('/projects/proj-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('Task Tag Routes', () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    mockRbacService.resolveUserRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+  });
+
+  it('assigns a tag to a task', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          if (selectCall === 1) return Promise.resolve([{ projectId: 'proj-1' }]); // task lookup
+          if (selectCall === 2) return Promise.resolve([{ teamId: 'team-1' }]); // tag record
+          return Promise.resolve([{ teamId: 'team-1' }]); // team owns project
+        }),
+      }),
+    }));
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const response = await app.request('/tasks/task-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.ok).toBe(true);
+  });
+
+  it('returns 404 when task not found', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const response = await app.request('/tasks/nonexistent/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/routes/tags.test.ts
+++ b/tests/routes/tags.test.ts
@@ -546,7 +546,7 @@ describe('POST /projects/:id/tags - Assign tag to project', () => {
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.projectId).toBe('proj-1');
@@ -682,7 +682,7 @@ describe('POST /projects/:id/tags - Assign tag to project', () => {
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect(onConflictDoNothing).toHaveBeenCalledTimes(1);
   });
 });
@@ -804,7 +804,7 @@ describe('POST /tasks/:id/tags - Assign tag to task', () => {
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.taskId).toBe('task-1');
@@ -996,7 +996,14 @@ describe('DELETE /tasks/:id/tags/:tagId - Remove tag from task', () => {
     rbacService = buildMockRbacService();
   });
 
-  it('removes tag from task (dev mode — skips project lookup)', async () => {
+  it('removes tag from task (dev mode)', async () => {
+    // Task lookup now runs unconditionally; mock it to return a valid task
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ projectId: 'proj-1' }]),
+      }),
+    });
+
     const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
     const app = new Hono();
     app.use('*', async (c, next) => {

--- a/tests/routes/tags.test.ts
+++ b/tests/routes/tags.test.ts
@@ -109,7 +109,7 @@ describe('POST /tags - Create tag', () => {
       body: JSON.stringify({ teamId: 'team-1', name: 'backend', color: '#ff0000' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.name).toBe('backend');
@@ -133,7 +133,7 @@ describe('POST /tags - Create tag', () => {
       body: JSON.stringify({ teamId: 'team-1', name: 'no-color' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect((await res.json()).ok).toBe(true);
   });
 

--- a/tests/routes/tags.test.ts
+++ b/tests/routes/tags.test.ts
@@ -1,7 +1,15 @@
 /**
- * Tag routes tests
+ * Tests for tag RBAC routes.
+ *
+ * Covers:
+ * - POST /tags: create (agent_operator required, duplicate name 409)
+ * - GET /tags?teamId: list with counts (H3 batch), viewer minimum
+ * - DELETE /tags/:id: admin required, not found 404
+ * - POST /projects/:id/tags: assign (agent_operator, cross-team forbidden)
+ * - DELETE /projects/:id/tags/:tagId: remove assignment
+ * - POST /tasks/:id/tags: assign (cross-team check via project)
+ * - DELETE /tasks/:id/tags/:tagId: remove
  */
-
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -9,26 +17,19 @@ import {
   createTagsRoutes,
   createTaskTagRoutes,
 } from '../../src/server/routes/tags';
+import type { AuthContext } from '../../src/lib/api/auth-middleware';
+import type { RbacService } from '../../src/services/rbac.service';
 
-// Mock helpers
-function chainable(returnValue?: unknown) {
-  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
-  for (const method of ['select', 'from', 'where', 'orderBy', 'limit', 'leftJoin', 'groupBy', 'innerJoin', 'insert', 'values', 'onConflictDoNothing', 'returning', 'delete']) {
-    chain[method] = vi.fn().mockReturnThis();
-  }
-  if (returnValue !== undefined) {
-    chain.where = vi.fn().mockResolvedValue(returnValue);
-    chain.returning = vi.fn().mockResolvedValue(returnValue);
-    chain.onConflictDoNothing = vi.fn().mockResolvedValue(returnValue);
-  }
-  return chain;
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function buildMockRbacService(overrides: Partial<RbacService> = {}): RbacService {
+  return {
+    resolveTeamRole: vi.fn().mockResolvedValue('agent_operator'),
+    resolveUserRole: vi.fn().mockResolvedValue('agent_operator'),
+    hasMinimumRole: vi.fn().mockReturnValue(true),
+    ...overrides,
+  } as unknown as RbacService;
 }
-
-const mockRbacService = {
-  resolveTeamRole: vi.fn(),
-  resolveUserRole: vi.fn(),
-  hasMinimumRole: vi.fn(),
-};
 
 function createMockDb() {
   return {
@@ -61,176 +62,460 @@ function createMockDb() {
   };
 }
 
-function createApp(routes: Hono, path: string, authOverride?: object) {
+type MockDb = ReturnType<typeof createMockDb>;
+
+const DEV_AUTH: AuthContext = { userId: 'user-dev-001', authMethod: 'dev' };
+
+function createApp(
+  routes: Hono,
+  mountPath: string,
+  auth: AuthContext = DEV_AUTH
+) {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('auth', authOverride ?? { userId: 'user-1', authMethod: 'session' });
+    c.set('auth', auth);
     return next();
   });
-  app.route(path, routes);
+  app.route(mountPath, routes);
   return app;
 }
 
-describe('Tag Routes', () => {
-  let mockDb: ReturnType<typeof createMockDb>;
+// ─── POST /tags ───────────────────────────────────────────────────────────────
+
+describe('POST /tags - Create tag', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockDb = createMockDb();
-    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
-    mockRbacService.resolveUserRole.mockResolvedValue('admin');
-    mockRbacService.hasMinimumRole.mockReturnValue(true);
+    rbacService = buildMockRbacService();
   });
 
-  describe('POST /tags - Create tag', () => {
-    it('creates a tag successfully', async () => {
-      const tag = { id: 'tag-1', teamId: 'team-1', name: 'backend', color: '#ff0000' };
-      mockDb.insert = vi.fn().mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([tag]),
-        }),
-      });
-
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
-
-      const response = await app.request('/tags', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ teamId: 'team-1', name: 'backend', color: '#ff0000' }),
-      });
-
-      expect(response.status).toBe(200);
-      const json = await response.json();
-      expect(json.ok).toBe(true);
-      expect(json.data.name).toBe('backend');
+  it('creates a tag successfully with name and color', async () => {
+    const tag = { id: 'tag-1', teamId: 'team-1', name: 'backend', color: '#ff0000', createdAt: '2024-01-01T00:00:00Z' };
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([tag]),
+      }),
     });
 
-    it('returns 409 for duplicate tag name', async () => {
-      mockDb.insert = vi.fn().mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockRejectedValue(new Error('UNIQUE constraint failed')),
-        }),
-      });
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
 
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
-
-      const response = await app.request('/tags', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ teamId: 'team-1', name: 'backend' }),
-      });
-
-      expect(response.status).toBe(409);
-      const json = await response.json();
-      expect(json.error.code).toBe('TAG_ALREADY_EXISTS');
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1', name: 'backend', color: '#ff0000' }),
     });
 
-    it('requires agent_operator role', async () => {
-      mockRbacService.resolveTeamRole.mockResolvedValue('viewer');
-      mockRbacService.hasMinimumRole.mockReturnValue(false);
-
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
-
-      const response = await app.request('/tags', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ teamId: 'team-1', name: 'backend' }),
-      });
-
-      // L6: Returns 404 for non-members
-      expect(response.status).toBeLessThanOrEqual(404);
-    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.name).toBe('backend');
+    expect(body.data.color).toBe('#ff0000');
   });
 
-  describe('GET /tags - List tags', () => {
-    it('lists tags with batch-counted projectCount and taskCount', async () => {
-      const tagList = [
-        { id: 'tag-1', teamId: 'team-1', name: 'backend', color: '#ff0000' },
-        { id: 'tag-2', teamId: 'team-1', name: 'frontend', color: '#00ff00' },
-      ];
-
-      // First select call returns tags
-      let callCount = 0;
-      mockDb.select = vi.fn().mockImplementation(() => ({
-        from: vi.fn().mockImplementation(() => ({
-          where: vi.fn().mockImplementation(() => {
-            callCount++;
-            if (callCount === 1) return Promise.resolve(tagList);
-            return Promise.resolve([]);
-          }),
-          groupBy: vi.fn().mockResolvedValue([]),
-        })),
-      }));
-
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
-
-      const response = await app.request('/tags?teamId=team-1');
-      expect(response.status).toBe(200);
-      const json = await response.json();
-      expect(json.ok).toBe(true);
-      expect(json.data.items).toHaveLength(2);
+  it('creates a tag successfully without optional color', async () => {
+    const tag = { id: 'tag-2', teamId: 'team-1', name: 'no-color', color: null, createdAt: '2024-01-01T00:00:00Z' };
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([tag]),
+      }),
     });
 
-    it('requires teamId query parameter', async () => {
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
 
-      const response = await app.request('/tags');
-      expect(response.status).toBe(400);
-      const json = await response.json();
-      expect(json.error.code).toBe('VALIDATION_ERROR');
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1', name: 'no-color' }),
     });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
   });
 
-  describe('DELETE /tags/:id - Delete tag', () => {
-    it('deletes a tag successfully', async () => {
-      mockDb.select = vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{ teamId: 'team-1' }]),
-        }),
-      });
-
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
-
-      const response = await app.request('/tags/tag-1', { method: 'DELETE' });
-      expect(response.status).toBe(200);
-      const json = await response.json();
-      expect(json.data.deleted).toBe(true);
+  it('returns 409 for duplicate tag name within a team', async () => {
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockRejectedValue(new Error('UNIQUE constraint failed: tags.name')),
+      }),
     });
 
-    it('returns 404 when tag not found', async () => {
-      mockDb.select = vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([]),
-        }),
-      });
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
 
-      const routes = createTagsRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-      const app = createApp(routes, '/tags');
-
-      const response = await app.request('/tags/nonexistent', { method: 'DELETE' });
-      expect(response.status).toBe(404);
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1', name: 'duplicate-tag' }),
     });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe('TAG_ALREADY_EXISTS');
+  });
+
+  it('requires agent_operator role — returns >=403 for insufficient role', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags', { userId: 'viewer-001', authMethod: 'session' });
+
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1', name: 'some-tag' }),
+    });
+
+    // Non-members get 404 from requireTeamRole, members with insufficient role get 403
+    expect(res.status).toBeGreaterThanOrEqual(403);
+  });
+
+  it('returns 400 for missing tag name', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for invalid color format', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1', name: 'my-tag', color: 'not-a-hex' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for missing teamId', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'orphan-tag' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 500 on unexpected DB error', async () => {
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockRejectedValue(new Error('SQLITE_DISK_IO_ERROR')),
+      }),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: 'team-1', name: 'crash-tag' }),
+    });
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error.code).toBe('DB_ERROR');
   });
 });
 
-describe('Project Tag Routes', () => {
-  let mockDb: ReturnType<typeof createMockDb>;
+// ─── GET /tags?teamId ─────────────────────────────────────────────────────────
+
+describe('GET /tags?teamId - List tags with usage counts (H3 batch)', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
+
+  const teamTags = [
+    { id: 'tag-1', teamId: 'team-1', name: 'backend', color: '#ff0000', createdAt: '2024-01-01T00:00:00Z' },
+    { id: 'tag-2', teamId: 'team-1', name: 'frontend', color: '#00ff00', createdAt: '2024-01-01T00:00:00Z' },
+  ];
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockDb = createMockDb();
-    mockRbacService.resolveUserRole.mockResolvedValue('admin');
-    mockRbacService.hasMinimumRole.mockReturnValue(true);
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
   });
 
-  it('assigns a tag to a project', async () => {
-    // Tag exists and belongs to team
+  it('returns 200 with tags enriched with projectCount and taskCount (H3 batch)', async () => {
+    // The route executes three sequential select calls:
+    //   call 1: db.select().from(tags).where(eq(tags.teamId, teamId)) → tags array
+    //   call 2: db.select({tagId, total}).from(projectTags).where(inArray(...)).groupBy(...) → project counts
+    //   call 3: db.select({tagId, total}).from(taskTags).where(inArray(...)).groupBy(...)   → task counts
+    // Calls 2 & 3 run in parallel via Promise.all and use a where→groupBy chain.
+    let selectCallIndex = 0;
+    mockDb.select = vi.fn().mockImplementation(() => {
+      selectCallIndex++;
+      const call = selectCallIndex;
+      // For the first call (tag list): where() is the terminal awaitable
+      if (call === 1) {
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(teamTags),
+          }),
+        };
+      }
+      // For calls 2 & 3 (batch count queries): where() returns a chainable object with groupBy()
+      const groupByResult =
+        call === 2
+          ? [{ tagId: 'tag-1', total: 3 }]
+          : [{ tagId: 'tag-1', total: 5 }, { tagId: 'tag-2', total: 2 }];
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockResolvedValue(groupByResult),
+          }),
+        }),
+      };
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags?teamId=team-1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toHaveLength(2);
+  });
+
+  it('returns projectCount=0 and taskCount=0 for tags with no assignments', async () => {
+    let selectCallIndex = 0;
+    mockDb.select = vi.fn().mockImplementation(() => {
+      selectCallIndex++;
+      const call = selectCallIndex;
+      if (call === 1) {
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(teamTags),
+          }),
+        };
+      }
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockResolvedValue([]), // no counts for either table
+          }),
+        }),
+      };
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags?teamId=team-1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // When no counts returned, defaults should be 0
+    for (const item of body.data.items) {
+      expect(item.projectCount).toBe(0);
+      expect(item.taskCount).toBe(0);
+    }
+  });
+
+  it('returns empty items array when team has no tags', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags?teamId=team-1');
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.items).toHaveLength(0);
+  });
+
+  it('returns 400 when teamId is missing', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when teamId contains invalid characters', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags?teamId=!!!invalid!!!');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('requires at minimum viewer role — non-member gets forbidden/not-found', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue(null),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags', { userId: 'outsider-001', authMethod: 'session' });
+
+    const res = await app.request('/tags?teamId=team-1');
+    expect(res.status).toBeGreaterThanOrEqual(403);
+  });
+
+  it('dev mode bypasses role check and returns tags', async () => {
+    let selectCallIndex = 0;
+    mockDb.select = vi.fn().mockImplementation(() => {
+      selectCallIndex++;
+      const call = selectCallIndex;
+      if (call === 1) {
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(teamTags),
+          }),
+        };
+      }
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      };
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    // DEV_AUTH should pass without any rbac lookup
+    const app = createApp(routes, '/tags', DEV_AUTH);
+
+    const res = await app.request('/tags?teamId=team-1');
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.items).toHaveLength(2);
+  });
+});
+
+// ─── DELETE /tags/:id ─────────────────────────────────────────────────────────
+
+describe('DELETE /tags/:id - Delete tag', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
+    // Default: tag exists
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ teamId: 'team-1' }]),
+      }),
+    });
+  });
+
+  it('deletes a tag successfully (admin role, dev mode)', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.deleted).toBe(true);
+  });
+
+  it('deletes a tag successfully when caller has admin role (non-dev)', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags', { userId: 'admin-user-001', authMethod: 'session' });
+
+    const res = await app.request('/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.deleted).toBe(true);
+  });
+
+  it('returns 404 when tag does not exist', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags/nonexistent-tag', { method: 'DELETE' });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('TAG_NOT_FOUND');
+  });
+
+  it('returns 403 when non-admin tries to delete a tag', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('agent_operator'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags', { userId: 'operator-001', authMethod: 'session' });
+
+    const res = await app.request('/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid tag ID (special chars)', async () => {
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags/!!!', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('returns 500 on unexpected DB error during delete', async () => {
+    mockDb.delete = vi.fn().mockReturnValue({
+      where: vi.fn().mockRejectedValue(new Error('disk full')),
+    });
+
+    const routes = createTagsRoutes({ db: mockDb as never, rbacService });
+    const app = createApp(routes, '/tags');
+
+    const res = await app.request('/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(500);
+    expect((await res.json()).error.code).toBe('DB_ERROR');
+  });
+});
+
+// ─── POST /projects/:id/tags ──────────────────────────────────────────────────
+
+describe('POST /projects/:id/tags - Assign tag to project', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    rbacService = buildMockRbacService();
+  });
+
+  it('assigns a tag to a project successfully', async () => {
     let selectCall = 0;
     mockDb.select = vi.fn().mockImplementation(() => ({
       from: vi.fn().mockImplementation(() => ({
@@ -239,7 +524,7 @@ describe('Project Tag Routes', () => {
           if (selectCall === 1) return Promise.resolve([{ teamId: 'team-1' }]); // tag record
           return Promise.resolve([{ teamId: 'team-1' }]); // team owns project
         }),
-      }),
+      })),
     }));
     mockDb.insert = vi.fn().mockReturnValue({
       values: vi.fn().mockReturnValue({
@@ -247,77 +532,257 @@ describe('Project Tag Routes', () => {
       }),
     });
 
-    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
-    // Wrap with parent route that provides :id param
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      c.set('auth', DEV_AUTH);
       return next();
     });
     app.route('/projects/:id/tags', routes);
 
-    const response = await app.request('/projects/proj-1/tags', {
+    const res = await app.request('/projects/proj-1/tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(response.status).toBe(200);
-    const json = await response.json();
-    expect(json.ok).toBe(true);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.projectId).toBe('proj-1');
+    expect(body.data.tagId).toBe('tag-1');
+    expect(body.data.assignedAt).toBeDefined();
   });
 
-  it('returns 403 when tag belongs to different team', async () => {
+  it('returns 403 when tag belongs to a different team than the project (cross-team forbidden)', async () => {
     let selectCall = 0;
     mockDb.select = vi.fn().mockImplementation(() => ({
       from: vi.fn().mockImplementation(() => ({
         where: vi.fn().mockImplementation(() => {
           selectCall++;
-          if (selectCall === 1) return Promise.resolve([{ teamId: 'team-1' }]);
-          return Promise.resolve([]); // team does NOT own project
+          if (selectCall === 1) return Promise.resolve([{ teamId: 'foreign-team-999' }]);
+          return Promise.resolve([]); // foreign team does NOT own project
         }),
-      }),
+      })),
     }));
 
-    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      c.set('auth', DEV_AUTH);
       return next();
     });
     app.route('/projects/:id/tags', routes);
 
-    const response = await app.request('/projects/proj-1/tags', {
+    const res = await app.request('/projects/proj-1/tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(response.status).toBe(403);
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 404 when the tag does not exist', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/proj-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'nonexistent-tag' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 403 when caller lacks agent_operator role on project (non-dev)', async () => {
+    rbacService = buildMockRbacService({
+      resolveUserRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'viewer-001', authMethod: 'session' as const });
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/proj-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid project ID', async () => {
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/!!!/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('assignment is idempotent (onConflictDoNothing)', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          return selectCall === 1
+            ? Promise.resolve([{ teamId: 'team-1' }])
+            : Promise.resolve([{ teamId: 'team-1' }]);
+        }),
+      })),
+    }));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoNothing }),
+    });
+
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/proj-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(onConflictDoNothing).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('Task Tag Routes', () => {
-  let mockDb: ReturnType<typeof createMockDb>;
+// ─── DELETE /projects/:id/tags/:tagId ────────────────────────────────────────
+
+describe('DELETE /projects/:id/tags/:tagId - Remove tag from project', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockDb = createMockDb();
-    mockRbacService.resolveUserRole.mockResolvedValue('admin');
-    mockRbacService.hasMinimumRole.mockReturnValue(true);
+    rbacService = buildMockRbacService();
   });
 
-  it('assigns a tag to a task', async () => {
+  it('removes a tag from a project (dev mode)', async () => {
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/proj-1/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.removed).toBe(true);
+  });
+
+  it('returns 403 when caller lacks agent_operator role', async () => {
+    rbacService = buildMockRbacService({
+      resolveUserRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'viewer-001', authMethod: 'session' as const });
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/proj-1/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid project ID', async () => {
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/!!!/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('returns 400 for invalid tag ID in path', async () => {
+    const routes = createProjectTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/projects/:id/tags', routes);
+
+    const res = await app.request('/projects/proj-1/tags/!!!', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+});
+
+// ─── POST /tasks/:id/tags ─────────────────────────────────────────────────────
+
+describe('POST /tasks/:id/tags - Assign tag to task', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    rbacService = buildMockRbacService();
+  });
+
+  it('assigns a tag to a task successfully', async () => {
     let selectCall = 0;
     mockDb.select = vi.fn().mockImplementation(() => ({
       from: vi.fn().mockImplementation(() => ({
         where: vi.fn().mockImplementation(() => {
           selectCall++;
           if (selectCall === 1) return Promise.resolve([{ projectId: 'proj-1' }]); // task lookup
-          if (selectCall === 2) return Promise.resolve([{ teamId: 'team-1' }]); // tag record
-          return Promise.resolve([{ teamId: 'team-1' }]); // team owns project
+          if (selectCall === 2) return Promise.resolve([{ teamId: 'team-1' }]);     // tag record
+          return Promise.resolve([{ teamId: 'team-1' }]);                           // team owns project
         }),
-      }),
+      })),
     }));
     mockDb.insert = vi.fn().mockReturnValue({
       values: vi.fn().mockReturnValue({
@@ -325,23 +790,26 @@ describe('Task Tag Routes', () => {
       }),
     });
 
-    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      c.set('auth', DEV_AUTH);
       return next();
     });
     app.route('/tasks/:id/tags', routes);
 
-    const response = await app.request('/tasks/task-1/tags', {
+    const res = await app.request('/tasks/task-1/tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(response.status).toBe(200);
-    const json = await response.json();
-    expect(json.ok).toBe(true);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.taskId).toBe('task-1');
+    expect(body.data.tagId).toBe('tag-1');
+    expect(body.data.assignedAt).toBeDefined();
   });
 
   it('returns 404 when task not found', async () => {
@@ -351,20 +819,286 @@ describe('Task Tag Routes', () => {
       }),
     });
 
-    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService: mockRbacService as never });
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('auth', { userId: 'user-1', authMethod: 'session' });
+      c.set('auth', DEV_AUTH);
       return next();
     });
     app.route('/tasks/:id/tags', routes);
 
-    const response = await app.request('/tasks/nonexistent/tags', {
+    const res = await app.request('/tasks/nonexistent/tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tagId: 'tag-1' }),
     });
 
-    expect(response.status).toBe(404);
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 403 when tag belongs to a different team than the task project (cross-team check via project)', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          if (selectCall === 1) return Promise.resolve([{ projectId: 'proj-1' }]);
+          if (selectCall === 2) return Promise.resolve([{ teamId: 'foreign-team-999' }]);
+          return Promise.resolve([]); // foreign team doesn't own the project
+        }),
+      })),
+    }));
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-foreign' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 404 when tag not found', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          if (selectCall === 1) return Promise.resolve([{ projectId: 'proj-1' }]); // task found
+          return Promise.resolve([]); // tag not found
+        }),
+      })),
+    }));
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'ghost-tag' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 403 when caller lacks agent_operator role on the task project', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          return selectCall === 1
+            ? Promise.resolve([{ projectId: 'proj-1' }])
+            : Promise.resolve([]);
+        }),
+      })),
+    }));
+
+    rbacService = buildMockRbacService({
+      resolveUserRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'viewer-001', authMethod: 'session' as const });
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid task ID', async () => {
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/!!!/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagId: 'tag-1' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('returns 400 when tagId is missing from request body', async () => {
+    let selectCall = 0;
+    mockDb.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          return selectCall === 1
+            ? Promise.resolve([{ projectId: 'proj-1' }])
+            : Promise.resolve([]);
+        }),
+      })),
+    }));
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ─── DELETE /tasks/:id/tags/:tagId ───────────────────────────────────────────
+
+describe('DELETE /tasks/:id/tags/:tagId - Remove tag from task', () => {
+  let mockDb: MockDb;
+  let rbacService: RbacService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    rbacService = buildMockRbacService();
+  });
+
+  it('removes tag from task (dev mode — skips project lookup)', async () => {
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.removed).toBe(true);
+  });
+
+  it('removes tag from task for non-dev user with correct role', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ projectId: 'proj-1' }]),
+      }),
+    });
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'operator-001', authMethod: 'session' as const });
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.removed).toBe(true);
+  });
+
+  it('returns 404 when task not found (non-dev user)', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'operator-001', authMethod: 'session' as const });
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/missing-task/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 403 when non-dev caller lacks agent_operator role', async () => {
+    mockDb.select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ projectId: 'proj-1' }]),
+      }),
+    });
+
+    rbacService = buildMockRbacService({
+      resolveUserRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { userId: 'viewer-001', authMethod: 'session' as const });
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid task ID', async () => {
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/!!!/tags/tag-1', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('returns 400 for invalid tag ID in path', async () => {
+    const routes = createTaskTagRoutes({ db: mockDb as never, rbacService });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', DEV_AUTH);
+      return next();
+    });
+    app.route('/tasks/:id/tags', routes);
+
+    const res = await app.request('/tasks/task-1/tags/!!!', { method: 'DELETE' });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
   });
 });

--- a/tests/routes/team-invitations.test.ts
+++ b/tests/routes/team-invitations.test.ts
@@ -1,0 +1,737 @@
+/**
+ * Tests for team invitation RBAC routes.
+ *
+ * Covers:
+ * - POST /invitations: create (admin required, duplicate pending 409, already member 409)
+ * - GET /invitations: list pending (admin required, enriched invitedBy L4)
+ * - POST /invitations/:iid/decline: only invitee can decline, not found
+ * - DELETE /invitations/:iid: revoke (admin required)
+ * - POST /invitations/:token/accept: success with teamName (H8), expired 404, email mismatch 403,
+ *   already member 409
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTeamInvitationsRoutes } from '../../src/server/routes/team-invitations';
+import { createInvitationAcceptRoutes } from '../../src/server/routes/invitation-accept';
+import type { AuthContext } from '../../src/lib/api/auth-middleware';
+import type { RbacService } from '../../src/services/rbac.service';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildMockRbacService(overrides: Partial<RbacService> = {}): RbacService {
+  return {
+    resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    resolveUserRole: vi.fn().mockResolvedValue('admin'),
+    hasMinimumRole: vi.fn().mockReturnValue(true),
+    ...overrides,
+  } as unknown as RbacService;
+}
+
+/**
+ * Build a fluent mock DB chain that can be overridden per-test via
+ * mockImplementation on the top-level methods.
+ */
+function buildMockDb() {
+  function chain(defaultResult: unknown[] = []) {
+    const obj: Record<string, unknown> = {};
+    const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy', 'limit', 'groupBy'];
+    for (const m of methods) {
+      obj[m] = vi.fn().mockReturnValue(obj);
+    }
+    obj.then = (onfulfilled: (v: unknown) => unknown) =>
+      Promise.resolve(defaultResult).then(onfulfilled);
+    return obj;
+  }
+
+  const db = {
+    select: vi.fn().mockReturnValue(chain()),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue({ rowsAffected: 0 }),
+    }),
+    transaction: vi.fn(),
+    query: {
+      teams: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    },
+  };
+
+  return db;
+}
+
+type MockDb = ReturnType<typeof buildMockDb>;
+
+/**
+ * Build a Hono app with team-invitation routes mounted under /api/teams/:id/invitations.
+ */
+function buildTeamInvitationsApp(
+  db: MockDb,
+  rbacService: RbacService,
+  authContext: Partial<AuthContext> = {}
+) {
+  const defaultAuth: AuthContext = {
+    userId: 'user-admin-001',
+    authMethod: 'dev',
+    user: { id: 'user-admin-001', githubId: 1, githubLogin: 'admin', name: 'Admin', email: 'admin@example.com', avatarUrl: null },
+    ...authContext,
+  };
+
+  const routes = createTeamInvitationsRoutes({ db: db as never, rbacService });
+  const app = new Hono();
+  app.use('/api/teams/:id/invitations/*', async (c, next) => {
+    c.set('auth', defaultAuth);
+    await next();
+  });
+  app.use('/api/teams/:id/invitations', async (c, next) => {
+    c.set('auth', defaultAuth);
+    await next();
+  });
+  app.route('/api/teams/:id/invitations', routes);
+  return app;
+}
+
+/**
+ * Build a Hono app for the public invitation-accept route.
+ */
+function buildAcceptApp(db: MockDb, authContext: Partial<AuthContext> = {}) {
+  const defaultAuth: AuthContext = {
+    userId: 'user-invitee-001',
+    authMethod: 'session',
+    user: { id: 'user-invitee-001', githubId: 2, githubLogin: 'invitee', name: 'Invitee', email: 'invitee@example.com', avatarUrl: null },
+    ...authContext,
+  };
+
+  const routes = createInvitationAcceptRoutes({ db: db as never });
+  const app = new Hono();
+  app.use('/api/invitations/*', async (c, next) => {
+    c.set('auth', defaultAuth);
+    await next();
+  });
+  app.route('/api/invitations', routes);
+  return app;
+}
+
+const VALID_TEAM_ID = 'team-aaa-001';
+const VALID_INV_ID = 'inv-zzz-001';
+const VALID_TOKEN = 'validtoken1234567890abcdefghijklmnopqrstuvwxyz';
+
+// ─── POST /invitations ────────────────────────────────────────────────────────
+
+describe('POST /api/teams/:id/invitations - Create invitation', () => {
+  let db: MockDb;
+  let rbacService: RbacService;
+  let app: Hono;
+
+  const sampleInvitation = {
+    id: VALID_INV_ID,
+    teamId: VALID_TEAM_ID,
+    invitedBy: 'user-admin-001',
+    email: 'newuser@example.com',
+    role: 'viewer',
+    token: VALID_TOKEN,
+    status: 'pending',
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    createdAt: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+    app = buildTeamInvitationsApp(db, rbacService);
+  });
+
+  it('returns 200 and invitation data on success', async () => {
+    // No pending invitation, no existing member, insert succeeds
+    let selectCall = 0;
+    db.select.mockImplementation(() => {
+      selectCall++;
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) => {
+        const result = selectCall <= 2 ? [] : [];
+        return Promise.resolve(result).then(fn);
+      };
+      return obj;
+    });
+    db.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([sampleInvitation]),
+      }),
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'newuser@example.com', role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.email).toBe('newuser@example.com');
+    expect(body.data.status).toBe('pending');
+  });
+
+  it('returns 409 when a pending invitation already exists', async () => {
+    db.select.mockImplementation(() => {
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) =>
+        Promise.resolve([sampleInvitation]).then(fn);
+      return obj;
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'newuser@example.com', role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe('INVITATION_ALREADY_EXISTS');
+  });
+
+  it('returns 409 when user with that email is already a member', async () => {
+    let selectCall = 0;
+    db.select.mockImplementation(() => {
+      selectCall++;
+      const call = selectCall;
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) => {
+        // First call: no pending invitation; second call: user is already a member
+        const result = call === 1 ? [] : [{ userId: 'existing-user-001' }];
+        return Promise.resolve(result).then(fn);
+      };
+      return obj;
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'existing@example.com', role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe('MEMBER_ALREADY_EXISTS');
+  });
+
+  it('returns 400 for invalid email', async () => {
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email', role: 'viewer' }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 403 when caller lacks admin role', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+    app = buildTeamInvitationsApp(db, rbacService, { authMethod: 'session', userId: 'viewer-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'x@example.com', role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid team ID', async () => {
+    const res = await app.request('/api/teams/!!!/invitations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'x@example.com', role: 'viewer' }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+});
+
+// ─── GET /invitations ─────────────────────────────────────────────────────────
+
+describe('GET /api/teams/:id/invitations - List pending invitations', () => {
+  let db: MockDb;
+  let rbacService: RbacService;
+  let app: Hono;
+
+  const pendingInvitations = [
+    {
+      id: VALID_INV_ID,
+      teamId: VALID_TEAM_ID,
+      invitedBy: 'user-admin-001',
+      invitedByName: 'Admin User',
+      email: 'pending@example.com',
+      role: 'viewer',
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      createdAt: new Date().toISOString(),
+    },
+  ];
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+    app = buildTeamInvitationsApp(db, rbacService);
+  });
+
+  it('returns 200 with enriched invitations (L4 invitedBy object)', async () => {
+    db.select.mockImplementation(() => {
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) =>
+        Promise.resolve(pendingInvitations).then(fn);
+      return obj;
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toHaveLength(1);
+    // L4: invitedBy must be enriched as an object with userId and name
+    expect(body.data.items[0].invitedBy).toMatchObject({
+      userId: 'user-admin-001',
+      name: 'Admin User',
+    });
+    // invitedByName raw field should be removed
+    expect(body.data.items[0].invitedByName).toBeUndefined();
+  });
+
+  it('returns 403 when caller lacks admin role', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+    app = buildTeamInvitationsApp(db, rbacService, { authMethod: 'session', userId: 'viewer-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns empty list when there are no pending invitations', async () => {
+    db.select.mockImplementation(() => {
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) => Promise.resolve([]).then(fn);
+      return obj;
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.items).toHaveLength(0);
+  });
+
+  it('returns 400 for invalid team ID', async () => {
+    const res = await app.request('/api/teams/!!!/invitations');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+});
+
+// ─── POST /invitations/:iid/decline ──────────────────────────────────────────
+
+describe('POST /api/teams/:id/invitations/:iid/decline - Decline invitation', () => {
+  let db: MockDb;
+  let rbacService: RbacService;
+
+  const inviteeEmail = 'invitee@example.com';
+
+  const pendingInvitation = {
+    id: VALID_INV_ID,
+    teamId: VALID_TEAM_ID,
+    email: inviteeEmail,
+    status: 'pending',
+  };
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+  });
+
+  it('returns 200 when invitee declines their own invitation', async () => {
+    db.select.mockImplementation(() => {
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) =>
+        Promise.resolve([pendingInvitation]).then(fn);
+      return obj;
+    });
+    db.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ ...pendingInvitation, status: 'declined' }]),
+        }),
+      }),
+    });
+
+    // The invitee's email matches the invitation email
+    const app = buildTeamInvitationsApp(db, rbacService, {
+      authMethod: 'session',
+      userId: 'user-invitee-001',
+      user: { id: 'user-invitee-001', githubId: 2, githubLogin: 'invitee', name: 'Invitee', email: inviteeEmail, avatarUrl: null },
+    });
+
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/${VALID_INV_ID}/decline`,
+      { method: 'POST' }
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.declined).toBe(true);
+  });
+
+  it('returns 403 when a different user tries to decline', async () => {
+    db.select.mockImplementation(() => {
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) =>
+        Promise.resolve([pendingInvitation]).then(fn);
+      return obj;
+    });
+
+    // Different email than the invitation target
+    const app = buildTeamInvitationsApp(db, rbacService, {
+      authMethod: 'session',
+      userId: 'user-other-001',
+      user: { id: 'user-other-001', githubId: 3, githubLogin: 'other', name: 'Other', email: 'other@example.com', avatarUrl: null },
+    });
+
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/${VALID_INV_ID}/decline`,
+      { method: 'POST' }
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 404 when invitation not found or already processed', async () => {
+    db.select.mockImplementation(() => {
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where'];
+      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+      obj.then = (fn: (v: unknown) => unknown) => Promise.resolve([]).then(fn);
+      return obj;
+    });
+
+    const app = buildTeamInvitationsApp(db, rbacService);
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/${VALID_INV_ID}/decline`,
+      { method: 'POST' }
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 for invalid invitation ID', async () => {
+    const app = buildTeamInvitationsApp(db, rbacService);
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/!!!/decline`,
+      { method: 'POST' }
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+});
+
+// ─── DELETE /invitations/:iid ─────────────────────────────────────────────────
+
+describe('DELETE /api/teams/:id/invitations/:iid - Revoke invitation', () => {
+  let db: MockDb;
+  let rbacService: RbacService;
+  let app: Hono;
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+    app = buildTeamInvitationsApp(db, rbacService);
+  });
+
+  it('returns 200 on successful revocation', async () => {
+    db.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: VALID_INV_ID, status: 'revoked' }]),
+        }),
+      }),
+    });
+
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/${VALID_INV_ID}`,
+      { method: 'DELETE' }
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.revoked).toBe(true);
+  });
+
+  it('returns 404 when invitation not found', async () => {
+    db.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/${VALID_INV_ID}`,
+      { method: 'DELETE' }
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 403 when caller lacks admin role', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+    app = buildTeamInvitationsApp(db, rbacService, { authMethod: 'session', userId: 'viewer-001' });
+
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/${VALID_INV_ID}`,
+      { method: 'DELETE' }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid invitation ID', async () => {
+    const res = await app.request(
+      `/api/teams/${VALID_TEAM_ID}/invitations/!!!`,
+      { method: 'DELETE' }
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+});
+
+// ─── POST /invitations/:token/accept ─────────────────────────────────────────
+
+describe('POST /api/invitations/:token/accept - Accept invitation', () => {
+  let db: MockDb;
+  let app: Hono;
+
+  const futureExpiry = new Date(Date.now() + 86400000).toISOString();
+
+  beforeEach(() => {
+    db = buildMockDb();
+    app = buildAcceptApp(db);
+  });
+
+  it('returns 200 with teamName on successful acceptance (H8)', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const claimed = {
+        id: VALID_INV_ID,
+        teamId: VALID_TEAM_ID,
+        email: 'invitee@example.com',
+        role: 'viewer',
+        status: 'accepted',
+      };
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([claimed]),
+            }),
+          }),
+        }),
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]), // not yet a member
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockResolvedValue(undefined),
+        }),
+        query: {
+          teams: {
+            findFirst: vi.fn().mockResolvedValue({ name: 'Engineering Team' }),
+          },
+        },
+      };
+      return fn(tx);
+    });
+
+    const res = await app.request(`/api/invitations/${VALID_TOKEN}/accept`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.teamId).toBe(VALID_TEAM_ID);
+    expect(body.data.role).toBe('viewer');
+    expect(body.data.teamName).toBe('Engineering Team');
+    expect(body.data.joinedAt).toBeDefined();
+  });
+
+  it('returns 404 when invitation is expired or not found', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([]), // no matching row (expired/not found)
+            }),
+          }),
+        }),
+      };
+      return fn(tx);
+    });
+
+    const res = await app.request(`/api/invitations/${VALID_TOKEN}/accept`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('INVITATION_NOT_FOUND');
+  });
+
+  it('returns 403 when invitee email does not match', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const claimed = {
+        id: VALID_INV_ID,
+        teamId: VALID_TEAM_ID,
+        email: 'someone-else@example.com', // different email
+        role: 'viewer',
+        status: 'accepted',
+      };
+      let updateCallCount = 0;
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              updateCallCount++;
+              if (updateCallCount === 1) {
+                return { returning: vi.fn().mockResolvedValue([claimed]) };
+              }
+              // rollback update
+              return { returning: vi.fn().mockResolvedValue([]) };
+            }),
+          }),
+        }),
+      };
+      return fn(tx);
+    });
+
+    // User's email is 'invitee@example.com' but invitation targets 'someone-else@example.com'
+    const res = await app.request(`/api/invitations/${VALID_TOKEN}/accept`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('INVITATION_EMAIL_MISMATCH');
+  });
+
+  it('returns 409 when user is already a team member', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const claimed = {
+        id: VALID_INV_ID,
+        teamId: VALID_TEAM_ID,
+        email: 'invitee@example.com',
+        role: 'viewer',
+        status: 'accepted',
+      };
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([claimed]),
+            }),
+          }),
+        }),
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ userId: 'user-invitee-001', role: 'viewer' }]),
+          }),
+        }),
+        insert: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const res = await app.request(`/api/invitations/${VALID_TOKEN}/accept`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe('MEMBER_ALREADY_EXISTS');
+  });
+
+  it('returns 400 for an invalid token format', async () => {
+    const res = await app.request('/api/invitations/!!! bad token ***/accept', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_TOKEN');
+  });
+
+  it('returns 403 when user has no email and invitation requires email verification', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const claimed = {
+        id: VALID_INV_ID,
+        teamId: VALID_TEAM_ID,
+        email: 'somespecific@example.com',
+        role: 'viewer',
+        status: 'accepted',
+      };
+      let updateCallCount = 0;
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              updateCallCount++;
+              if (updateCallCount === 1) {
+                return { returning: vi.fn().mockResolvedValue([claimed]) };
+              }
+              return { returning: vi.fn().mockResolvedValue([]) };
+            }),
+          }),
+        }),
+      };
+      return fn(tx);
+    });
+
+    // User has no email set in auth context
+    const noEmailApp = buildAcceptApp(db, {
+      userId: 'user-no-email-001',
+      authMethod: 'session',
+      user: { id: 'user-no-email-001', githubId: 5, githubLogin: 'noemail', name: 'No Email', email: null, avatarUrl: null },
+    });
+
+    const res = await noEmailApp.request(`/api/invitations/${VALID_TOKEN}/accept`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('FORBIDDEN');
+  });
+});

--- a/tests/routes/team-invitations.test.ts
+++ b/tests/routes/team-invitations.test.ts
@@ -154,22 +154,25 @@ describe('POST /api/teams/:id/invitations - Create invitation', () => {
 
   it('returns 201 and invitation data on success', async () => {
     // No pending invitation, no existing member, insert succeeds
-    let selectCall = 0;
-    db.select.mockImplementation(() => {
-      selectCall++;
-      const obj: Record<string, unknown> = {};
-      const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy'];
-      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
-      obj.then = (fn: (v: unknown) => unknown) => {
-        const result = selectCall <= 2 ? [] : [];
-        return Promise.resolve(result).then(fn);
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let selectCall = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => {
+          selectCall++;
+          const obj: Record<string, unknown> = {};
+          const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy'];
+          for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+          obj.then = (fn: (v: unknown) => unknown) =>
+            Promise.resolve([]).then(fn);
+          return obj;
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([sampleInvitation]),
+          }),
+        }),
       };
-      return obj;
-    });
-    db.insert.mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([sampleInvitation]),
-      }),
+      return fn(tx);
     });
 
     const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
@@ -186,13 +189,18 @@ describe('POST /api/teams/:id/invitations - Create invitation', () => {
   });
 
   it('returns 409 when a pending invitation already exists', async () => {
-    db.select.mockImplementation(() => {
-      const obj: Record<string, unknown> = {};
-      const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
-      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
-      obj.then = (fn: (v: unknown) => unknown) =>
-        Promise.resolve([sampleInvitation]).then(fn);
-      return obj;
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockImplementation(() => {
+          const obj: Record<string, unknown> = {};
+          const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
+          for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+          obj.then = (fn: (v: unknown) => unknown) =>
+            Promise.resolve([sampleInvitation]).then(fn);
+          return obj;
+        }),
+      };
+      return fn(tx);
     });
 
     const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
@@ -206,19 +214,24 @@ describe('POST /api/teams/:id/invitations - Create invitation', () => {
   });
 
   it('returns 409 when user with that email is already a member', async () => {
-    let selectCall = 0;
-    db.select.mockImplementation(() => {
-      selectCall++;
-      const call = selectCall;
-      const obj: Record<string, unknown> = {};
-      const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
-      for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
-      obj.then = (fn: (v: unknown) => unknown) => {
-        // First call: no pending invitation; second call: user is already a member
-        const result = call === 1 ? [] : [{ userId: 'existing-user-001' }];
-        return Promise.resolve(result).then(fn);
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let selectCall = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => {
+          selectCall++;
+          const call = selectCall;
+          const obj: Record<string, unknown> = {};
+          const methods = ['from', 'where', 'leftJoin', 'innerJoin'];
+          for (const m of methods) obj[m] = vi.fn().mockReturnValue(obj);
+          obj.then = (fn: (v: unknown) => unknown) => {
+            // First call: no pending invitation; second call: user is already a member
+            const result = call === 1 ? [] : [{ userId: 'existing-user-001' }];
+            return Promise.resolve(result).then(fn);
+          };
+          return obj;
+        }),
       };
-      return obj;
+      return fn(tx);
     });
 
     const res = await app.request(`/api/teams/${VALID_TEAM_ID}/invitations`, {
@@ -584,7 +597,7 @@ describe('POST /api/invitations/:token/accept - Accept invitation', () => {
       method: 'POST',
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.teamId).toBe(VALID_TEAM_ID);

--- a/tests/routes/team-invitations.test.ts
+++ b/tests/routes/team-invitations.test.ts
@@ -152,7 +152,7 @@ describe('POST /api/teams/:id/invitations - Create invitation', () => {
     app = buildTeamInvitationsApp(db, rbacService);
   });
 
-  it('returns 200 and invitation data on success', async () => {
+  it('returns 201 and invitation data on success', async () => {
     // No pending invitation, no existing member, insert succeeds
     let selectCall = 0;
     db.select.mockImplementation(() => {
@@ -178,7 +178,7 @@ describe('POST /api/teams/:id/invitations - Create invitation', () => {
       body: JSON.stringify({ email: 'newuser@example.com', role: 'viewer' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.email).toBe('newuser@example.com');

--- a/tests/routes/team-members.test.ts
+++ b/tests/routes/team-members.test.ts
@@ -1,0 +1,713 @@
+/**
+ * Tests for team member RBAC routes.
+ *
+ * Covers:
+ * - POST /members: add member (admin required, user exists, duplicate 409, user not found 404)
+ * - GET /members: list with pagination and role filter
+ * - PATCH /members/:uid: update role, can't change own role, admin can't assign admin, last owner protection
+ * - DELETE /members/:uid: remove, can't remove self, can't remove last owner, only owners remove owners
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTeamMembersRoutes } from '../../src/server/routes/team-members';
+import type { AuthContext } from '../../src/lib/api/auth-middleware';
+import type { RbacService } from '../../src/services/rbac.service';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal mock DB that mirrors the drizzle query chain pattern.
+ * Each method returns an object that supports chaining all the way to an
+ * awaitable array / value.
+ */
+function buildMockDb(overrides: Record<string, unknown> = {}) {
+  // Default resolvers — most tests override these per-call via mockResolvedValueOnce
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+    query: { teams: { findFirst: vi.fn() } },
+    ...overrides,
+  };
+
+  // Fluent chain builder: select().from().where().orderBy().limit() etc.
+  // Returns a Promise that resolves to an array by default.
+  function chain(resolve: unknown[] = []) {
+    const obj: Record<string, unknown> = {};
+    const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy', 'limit', 'groupBy', 'returning'];
+    for (const m of methods) {
+      obj[m] = vi.fn().mockReturnValue(obj);
+    }
+    // Make the chain thenable (await-able)
+    obj.then = (onfulfilled: (v: unknown) => unknown) =>
+      Promise.resolve(resolve).then(onfulfilled);
+    obj[Symbol.iterator] = [][Symbol.iterator];
+    return obj;
+  }
+
+  mockDb.select.mockReturnValue(chain());
+  mockDb.insert.mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) });
+  mockDb.update.mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }) });
+  mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue({ rowsAffected: 1 }) });
+
+  return mockDb;
+}
+
+function buildMockRbacService(overrides: Partial<RbacService> = {}): RbacService {
+  return {
+    resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+    resolveUserRole: vi.fn().mockResolvedValue('admin'),
+    hasMinimumRole: vi.fn().mockReturnValue(true),
+    ...overrides,
+  } as unknown as RbacService;
+}
+
+/**
+ * Build a Hono app with the team-members routes mounted.
+ * The :id param is satisfied by mounting at /api/teams/:id/members.
+ */
+function buildApp(
+  db: ReturnType<typeof buildMockDb>,
+  rbacService: RbacService,
+  authContext: Partial<AuthContext> = {}
+) {
+  const defaultAuth: AuthContext = {
+    userId: 'user-admin-001',
+    authMethod: 'dev',
+    ...authContext,
+  };
+
+  const routes = createTeamMembersRoutes({ db: db as never, rbacService });
+
+  const app = new Hono();
+  app.use('/api/teams/:id/members/*', async (c, next) => {
+    c.set('auth', defaultAuth);
+    await next();
+  });
+  app.use('/api/teams/:id/members', async (c, next) => {
+    c.set('auth', defaultAuth);
+    await next();
+  });
+  app.route('/api/teams/:id/members', routes);
+
+  return app;
+}
+
+const VALID_TEAM_ID = 'team-aaa-001';
+const VALID_USER_ID = 'user-bbb-001';
+
+// ─── POST /members ────────────────────────────────────────────────────────────
+
+describe('POST /api/teams/:id/members - Add member', () => {
+  let db: ReturnType<typeof buildMockDb>;
+  let rbacService: RbacService;
+  let app: Hono;
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+    app = buildApp(db, rbacService);
+  });
+
+  it('returns 200 and member data on successful add', async () => {
+    // transaction resolves to 'OK'
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]), // no existing member
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      // First select: no existing member → []
+      // Second select: user exists → [{id: 'user-bbb-001'}]
+      let callCount = 0;
+      tx.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([]); // no duplicate
+            return Promise.resolve([{ id: VALID_USER_ID }]); // user exists
+          }),
+        }),
+      }));
+      return fn(tx);
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.teamId).toBe(VALID_TEAM_ID);
+    expect(body.data.userId).toBe(VALID_USER_ID);
+    expect(body.data.role).toBe('viewer');
+  });
+
+  it('returns 409 when user is already a member', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ teamId: VALID_TEAM_ID, userId: VALID_USER_ID }]),
+          }),
+        }),
+        insert: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('MEMBER_ALREADY_EXISTS');
+  });
+
+  it('returns 404 when user does not exist', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let callCount = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) return Promise.resolve([]); // no duplicate
+              return Promise.resolve([]); // user not found
+            }),
+          }),
+        })),
+        insert: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('USER_NOT_FOUND');
+  });
+
+  it('returns 400 for invalid team ID', async () => {
+    const res = await app.request('/api/teams/!!!/members', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'viewer' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('INVALID_ID');
+  });
+
+  it('returns 403 when caller lacks admin role (non-dev mode)', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('viewer'),
+      hasMinimumRole: vi.fn().mockReturnValue(false),
+    });
+    app = buildApp(db, rbacService, { authMethod: 'session', userId: 'user-viewer-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for validation error (missing required fields)', async () => {
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'viewer' }), // missing userId
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when attempting to assign owner role directly', async () => {
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'owner' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ─── GET /members ─────────────────────────────────────────────────────────────
+
+describe('GET /api/teams/:id/members - List members with pagination', () => {
+  let db: ReturnType<typeof buildMockDb>;
+  let rbacService: RbacService;
+  let app: Hono;
+
+  const mockMembers = [
+    {
+      userId: 'user-aaa',
+      role: 'admin',
+      joinedAt: '2024-01-01T00:00:00Z',
+      name: 'Alice',
+      email: 'alice@example.com',
+      githubLogin: 'alice',
+      avatarUrl: null,
+    },
+    {
+      userId: 'user-bbb',
+      role: 'viewer',
+      joinedAt: '2024-01-02T00:00:00Z',
+      name: 'Bob',
+      email: 'bob@example.com',
+      githubLogin: 'bob',
+      avatarUrl: null,
+    },
+  ];
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+    app = buildApp(db, rbacService);
+
+    // Default: count query then members query
+    let selectCallIndex = 0;
+    db.select.mockImplementation(() => {
+      selectCallIndex++;
+      const call = selectCallIndex;
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy', 'limit', 'groupBy'];
+      for (const m of methods) {
+        obj[m] = vi.fn().mockReturnValue(obj);
+      }
+      obj.then = (onfulfilled: (v: unknown) => unknown) => {
+        // Call 1 is the count query, call 2+ is the members list
+        const result = call === 1 ? [{ total: 2 }] : mockMembers;
+        return Promise.resolve(result).then(onfulfilled);
+      };
+      return obj;
+    });
+  });
+
+  it('returns 200 with member list and pagination metadata', async () => {
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toHaveLength(2);
+    expect(body.data.totalCount).toBe(2);
+    expect(body.data.hasMore).toBe(false);
+  });
+
+  it('returns 400 for invalid team ID', async () => {
+    const res = await app.request('/api/teams/!!!/members');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('returns 403 when caller is not a team member (non-dev mode)', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue(null),
+    });
+    app = buildApp(db, rbacService, { authMethod: 'session', userId: 'outsider-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+  });
+
+  it('supports role filter query parameter (H6)', async () => {
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members?role=admin`);
+    expect(res.status).toBe(200);
+    // Verify that the DB select was called (role filter is applied via query)
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('returns hasMore=true and nextCursor when results exceed limit', async () => {
+    // Generate limit+1 members to trigger pagination
+    const manyMembers = Array.from({ length: 21 }, (_, i) => ({
+      userId: `user-${String(i).padStart(3, '0')}`,
+      role: 'viewer',
+      joinedAt: '2024-01-01T00:00:00Z',
+      name: `User ${i}`,
+      email: `user${i}@example.com`,
+      githubLogin: `user${i}`,
+      avatarUrl: null,
+    }));
+
+    let selectCallIndex2 = 0;
+    db.select.mockImplementation(() => {
+      selectCallIndex2++;
+      const call = selectCallIndex2;
+      const obj: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy', 'limit', 'groupBy'];
+      for (const m of methods) {
+        obj[m] = vi.fn().mockReturnValue(obj);
+      }
+      obj.then = (onfulfilled: (v: unknown) => unknown) => {
+        const result = call === 1 ? [{ total: 21 }] : manyMembers;
+        return Promise.resolve(result).then(onfulfilled);
+      };
+      return obj;
+    });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members?limit=20`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.hasMore).toBe(true);
+    expect(body.data.nextCursor).toBeDefined();
+  });
+});
+
+// ─── PATCH /members/:uid ──────────────────────────────────────────────────────
+
+describe('PATCH /api/teams/:id/members/:uid - Update member role', () => {
+  let db: ReturnType<typeof buildMockDb>;
+  let rbacService: RbacService;
+
+  const OTHER_USER_ID = 'user-other-002';
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+  });
+
+  it('returns 200 on successful role update', async () => {
+    const updatedMember = {
+      teamId: VALID_TEAM_ID,
+      userId: OTHER_USER_ID,
+      role: 'agent_operator',
+      joinedAt: '2024-01-01T00:00:00Z',
+    };
+
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ userId: OTHER_USER_ID, role: 'viewer' }]),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([updatedMember]),
+            }),
+          }),
+        }),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'agent_operator' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.role).toBe('agent_operator');
+  });
+
+  it('returns 400 when user tries to change their own role', async () => {
+    // Non-dev auth so the self-check fires
+    const app = buildApp(db, rbacService, { authMethod: 'session', userId: VALID_USER_ID });
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${VALID_USER_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('CANNOT_CHANGE_OWN_ROLE');
+  });
+
+  it('returns 403 when admin tries to assign admin role to another user', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
+    const app = buildApp(db, rbacService, { authMethod: 'session', userId: 'user-admin-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'admin' }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+  });
+
+  it('returns 400 when trying to demote the last owner', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let callCount = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) {
+                // target member is an owner
+                return Promise.resolve([{ userId: OTHER_USER_ID, role: 'owner' }]);
+              }
+              // Only one owner
+              return Promise.resolve([{ userId: OTHER_USER_ID, role: 'owner' }]);
+            }),
+          }),
+        })),
+        update: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'admin' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('CANNOT_DEMOTE_LAST_OWNER');
+  });
+
+  it('returns 404 when member not found', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]), // no member
+          }),
+        }),
+        update: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'viewer' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('MEMBER_NOT_FOUND');
+  });
+
+  it('returns 400 for invalid ID in path', async () => {
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/!!!/members/${OTHER_USER_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: 'viewer' }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+});
+
+// ─── DELETE /members/:uid ─────────────────────────────────────────────────────
+
+describe('DELETE /api/teams/:id/members/:uid - Remove member', () => {
+  let db: ReturnType<typeof buildMockDb>;
+  let rbacService: RbacService;
+
+  const OTHER_USER_ID = 'user-other-003';
+
+  beforeEach(() => {
+    db = buildMockDb();
+    rbacService = buildMockRbacService();
+  });
+
+  it('returns 200 on successful removal', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ userId: OTHER_USER_ID, role: 'viewer' }]),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.removed).toBe(true);
+  });
+
+  it('returns 403 when user tries to remove themselves (non-dev)', async () => {
+    const app = buildApp(db, rbacService, { authMethod: 'session', userId: VALID_USER_ID });
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${VALID_USER_ID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('CANNOT_REMOVE_SELF');
+  });
+
+  it('returns 409 when trying to remove the last owner', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let callCount = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) {
+                return Promise.resolve([{ userId: OTHER_USER_ID, role: 'owner' }]);
+              }
+              // Only one owner in team
+              return Promise.resolve([{ userId: OTHER_USER_ID, role: 'owner' }]);
+            }),
+          }),
+        })),
+        delete: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe('CANNOT_REMOVE_LAST_OWNER');
+  });
+
+  it('returns 403 when an admin tries to remove an owner', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
+
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ userId: OTHER_USER_ID, role: 'owner' }]),
+          }),
+        }),
+        delete: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService, { authMethod: 'session', userId: 'user-admin-001' });
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('INSUFFICIENT_ROLE');
+  });
+
+  it('returns 404 when member not found', async () => {
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+        delete: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${OTHER_USER_ID}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe('MEMBER_NOT_FOUND');
+  });
+
+  it('returns 400 for invalid IDs in path', async () => {
+    const app = buildApp(db, rbacService);
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/!!!`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe('INVALID_ID');
+  });
+
+  it('owner can successfully remove another owner when multiple owners exist', async () => {
+    const secondOwnerId = 'user-owner-002';
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('owner'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
+
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let callCount = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) {
+                return Promise.resolve([{ userId: secondOwnerId, role: 'owner' }]);
+              }
+              // Two owners exist
+              return Promise.resolve([
+                { userId: 'user-owner-001', role: 'owner' },
+                { userId: secondOwnerId, role: 'owner' },
+              ]);
+            }),
+          }),
+        })),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      return fn(tx);
+    });
+
+    const app = buildApp(db, rbacService, { authMethod: 'session', userId: 'user-owner-001' });
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${secondOwnerId}`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.removed).toBe(true);
+  });
+});

--- a/tests/routes/team-members.test.ts
+++ b/tests/routes/team-members.test.ts
@@ -111,7 +111,7 @@ describe('POST /api/teams/:id/members - Add member', () => {
     app = buildApp(db, rbacService);
   });
 
-  it('returns 200 and member data on successful add', async () => {
+  it('returns 201 and member data on successful add', async () => {
     // transaction resolves to 'OK'
     db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       const tx = {
@@ -145,7 +145,7 @@ describe('POST /api/teams/:id/members - Add member', () => {
       body: JSON.stringify({ userId: VALID_USER_ID, role: 'viewer' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.teamId).toBe(VALID_TEAM_ID);
@@ -572,13 +572,13 @@ describe('DELETE /api/teams/:id/members/:uid - Remove member', () => {
     expect(body.data.removed).toBe(true);
   });
 
-  it('returns 403 when user tries to remove themselves (non-dev)', async () => {
+  it('returns 400 when user tries to remove themselves (non-dev)', async () => {
     const app = buildApp(db, rbacService, { authMethod: 'session', userId: VALID_USER_ID });
     const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members/${VALID_USER_ID}`, {
       method: 'DELETE',
     });
 
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(400);
     expect((await res.json()).error.code).toBe('CANNOT_REMOVE_SELF');
   });
 

--- a/tests/routes/team-members.test.ts
+++ b/tests/routes/team-members.test.ts
@@ -244,6 +244,64 @@ describe('POST /api/teams/:id/members - Add member', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 403 when non-owner admin tries to add member with admin role (H5)', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('admin'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
+    app = buildApp(db, rbacService, { authMethod: 'session', userId: 'user-admin-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'admin' }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+  });
+
+  it('allows owner to add member with admin role (H5)', async () => {
+    rbacService = buildMockRbacService({
+      resolveTeamRole: vi.fn().mockResolvedValue('owner'),
+      hasMinimumRole: vi.fn().mockReturnValue(true),
+    });
+
+    db.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      let callCount = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) return Promise.resolve([]); // no duplicate
+              return Promise.resolve([{ id: VALID_USER_ID }]); // user exists
+            }),
+          }),
+        })),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockResolvedValue(undefined),
+        }),
+      };
+      return fn(tx);
+    });
+
+    app = buildApp(db, rbacService, { authMethod: 'session', userId: 'user-owner-001' });
+
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: VALID_USER_ID, role: 'admin' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.role).toBe('admin');
+  });
+
   it('returns 400 when attempting to assign owner role directly', async () => {
     const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members`, {
       method: 'POST',
@@ -341,6 +399,14 @@ describe('GET /api/teams/:id/members - List members with pagination', () => {
     expect(res.status).toBe(200);
     // Verify that the DB select was called (role filter is applied via query)
     expect(db.select).toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid role filter query parameter (M9)', async () => {
+    const res = await app.request(`/api/teams/${VALID_TEAM_ID}/members?role=superadmin`);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns hasMore=true and nextCursor when results exceed limit', async () => {

--- a/tests/routes/teams.test.ts
+++ b/tests/routes/teams.test.ts
@@ -143,7 +143,7 @@ describe('POST /teams', () => {
       body: JSON.stringify({ name: 'Acme Corp', slug: 'acme-corp' }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.id).toBe('team-abc123');

--- a/tests/routes/teams.test.ts
+++ b/tests/routes/teams.test.ts
@@ -1,0 +1,780 @@
+/**
+ * Tests for teams API routes.
+ *
+ * Covers:
+ * - POST /teams: create team (201, 409 slug conflict)
+ * - GET /teams: list teams (dev mode, authenticated user, search filter, pagination)
+ * - GET /teams/:id: get team details (success, not found, not member)
+ * - PATCH /teams/:id: update team (admin required, returns updated)
+ * - POST /teams/:id/transfer-ownership: owner only, self-transfer, target not member
+ * - DELETE /teams/:id: owner only, cascading deletes
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTeamsRoutes } from '../../src/server/routes/teams';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+const mockRbacService = {
+  resolveTeamRole: vi.fn(),
+  resolveUserRole: vi.fn(),
+  hasMinimumRole: vi.fn(),
+};
+
+// A minimal mock db that mirrors the Drizzle query builder chain used in teams.ts.
+// Each chainable method returns `this` unless overridden per test.
+const mockDb = {
+  query: {
+    teams: { findFirst: vi.fn() },
+    teamMembers: { findFirst: vi.fn() },
+  },
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  orderBy: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  leftJoin: vi.fn().mockReturnThis(),
+  groupBy: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnValue({
+    values: vi.fn().mockReturnValue({ returning: vi.fn() }),
+  }),
+  update: vi.fn().mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn() }),
+    }),
+  }),
+  delete: vi.fn().mockReturnValue({ where: vi.fn() }),
+  transaction: vi.fn(),
+};
+
+// Reusable sample data
+const sampleTeam = {
+  id: 'team-abc123',
+  name: 'Acme Corp',
+  slug: 'acme-corp',
+  description: 'A test team',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+type AuthMethod = 'session' | 'api_token' | 'dev';
+
+const createApp = (authMethod: AuthMethod = 'session', userId = 'user-1') => {
+  const routes = createTeamsRoutes({
+    db: mockDb as never,
+    rbacService: mockRbacService as never,
+  });
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', { userId, authMethod });
+    return next();
+  });
+  app.route('/teams', routes);
+  return app;
+};
+
+// ---------------------------------------------------------------------------
+// Reset mocks before each test
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Restore chainable defaults after clearAllMocks wipes them
+  mockDb.select.mockReturnThis();
+  mockDb.from.mockReturnThis();
+  mockDb.where.mockReturnThis();
+  mockDb.orderBy.mockReturnThis();
+  mockDb.limit.mockReturnThis();
+  mockDb.leftJoin.mockReturnThis();
+  mockDb.groupBy.mockReturnThis();
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({ returning: vi.fn() }),
+  });
+  mockDb.update.mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn() }),
+    }),
+  });
+  mockDb.delete.mockReturnValue({ where: vi.fn() });
+
+  // Default RBAC: resolve as owner with minimum role always passing
+  mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+  mockRbacService.hasMinimumRole.mockReturnValue(true);
+});
+
+// ===========================================================================
+// POST /teams — Create team
+// ===========================================================================
+
+describe('POST /teams', () => {
+  it('creates a team and returns 201-compatible data with membership', async () => {
+    const createdTeam = { ...sampleTeam };
+
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+      const tx = {
+        ...mockDb,
+        query: {
+          teams: {
+            findFirst: vi
+              .fn()
+              // First call: slug uniqueness check → not found
+              .mockResolvedValueOnce(undefined)
+              // Second call: fetch the newly created team
+              .mockResolvedValueOnce(createdTeam),
+          },
+          teamMembers: { findFirst: vi.fn() },
+        },
+        insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(tx as never);
+    });
+
+    const app = createApp();
+    const res = await app.request('/teams', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Acme Corp', slug: 'acme-corp' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.id).toBe('team-abc123');
+    expect(body.data.membership.role).toBe('owner');
+    expect(body.data.membership.userId).toBe('user-1');
+  });
+
+  it('returns 409 when slug already exists', async () => {
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+      const tx = {
+        ...mockDb,
+        query: {
+          teams: {
+            // Slug uniqueness check: slug taken
+            findFirst: vi.fn().mockResolvedValueOnce(sampleTeam),
+          },
+          teamMembers: { findFirst: vi.fn() },
+        },
+        insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(tx as never);
+    });
+
+    const app = createApp();
+    const res = await app.request('/teams', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Acme Corp', slug: 'acme-corp' }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('TEAM_SLUG_EXISTS');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const app = createApp();
+    const res = await app.request('/teams', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'no-name' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ===========================================================================
+// GET /teams — List teams
+// ===========================================================================
+
+describe('GET /teams', () => {
+  it('returns all teams for dev mode without membership filter', async () => {
+    // Count query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 2 }]),
+      }),
+    });
+    // Teams list query (limit+1 rows)
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([sampleTeam, { ...sampleTeam, id: 'team-xyz' }]),
+          }),
+        }),
+      }),
+    });
+    // Member counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([{ teamId: 'team-abc123', total: 3 }]),
+        }),
+      }),
+    });
+    // Project counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([{ teamId: 'team-abc123', total: 1 }]),
+        }),
+      }),
+    });
+
+    const app = createApp('dev');
+    const res = await app.request('/teams');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.data.items)).toBe(true);
+  });
+
+  it('returns empty list when authenticated user has no memberships', async () => {
+    // Members query returns empty
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toEqual([]);
+    expect(body.data.totalCount).toBe(0);
+    expect(body.data.hasMore).toBe(false);
+  });
+
+  it('returns teams with myRole for authenticated user', async () => {
+    // Members query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ teamId: 'team-abc123', role: 'admin' }]),
+      }),
+    });
+    // Count query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 1 }]),
+      }),
+    });
+    // Teams list query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([sampleTeam]),
+          }),
+        }),
+      }),
+    });
+    // Member counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([{ teamId: 'team-abc123', total: 5 }]),
+        }),
+      }),
+    });
+    // Project counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items[0].myRole).toBe('admin');
+    expect(body.data.items[0].memberCount).toBe(5);
+    expect(body.data.items[0].projectCount).toBe(0);
+  });
+
+  it('supports search filter and returns matching teams for dev mode', async () => {
+    // Count query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 1 }]),
+      }),
+    });
+    // Teams list (search filtered)
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([sampleTeam]),
+          }),
+        }),
+      }),
+    });
+    // Member counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+    // Project counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const app = createApp('dev');
+    const res = await app.request('/teams?search=Acme');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.items.length).toBe(1);
+  });
+
+  it('supports pagination with cursor and hasMore flag', async () => {
+    const teamsPage = [sampleTeam, { ...sampleTeam, id: 'team-page2' }];
+    // limit=1 → fetch 2 items, hasMore=true
+
+    // Members query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          { teamId: 'team-abc123', role: 'owner' },
+          { teamId: 'team-page2', role: 'viewer' },
+        ]),
+      }),
+    });
+    // Count query
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 2 }]),
+      }),
+    });
+    // Teams list (limit+1 = 2 items returned)
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(teamsPage),
+          }),
+        }),
+      }),
+    });
+    // Member counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+    // Project counts
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          groupBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams?limit=1');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.hasMore).toBe(true);
+    expect(body.data.nextCursor).toBe('team-abc123');
+    expect(body.data.items.length).toBe(1);
+  });
+});
+
+// ===========================================================================
+// GET /teams/:id — Get team details
+// ===========================================================================
+
+describe('GET /teams/:id', () => {
+  it('returns team details with counts and myRole for a team member', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.query.teams.findFirst.mockResolvedValue(sampleTeam);
+
+    // Member count
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 4 }]),
+      }),
+    });
+    // Project count
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 2 }]),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams/team-abc123');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.id).toBe('team-abc123');
+    expect(body.data.memberCount).toBe(4);
+    expect(body.data.projectCount).toBe(2);
+    expect(body.data.myRole).toBe('admin');
+  });
+
+  it('returns 404 when team does not exist', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.query.teams.findFirst.mockResolvedValue(undefined);
+
+    // Member count
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 0 }]),
+      }),
+    });
+    // Project count
+    mockDb.select.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ total: 0 }]),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams/team-abc123');
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 404 when user is not a team member', async () => {
+    // resolveTeamRole returns null → not a member
+    mockRbacService.resolveTeamRole.mockResolvedValue(null);
+    mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+    const app = createApp('session');
+    const res = await app.request('/teams/team-abc123');
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 for an invalid team ID', async () => {
+    const app = createApp('session');
+    const res = await app.request('/teams/!!!invalid!!!');
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('INVALID_ID');
+  });
+});
+
+// ===========================================================================
+// PATCH /teams/:id — Update team
+// ===========================================================================
+
+describe('PATCH /teams/:id', () => {
+  it('updates team when caller is admin and returns updated data', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    const updatedTeam = { ...sampleTeam, name: 'Updated Name' };
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([updatedTeam]),
+        }),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams/team-abc123', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Updated Name' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.name).toBe('Updated Name');
+  });
+
+  it('returns 403 when caller lacks admin role', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('viewer');
+    mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+    const app = createApp('session');
+    const res = await app.request('/teams/team-abc123', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Sneaky Update' }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+  });
+
+  it('returns 404 when team does not exist during update', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]), // empty → not found
+        }),
+      }),
+    });
+
+    const app = createApp('session');
+    const res = await app.request('/teams/team-abc123', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Ghost Team' }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 for invalid ID format on update', async () => {
+    const app = createApp('session');
+    const res = await app.request('/teams/bad id!', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('INVALID_ID');
+  });
+});
+
+// ===========================================================================
+// POST /teams/:id/transfer-ownership
+// ===========================================================================
+
+describe('POST /teams/:id/transfer-ownership', () => {
+  it('transfers ownership successfully when target is a member', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+      const tx = {
+        ...mockDb,
+        query: {
+          teams: { findFirst: vi.fn() },
+          teamMembers: {
+            findFirst: vi.fn().mockResolvedValue({ teamId: 'team-abc123', userId: 'user-2', role: 'admin' }),
+          },
+        },
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+      };
+      return fn(tx as never);
+    });
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123/transfer-ownership', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetUserId: 'user-2' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.newOwnerId).toBe('user-2');
+    expect(body.data.previousOwnerId).toBe('user-1');
+  });
+
+  it('returns 400 when attempting to transfer ownership to self', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123/transfer-ownership', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetUserId: 'user-1' }), // same as current user
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('CANNOT_TRANSFER_TO_SELF');
+  });
+
+  it('returns 404 when target user is not a team member', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+      const tx = {
+        ...mockDb,
+        query: {
+          teams: { findFirst: vi.fn() },
+          teamMembers: {
+            findFirst: vi.fn().mockResolvedValue(undefined), // not a member
+          },
+        },
+        update: vi.fn(),
+      };
+      return fn(tx as never);
+    });
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123/transfer-ownership', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetUserId: 'user-outsider' }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('MEMBER_NOT_FOUND');
+  });
+
+  it('returns 403 when caller is not an owner', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123/transfer-ownership', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetUserId: 'user-2' }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+  });
+});
+
+// ===========================================================================
+// DELETE /teams/:id — Delete team
+// ===========================================================================
+
+describe('DELETE /teams/:id', () => {
+  it('deletes team and all associated data when caller is owner', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+      const tx = {
+        ...mockDb,
+        query: {
+          teams: {
+            findFirst: vi.fn().mockResolvedValue(sampleTeam),
+          },
+          teamMembers: { findFirst: vi.fn() },
+        },
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(tx as never);
+    });
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123', { method: 'DELETE' });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.deleted).toBe(true);
+  });
+
+  it('returns 403 when caller is not an owner', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('admin');
+    mockRbacService.hasMinimumRole.mockReturnValue(false);
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123', { method: 'DELETE' });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('INSUFFICIENT_ROLE');
+  });
+
+  it('returns 404 when the team does not exist', async () => {
+    mockRbacService.resolveTeamRole.mockResolvedValue('owner');
+    mockRbacService.hasMinimumRole.mockReturnValue(true);
+
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+      const tx = {
+        ...mockDb,
+        query: {
+          teams: {
+            findFirst: vi.fn().mockResolvedValue(undefined), // team not found
+          },
+          teamMembers: { findFirst: vi.fn() },
+        },
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      };
+      return fn(tx as never);
+    });
+
+    const app = createApp('session', 'user-1');
+    const res = await app.request('/teams/team-abc123', { method: 'DELETE' });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 for an invalid team ID', async () => {
+    const app = createApp('session');
+    const res = await app.request('/teams/!!!bad!!!', { method: 'DELETE' });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('INVALID_ID');
+  });
+});

--- a/tests/services/rbac.service.test.ts
+++ b/tests/services/rbac.service.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { RbacService } from '../../src/services/rbac.service';
+import type { RbacRole } from '../../src/db/schema/shared/enums';
+
+// =============================================================================
+// Mock database factory
+// =============================================================================
+
+function createMockDb() {
+  return {
+    query: {
+      projectMembers: {
+        findFirst: vi.fn(),
+      },
+      teamMembers: {
+        findFirst: vi.fn(),
+      },
+    },
+    select: vi.fn(),
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+  };
+}
+
+// Helper that builds a chainable query builder for select().from().innerJoin().where()
+function buildSelectChain(resolvedValue: unknown) {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+  };
+  // Make each step return the chain so calls are fluent, resolving at .where()
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockResolvedValue(resolvedValue);
+  return chain;
+}
+
+// Helper that builds a chainable select chain for select().from().where() (no join)
+function buildSelectWhereChain(resolvedValue: unknown) {
+  const chain = {
+    from: vi.fn(),
+    where: vi.fn(),
+  };
+  chain.from.mockReturnValue(chain);
+  chain.where.mockResolvedValue(resolvedValue);
+  return chain;
+}
+
+// =============================================================================
+// RbacService Tests
+// =============================================================================
+
+describe('RbacService', () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+  let service: RbacService;
+
+  beforeEach(() => {
+    mockDb = createMockDb();
+    service = new RbacService(mockDb as never);
+  });
+
+  // ===========================================================================
+  // resolveUserRole
+  // ===========================================================================
+
+  describe('resolveUserRole', () => {
+    it('returns the direct project member role when a direct override exists', async () => {
+      mockDb.query.projectMembers.findFirst.mockResolvedValue({ role: 'admin' });
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      expect(role).toBe('admin');
+      expect(mockDb.query.projectMembers.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns owner role when direct project member is owner', async () => {
+      mockDb.query.projectMembers.findFirst.mockResolvedValue({ role: 'owner' });
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      expect(role).toBe('owner');
+    });
+
+    it('returns viewer role when direct project member is viewer', async () => {
+      mockDb.query.projectMembers.findFirst.mockResolvedValue({ role: 'viewer' });
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      expect(role).toBe('viewer');
+    });
+
+    it('falls through to team membership when no direct project member exists', async () => {
+      mockDb.query.projectMembers.findFirst.mockResolvedValue(undefined);
+
+      // Set up the select chain for the team join query
+      const chain = buildSelectChain([{ role: 'agent_operator' }]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      expect(role).toBe('agent_operator');
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the highest role when user belongs to multiple teams linked to the project', async () => {
+      mockDb.query.projectMembers.findFirst.mockResolvedValue(undefined);
+
+      const chain = buildSelectChain([{ role: 'viewer' }, { role: 'admin' }, { role: 'agent_operator' }]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      expect(role).toBe('admin');
+    });
+
+    it('returns null when user has no direct membership and no team memberships', async () => {
+      mockDb.query.projectMembers.findFirst.mockResolvedValue(undefined);
+
+      const chain = buildSelectChain([]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      expect(role).toBeNull();
+    });
+
+    it('prefers direct project member role over higher team role', async () => {
+      // Direct member is viewer but team would give admin - direct member wins
+      mockDb.query.projectMembers.findFirst.mockResolvedValue({ role: 'viewer' });
+
+      const role = await service.resolveUserRole('user-1', 'project-1');
+
+      // select() should never be called since direct member found
+      expect(mockDb.select).not.toHaveBeenCalled();
+      expect(role).toBe('viewer');
+    });
+  });
+
+  // ===========================================================================
+  // resolveTeamRole
+  // ===========================================================================
+
+  describe('resolveTeamRole', () => {
+    it('returns the team role when the user is a member of the team', async () => {
+      mockDb.query.teamMembers.findFirst.mockResolvedValue({ role: 'admin' });
+
+      const role = await service.resolveTeamRole('user-1', 'team-1');
+
+      expect(role).toBe('admin');
+      expect(mockDb.query.teamMembers.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when the user is not a member of the team', async () => {
+      mockDb.query.teamMembers.findFirst.mockResolvedValue(undefined);
+
+      const role = await service.resolveTeamRole('user-1', 'team-1');
+
+      expect(role).toBeNull();
+    });
+
+    it('returns owner role correctly from team membership', async () => {
+      mockDb.query.teamMembers.findFirst.mockResolvedValue({ role: 'owner' });
+
+      const role = await service.resolveTeamRole('user-owner', 'team-1');
+
+      expect(role).toBe('owner');
+    });
+  });
+
+  // ===========================================================================
+  // resolveGlobalRole
+  // ===========================================================================
+
+  describe('resolveGlobalRole', () => {
+    it('returns the highest role across all teams', async () => {
+      const chain = buildSelectWhereChain([
+        { role: 'viewer' },
+        { role: 'admin' },
+        { role: 'agent_operator' },
+      ]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveGlobalRole('user-1');
+
+      expect(role).toBe('admin');
+    });
+
+    it('returns owner when the user is an owner in at least one team', async () => {
+      const chain = buildSelectWhereChain([
+        { role: 'admin' },
+        { role: 'owner' },
+        { role: 'viewer' },
+      ]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveGlobalRole('user-1');
+
+      expect(role).toBe('owner');
+    });
+
+    it('returns the single role when the user belongs to one team', async () => {
+      const chain = buildSelectWhereChain([{ role: 'agent_operator' }]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveGlobalRole('user-1');
+
+      expect(role).toBe('agent_operator');
+    });
+
+    it('returns null when the user belongs to no teams', async () => {
+      const chain = buildSelectWhereChain([]);
+      mockDb.select = vi.fn().mockReturnValue(chain);
+
+      const role = await service.resolveGlobalRole('user-1');
+
+      expect(role).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // hasMinimumRole
+  // ===========================================================================
+
+  describe('hasMinimumRole', () => {
+    it('owner meets the minimum of owner', () => {
+      expect(service.hasMinimumRole('owner', 'owner')).toBe(true);
+    });
+
+    it('owner meets the minimum of admin', () => {
+      expect(service.hasMinimumRole('owner', 'admin')).toBe(true);
+    });
+
+    it('owner meets the minimum of agent_operator', () => {
+      expect(service.hasMinimumRole('owner', 'agent_operator')).toBe(true);
+    });
+
+    it('owner meets the minimum of viewer', () => {
+      expect(service.hasMinimumRole('owner', 'viewer')).toBe(true);
+    });
+
+    it('admin does not meet the minimum of owner', () => {
+      expect(service.hasMinimumRole('admin', 'owner')).toBe(false);
+    });
+
+    it('admin meets the minimum of admin', () => {
+      expect(service.hasMinimumRole('admin', 'admin')).toBe(true);
+    });
+
+    it('admin meets the minimum of agent_operator', () => {
+      expect(service.hasMinimumRole('admin', 'agent_operator')).toBe(true);
+    });
+
+    it('admin meets the minimum of viewer', () => {
+      expect(service.hasMinimumRole('admin', 'viewer')).toBe(true);
+    });
+
+    it('agent_operator does not meet the minimum of owner', () => {
+      expect(service.hasMinimumRole('agent_operator', 'owner')).toBe(false);
+    });
+
+    it('agent_operator does not meet the minimum of admin', () => {
+      expect(service.hasMinimumRole('agent_operator', 'admin')).toBe(false);
+    });
+
+    it('agent_operator meets the minimum of agent_operator', () => {
+      expect(service.hasMinimumRole('agent_operator', 'agent_operator')).toBe(true);
+    });
+
+    it('agent_operator meets the minimum of viewer', () => {
+      expect(service.hasMinimumRole('agent_operator', 'viewer')).toBe(true);
+    });
+
+    it('viewer does not meet the minimum of owner', () => {
+      expect(service.hasMinimumRole('viewer', 'owner')).toBe(false);
+    });
+
+    it('viewer does not meet the minimum of admin', () => {
+      expect(service.hasMinimumRole('viewer', 'admin')).toBe(false);
+    });
+
+    it('viewer does not meet the minimum of agent_operator', () => {
+      expect(service.hasMinimumRole('viewer', 'agent_operator')).toBe(false);
+    });
+
+    it('viewer meets the minimum of viewer', () => {
+      expect(service.hasMinimumRole('viewer', 'viewer')).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // applyTokenCeiling
+  // ===========================================================================
+
+  describe('applyTokenCeiling', () => {
+    it('returns membership role when membership is lower than token role', () => {
+      // viewer(1) < admin(3) -> effective = viewer
+      const effective = service.applyTokenCeiling('viewer', 'admin');
+      expect(effective).toBe('viewer');
+    });
+
+    it('returns token role when token is lower than membership role', () => {
+      // admin(3) > viewer(1) -> effective = viewer
+      const effective = service.applyTokenCeiling('admin', 'viewer');
+      expect(effective).toBe('viewer');
+    });
+
+    it('returns either role when membership and token roles are equal', () => {
+      // admin(3) == admin(3) -> effective = admin (membership returned)
+      const effective = service.applyTokenCeiling('admin', 'admin');
+      expect(effective).toBe('admin');
+    });
+
+    it('caps owner membership to agent_operator token', () => {
+      const effective = service.applyTokenCeiling('owner', 'agent_operator');
+      expect(effective).toBe('agent_operator');
+    });
+
+    it('preserves owner membership when token is also owner', () => {
+      const effective = service.applyTokenCeiling('owner', 'owner');
+      expect(effective).toBe('owner');
+    });
+
+    it('caps admin membership to viewer token', () => {
+      const effective = service.applyTokenCeiling('admin', 'viewer');
+      expect(effective).toBe('viewer');
+    });
+  });
+
+  // ===========================================================================
+  // canPerformAction
+  // ===========================================================================
+
+  describe('canPerformAction', () => {
+    it('allows viewer to perform project:read', () => {
+      expect(service.canPerformAction('viewer', 'project:read')).toBe(true);
+    });
+
+    it('allows viewer to perform task:read', () => {
+      expect(service.canPerformAction('viewer', 'task:read')).toBe(true);
+    });
+
+    it('denies viewer from performing task:create (requires agent_operator)', () => {
+      expect(service.canPerformAction('viewer', 'task:create')).toBe(false);
+    });
+
+    it('denies viewer from performing project:update (requires admin)', () => {
+      expect(service.canPerformAction('viewer', 'project:update')).toBe(false);
+    });
+
+    it('denies viewer from performing team:delete (requires owner)', () => {
+      expect(service.canPerformAction('viewer', 'team:delete')).toBe(false);
+    });
+
+    it('allows agent_operator to perform task:create', () => {
+      expect(service.canPerformAction('agent_operator', 'task:create')).toBe(true);
+    });
+
+    it('allows agent_operator to perform agent:start', () => {
+      expect(service.canPerformAction('agent_operator', 'agent:start')).toBe(true);
+    });
+
+    it('denies agent_operator from performing project:update (requires admin)', () => {
+      expect(service.canPerformAction('agent_operator', 'project:update')).toBe(false);
+    });
+
+    it('allows admin to perform project:update', () => {
+      expect(service.canPerformAction('admin', 'project:update')).toBe(true);
+    });
+
+    it('allows admin to perform settings:update', () => {
+      expect(service.canPerformAction('admin', 'settings:update')).toBe(true);
+    });
+
+    it('denies admin from performing team:delete (requires owner)', () => {
+      expect(service.canPerformAction('admin', 'team:delete')).toBe(false);
+    });
+
+    it('allows owner to perform team:delete', () => {
+      expect(service.canPerformAction('owner', 'team:delete')).toBe(true);
+    });
+
+    it('allows owner to perform team:transfer_owner', () => {
+      expect(service.canPerformAction('owner', 'team:transfer_owner')).toBe(true);
+    });
+
+    it('denies any role from performing an unknown action', () => {
+      expect(service.canPerformAction('owner', 'unknown:action')).toBe(false);
+    });
+
+    it('denies viewer from performing an unknown action', () => {
+      expect(service.canPerformAction('viewer', 'nonexistent:permission')).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // checkTagAccess
+  // ===========================================================================
+
+  describe('checkTagAccess', () => {
+    it('allows access when tokenScopeTags is null (no restriction)', () => {
+      expect(service.checkTagAccess(null, ['tag-a', 'tag-b'])).toBe(true);
+    });
+
+    it('allows access when tokenScopeTags is empty array (no restriction)', () => {
+      expect(service.checkTagAccess([], ['tag-a'])).toBe(true);
+    });
+
+    it('denies access when token has tags but resource has no tags', () => {
+      expect(service.checkTagAccess(['tag-a'], [])).toBe(false);
+    });
+
+    it('allows access when token scope and resource tags overlap', () => {
+      expect(service.checkTagAccess(['tag-a', 'tag-b'], ['tag-b', 'tag-c'])).toBe(true);
+    });
+
+    it('denies access when token scope and resource tags have no overlap', () => {
+      expect(service.checkTagAccess(['tag-x', 'tag-y'], ['tag-a', 'tag-b'])).toBe(false);
+    });
+
+    it('allows access when token has a single tag that matches the resource', () => {
+      expect(service.checkTagAccess(['production'], ['staging', 'production'])).toBe(true);
+    });
+
+    it('denies access when token has a single tag that does not match any resource tag', () => {
+      expect(service.checkTagAccess(['production'], ['staging', 'development'])).toBe(false);
+    });
+
+    it('allows access when token scope is null and resource has no tags', () => {
+      expect(service.checkTagAccess(null, [])).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // checkProjectScope
+  // ===========================================================================
+
+  describe('checkProjectScope', () => {
+    it('allows access when tokenProjectId is null (no restriction)', () => {
+      expect(service.checkProjectScope(null, 'project-1')).toBe(true);
+    });
+
+    it('allows access when tokenProjectId matches requestedProjectId', () => {
+      expect(service.checkProjectScope('project-1', 'project-1')).toBe(true);
+    });
+
+    it('denies access when tokenProjectId does not match requestedProjectId', () => {
+      expect(service.checkProjectScope('project-1', 'project-2')).toBe(false);
+    });
+
+    it('denies access when tokenProjectId is a different project entirely', () => {
+      expect(service.checkProjectScope('proj-abc', 'proj-xyz')).toBe(false);
+    });
+
+    it('allows access when null token scopes any project ID', () => {
+      expect(service.checkProjectScope(null, 'any-project-id')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for the RBAC system and refactors API token handling into a dedicated service. The changes include comprehensive test suites for RBAC middleware, routes, and services, along with improvements to token management and transaction safety.

## Key Changes

### Test Coverage (New Files)
- **`tests/lib/api/rbac-middleware.test.ts`** (1013 lines): Complete test suite for RBAC middleware covering:
  - `enrichAuthContext()` - auth context enrichment with role resolution
  - `requireRole()` - role-based access control enforcement
  - `requireTagAccess()` - tag-scoped API token validation
  - Dev mode, session, and API token authentication flows

- **`tests/routes/tags.test.ts`** (1111 lines): Tag route tests covering:
  - POST /tags creation with RBAC validation
  - GET /tags listing with H3 batch operations
  - DELETE /tags with admin requirements
  - Project and task tag assignment/removal with cross-team checks

- **`tests/routes/rbac-tokens.test.ts`** (810 lines): API token route tests covering:
  - Token creation with role ceiling validation
  - Token listing with pagination and filtering
  - Token revocation and status management
  - Scope validation (tags, projects)

- **`tests/routes/teams.test.ts`** (780 lines): Team management tests covering:
  - Team creation with slug uniqueness
  - Team listing and filtering
  - Team updates and ownership transfer
  - Cascading deletes

- **`tests/routes/team-members.test.ts`** (779 lines): Team member RBAC tests covering:
  - Member addition with role validation
  - Role updates with ownership protection
  - Member removal with last-owner safeguards

- **`tests/routes/team-invitations.test.ts`** (750 lines): Invitation flow tests covering:
  - Invitation creation and duplicate prevention
  - Acceptance with email validation
  - Expiration and revocation

- **`tests/services/rbac.service.test.ts`** (460 lines): RBAC service unit tests for role resolution and permission checking

### Service Refactoring
- **`src/services/rbac-token.service.ts`** (new): Dedicated service for API token operations:
  - Token generation with `ap_` prefix format
  - Token hashing and validation
  - CRUD operations with transaction safety
  - Scope management (tags, projects)
  - Token listing with pagination

### Route Improvements
- **`src/server/routes/rbac-tokens.ts`**: Wrapped token creation in transaction (M1) to prevent TOCTOU races on name uniqueness checks
- **`src/server/routes/tags.ts`**: Fixed POST /tags to return 201 status code instead of 200
- **`src/server/routes/teams.ts`**: Added search filtering with `like` operator and `escapeLike()` helper
- **`src/server/routes/team-invitations.ts`**: Wrapped invitation creation in transaction for atomicity
- **`src/server/routes/team-members.ts`**: Added RBAC_ROLES constant import for role validation
- **`src/server/routes/project-members.ts`**: Fixed POST response to return 201 status
- **`src/server/routes/invitation-accept.ts`**: Enhanced with transaction safety

### Middleware & Security
- **`src/lib/api/rbac-middleware.ts`**: 
  - Refactored API token resolution to use cached `_resolvedApiToken` (H1)
  - Added defense-in-depth check for dev-mode in production
  - Improved token format validation with regex pattern
  - Extracted `CachedApiToken` interface for type safety
  - Removed unused `createHash` import (moved to token service)

### Schema & Validation
- **`src/db/schema/shared/enums.ts`**: Updated role resolution documentation
- **`src/server/validation.ts`**: Refined assignable role schema
- **`src/server/shared.ts`**: Added logging support for shared

https://claude.ai/code/session_01FwUkwZn8cqvAfiWh4DL1Yr