### PR TITLE
feat: ban useEffect — factory hook architecture

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,8 @@
             "noConsole": "off"
           },
           "style": {
-            "noNonNullAssertion": "off"
+            "noNonNullAssertion": "off",
+            "noRestrictedImports": "off"
           },
           "correctness": {
             "useYield": "off",
@@ -55,6 +56,23 @@
           "suspicious": {
             "noExplicitAny": "off",
             "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "src/app/hooks/use-mount-effect.ts",
+        "src/app/hooks/use-watch-effect.ts",
+        "src/app/hooks/use-interval.ts",
+        "src/app/hooks/use-timeout.ts",
+        "src/app/hooks/use-event-listener.ts",
+        "src/app/hooks/use-auto-scroll.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
           }
         }
       }
@@ -115,6 +133,17 @@
       },
       "style": {
         "noNonNullAssertion": "warn",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "react": {
+                "importNames": ["useEffect"],
+                "message": "useEffect is banned. Use hooks from @/app/hooks/use-effect-factories instead."
+              }
+            }
+          }
+        },
         "useConst": "error",
         "useImportType": "error"
       },

--- a/src/app/components/features/add-template-dialog.tsx
+++ b/src/app/components/features/add-template-dialog.tsx
@@ -8,7 +8,7 @@ import {
   Spinner,
   Star,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import {
   Dialog,
@@ -20,6 +20,7 @@ import {
 } from '@/app/components/ui/dialog';
 import { TextInput } from '@/app/components/ui/text-input';
 import { Textarea } from '@/app/components/ui/textarea';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import type { GitHubOrg, GitHubRepo } from '@/services/github-token.service';
 
@@ -115,7 +116,7 @@ function GitHubRepoSelector({
   const [searchTerm, setSearchTerm] = useState('');
 
   // Fetch repos when owner changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!selectedOwner) {
       setRepos([]);
       return;
@@ -349,7 +350,7 @@ export function AddTemplateDialog({
   }, [onFetchOrgs, isGitHubConfigured, hasFetchedOrgs]);
 
   // Fetch orgs when dialog opens and GitHub is configured
-  useEffect(() => {
+  useWatchEffect(() => {
     if (open && isGitHubConfigured && !hasFetchedOrgs) {
       void fetchGitHubOrgs();
     }

--- a/src/app/components/features/agent-session-view/header-bar.tsx
+++ b/src/app/components/features/agent-session-view/header-bar.tsx
@@ -1,7 +1,8 @@
 import { Pause, Play, Square, Timer } from '@phosphor-icons/react';
 import { cva } from 'class-variance-authority';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { Button } from '@/app/components/ui/button';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 export type AgentStatus = 'idle' | 'starting' | 'running' | 'paused' | 'error' | 'completed';
 
@@ -81,7 +82,7 @@ export function HeaderBar({
   const elapsedRef = useRef<HTMLSpanElement>(null);
 
   // Update elapsed time every second when running (direct DOM update to avoid re-renders)
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!startTime || status !== 'running') {
       return;
     }

--- a/src/app/components/features/agent-session-view/index.tsx
+++ b/src/app/components/features/agent-session-view/index.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 const AgentTopology = lazy(() =>
   import('@/app/components/features/agent-topology').then((m) => ({ default: m.AgentTopology }))
@@ -171,7 +172,7 @@ export function AgentSessionView({
   const agentStatus = mapAgentStatus(state.agentState?.status);
 
   // Track start time
-  useEffect(() => {
+  useWatchEffect(() => {
     if (agentStatus === 'running' && !startTimeRef.current) {
       startTimeRef.current = Date.now();
     }
@@ -182,7 +183,7 @@ export function AgentSessionView({
 
   // Mark as loaded after first state update
   const hasData = state.chunks.length > 0 || state.agentState !== null;
-  useEffect(() => {
+  useWatchEffect(() => {
     if (hasData) {
       setIsLoading(false);
       return;
@@ -193,7 +194,7 @@ export function AgentSessionView({
   }, [hasData]);
 
   // Track user joins/leaves
-  useEffect(() => {
+  useWatchEffect(() => {
     const prevUserIds = new Set(prevUsersRef.current);
     const currentUserIds = new Set(users.map((u) => u.userId));
 
@@ -235,7 +236,7 @@ export function AgentSessionView({
   }, [users, userId]);
 
   // Track agent state changes
-  useEffect(() => {
+  useWatchEffect(() => {
     const currentStatus = state.agentState?.status;
     if (currentStatus && currentStatus !== prevStatusRef.current) {
       const statusMessages: Record<string, { type: ActivityItemType; message: string } | null> = {
@@ -265,7 +266,7 @@ export function AgentSessionView({
   }, [state.agentState?.status]);
 
   // Handle errors
-  useEffect(() => {
+  useWatchEffect(() => {
     if (error) {
       onError?.(error);
     }

--- a/src/app/components/features/agent-session-view/stream-panel.tsx
+++ b/src/app/components/features/agent-session-view/stream-panel.tsx
@@ -1,6 +1,6 @@
 import { Terminal } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
+import { useAutoScroll } from '@/app/hooks/use-auto-scroll';
 import { cn } from '@/lib/utils/cn';
 import { StreamCursor, StreamLine } from './stream-line';
 import type { StreamLine as StreamLineData } from './use-stream-parser';
@@ -16,49 +16,7 @@ export function StreamPanel({
   isStreaming,
   viewerColors = [],
 }: StreamPanelProps): React.JSX.Element {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const autoScrollRef = useRef(true);
-  const userScrolledRef = useRef(false);
-  const [showScrollButton, setShowScrollButton] = useState(false);
-
-  // Auto-scroll to bottom when new lines arrive
-  useEffect(() => {
-    if (autoScrollRef.current && containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  });
-
-  // Detect user scroll to disable auto-scroll
-  const handleScroll = useCallback(() => {
-    if (!containerRef.current) return;
-
-    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
-
-    // If user scrolled up, disable auto-scroll
-    if (!isAtBottom && !userScrolledRef.current) {
-      userScrolledRef.current = true;
-      autoScrollRef.current = false;
-      setShowScrollButton(true);
-    }
-
-    // If user scrolled back to bottom, re-enable auto-scroll
-    if (isAtBottom && userScrolledRef.current) {
-      userScrolledRef.current = false;
-      autoScrollRef.current = true;
-      setShowScrollButton(false);
-    }
-  }, []);
-
-  // Scroll to bottom button
-  const scrollToBottom = useCallback(() => {
-    if (containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-      autoScrollRef.current = true;
-      userScrolledRef.current = false;
-      setShowScrollButton(false);
-    }
-  }, []);
+  const { containerRef, scrollToBottom, showScrollButton, handleScroll } = useAutoScroll();
 
   return (
     <div className="flex flex-1 flex-col rounded-lg border border-border bg-surface m-4 mr-2 overflow-hidden">

--- a/src/app/components/features/agent-topology/agent-topology.tsx
+++ b/src/app/components/features/agent-topology/agent-topology.tsx
@@ -7,7 +7,8 @@ import {
   useReactFlow,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { TopologyDetailPanel } from './detail-panel/topology-detail-panel';
 import { AgentEdge } from './edges/agent-edge';
 import { AgentEdgeMarkers } from './edges/agent-edge-markers';
@@ -48,7 +49,7 @@ function TopologyInner(): React.JSX.Element {
   }, []);
 
   // Structural changes — trigger full ELK relayout
-  useEffect(() => {
+  useWatchEffect(() => {
     if (state.graph.nodes.length === 0) {
       setNodes([]);
       setEdges([]);
@@ -66,8 +67,7 @@ function TopologyInner(): React.JSX.Element {
   // on AgentNode can skip re-renders for untouched nodes.
   // Uses graphRef to read the latest graph data without adding it as a dependency;
   // dataVersion is the sole trigger for this effect.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dataVersion is the intentional trigger; graph data is read from graphRef to avoid re-firing on every graph reference change
-  useEffect(() => {
+  useWatchEffect(() => {
     const graph = graphRef.current;
     if (graph.nodes.length === 0) return;
 

--- a/src/app/components/features/agent-topology/index.tsx
+++ b/src/app/components/features/agent-topology/index.tsx
@@ -1,4 +1,5 @@
-import { Component, type ErrorInfo, lazy, type ReactNode, Suspense, useEffect } from 'react';
+import { Component, type ErrorInfo, lazy, type ReactNode, Suspense } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import type { TopologyGraph } from '@/lib/topology/types';
 import { TopologyProvider } from './topology-context';
 
@@ -61,10 +62,10 @@ function TopologyLoading(): React.JSX.Element {
 }
 
 function DebugMount({ label }: { label: string }): null {
-  useEffect(() => {
+  useMountEffect(() => {
     console.debug(`[AgentTopology] ${label} mounted`);
     return () => console.debug(`[AgentTopology] ${label} unmounted`);
-  }, [label]);
+  });
   return null;
 }
 

--- a/src/app/components/features/agent-topology/topology-context.tsx
+++ b/src/app/components/features/agent-topology/topology-context.tsx
@@ -1,13 +1,6 @@
-import {
-  createContext,
-  type ReactNode,
-  useContext,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-} from 'react';
+import { createContext, type ReactNode, useContext, useMemo, useReducer, useRef } from 'react';
 import { useTopologyStream } from '@/app/hooks/use-topology-stream';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { TopologyDecision, TopologyGraph, TopologyNode } from '@/lib/topology/types';
 
 interface TopologyMetrics {
@@ -206,7 +199,7 @@ export function TopologyProvider({ children, sessionId, initialData }: TopologyP
 
   // Sync initialData prop changes into reducer (skip first render — already in initial state)
   const prevInitialDataRef = useRef(initialData);
-  useEffect(() => {
+  useWatchEffect(() => {
     if (initialData && initialData !== prevInitialDataRef.current) {
       prevInitialDataRef.current = initialData;
       dispatch({ type: 'REPLACE_GRAPH', graph: initialData });

--- a/src/app/components/features/approval-dialog/file-tabs.tsx
+++ b/src/app/components/features/approval-dialog/file-tabs.tsx
@@ -11,7 +11,8 @@ import {
   PencilSimple,
 } from '@phosphor-icons/react';
 import { cva } from 'class-variance-authority';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import type { DiffFile, DiffFileStatus } from '@/lib/types/diff';
 import { cn } from '@/lib/utils/cn';
 
@@ -72,7 +73,7 @@ export function FileTabs({ files, activeIndex, onSelect }: FileTabsProps): React
   const activeTabRef = useRef<HTMLButtonElement>(null);
 
   // Auto-scroll to active tab when it changes
-  useEffect(() => {
+  useMountEffect(() => {
     if (activeTabRef.current && scrollContainerRef.current) {
       const container = scrollContainerRef.current;
       const tab = activeTabRef.current;
@@ -85,7 +86,7 @@ export function FileTabs({ files, activeIndex, onSelect }: FileTabsProps): React
         container.scrollLeft += tabRect.right - containerRect.right + 16;
       }
     }
-  }, []);
+  });
 
   // Keyboard navigation
   const handleKeyDown = (event: React.KeyboardEvent, currentIndex: number) => {

--- a/src/app/components/features/approval-dialog/index.tsx
+++ b/src/app/components/features/approval-dialog/index.tsx
@@ -14,7 +14,7 @@ import {
   X,
   XCircle,
 } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { Checkbox } from '@/app/components/ui/checkbox';
 import {
@@ -28,6 +28,8 @@ import {
 import { MarkdownContent } from '@/app/components/ui/markdown-content';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/ui/tabs';
 import { Textarea } from '@/app/components/ui/textarea';
+import { useEventListener } from '@/app/hooks/use-event-listener';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Task } from '@/db/schema';
 import type { DiffFile, DiffResult, DiffSummary } from '@/lib/types/diff';
 import { cn } from '@/lib/utils/cn';
@@ -80,16 +82,11 @@ export function ApprovalDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submittingAction, setSubmittingAction] = useState<'approve' | 'reject' | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onOpenChange(false);
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [open, onOpenChange]);
+  useEventListener(open ? window : null, 'keydown', (event) => {
+    if (event.key === 'Escape') onOpenChange(false);
+  });
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (open) {
       setTab('summary');
       setRejectReason('');

--- a/src/app/components/features/cli-monitor/cards-right-panel.tsx
+++ b/src/app/components/features/cli-monitor/cards-right-panel.tsx
@@ -1,5 +1,6 @@
 import { ChatCircle, Clock, Lightning, Terminal } from '@phosphor-icons/react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { CliSession } from './cli-monitor-types';
 import { estimateCost, formatTokenCount, getSessionTokenTotal } from './cli-monitor-utils';
 
@@ -84,8 +85,7 @@ function StreamTab({ session }: { session: CliSession }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const isPinnedRef = useRef(true);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: recentOutput triggers auto-scroll on new output
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!contentRef.current || !isPinnedRef.current) return;
     contentRef.current.scrollTop = contentRef.current.scrollHeight;
   }, [session.recentOutput]);

--- a/src/app/components/features/cli-monitor/cli-monitor-context.tsx
+++ b/src/app/components/features/cli-monitor/cli-monitor-context.tsx
@@ -3,11 +3,13 @@ import {
   type ReactNode,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
+import { useEventListener } from '@/app/hooks/use-event-listener';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import { useCliSessions } from '@/lib/cli-monitor/hooks';
 import { startCliMonitorSync } from '@/lib/cli-monitor/sync';
@@ -67,29 +69,21 @@ export function CliMonitorProvider({ children }: { children: ReactNode }) {
   }, []);
 
   // Cleanup alert timers on unmount
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       for (const timer of alertTimersRef.current.values()) {
         clearTimeout(timer);
       }
       alertTimersRef.current.clear();
     };
-  }, []);
+  });
 
   // Browser offline/online detection
-  useEffect(() => {
-    const handleOnline = () => setIsOffline(false);
-    const handleOffline = () => setIsOffline(true);
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
-    return () => {
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
-    };
-  }, []);
+  useEventListener(window, 'online', () => setIsOffline(false));
+  useEventListener(window, 'offline', () => setIsOffline(true));
 
   // SSE sync via collection-backed sync module
-  useEffect(() => {
+  useMountEffect(() => {
     const cleanup = startCliMonitorSync(apiClient.cliMonitor.getStreamUrl(), {
       onDaemonConnected: () => setDaemonConnected(true),
       onDaemonDisconnected: () => {
@@ -143,13 +137,13 @@ export function CliMonitorProvider({ children }: { children: ReactNode }) {
     });
 
     return cleanup;
-  }, [addAlert]);
+  });
 
   // Derive page state from sessions (including historical DB data)
   // Only upgrade pageState, never downgrade from 'active' — the SSE snapshot
   // handler in sync.ts is the primary authority, this effect catches async
   // collection updates that arrive after the snapshot callback.
-  useEffect(() => {
+  useWatchEffect(() => {
     if (sessions.length > 0) {
       setPageState('active');
     } else if (daemonConnected) {

--- a/src/app/components/features/cli-monitor/terminal-pane.tsx
+++ b/src/app/components/features/cli-monitor/terminal-pane.tsx
@@ -1,5 +1,6 @@
 import { ArrowsIn, ArrowsOut, GitBranch, Terminal } from '@phosphor-icons/react';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { CliSession } from './cli-monitor-types';
 
 const statusDotClass: Record<string, string> = {
@@ -40,8 +41,7 @@ export function TerminalPane({
   const isPinnedRef = useRef(true);
 
   // Auto-scroll to bottom when content updates
-  // biome-ignore lint/correctness/useExhaustiveDependencies: recentOutput triggers scroll
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!contentRef.current || !isPinnedRef.current) return;
     contentRef.current.scrollTop = contentRef.current.scrollHeight;
   }, [session?.recentOutput]);

--- a/src/app/components/features/container-agent-panel/container-agent-header.tsx
+++ b/src/app/components/features/container-agent-panel/container-agent-header.tsx
@@ -8,8 +8,9 @@ import {
   WifiSlash,
 } from '@phosphor-icons/react';
 import { cva } from 'class-variance-authority';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { ExecutionBadge } from '@/app/components/ui/execution-badge';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { ConnectionState } from '@/lib/streams/client';
 
 export type ContainerAgentStatus =
@@ -108,7 +109,7 @@ export function ContainerAgentHeader({
   const elapsedRef = useRef<HTMLSpanElement>(null);
 
   // Update elapsed time every second when running (direct DOM update to avoid re-renders)
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!startedAt || (status !== 'running' && status !== 'starting')) {
       return;
     }

--- a/src/app/components/features/container-agent-panel/container-agent-stream.tsx
+++ b/src/app/components/features/container-agent-panel/container-agent-stream.tsx
@@ -6,9 +6,9 @@ import {
   Warning,
   XCircle,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { MarkdownContent } from '@/app/components/ui/markdown-content';
+import { useAutoScroll } from '@/app/hooks/use-auto-scroll';
 import type { ContainerAgentStatus } from './container-agent-header';
 
 interface Message {
@@ -57,47 +57,7 @@ export function ContainerAgentStream({
   onRejectPlan,
   isPlanActionPending,
 }: ContainerAgentStreamProps): React.JSX.Element {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const autoScrollRef = useRef(true);
-  const userScrolledRef = useRef(false);
-  const [showScrollButton, setShowScrollButton] = useState(false);
-
-  // Auto-scroll to bottom when content changes
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally trigger on content changes
-  useEffect(() => {
-    if (autoScrollRef.current && containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    }
-  }, [streamedText, messages]);
-
-  // Detect user scroll
-  const handleScroll = useCallback(() => {
-    if (!containerRef.current) return;
-
-    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
-
-    if (!isAtBottom && !userScrolledRef.current) {
-      userScrolledRef.current = true;
-      autoScrollRef.current = false;
-      setShowScrollButton(true);
-    }
-
-    if (isAtBottom && userScrolledRef.current) {
-      userScrolledRef.current = false;
-      autoScrollRef.current = true;
-      setShowScrollButton(false);
-    }
-  }, []);
-
-  const scrollToBottom = useCallback(() => {
-    if (containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight;
-      autoScrollRef.current = true;
-      userScrolledRef.current = false;
-      setShowScrollButton(false);
-    }
-  }, []);
+  const { containerRef, scrollToBottom, showScrollButton, handleScroll } = useAutoScroll();
 
   const hasContent = messages.length > 0 || streamedText.length > 0;
 

--- a/src/app/components/features/diff-viewer.tsx
+++ b/src/app/components/features/diff-viewer.tsx
@@ -1,5 +1,6 @@
 import { CaretDown, CaretRight, FileCode, SpinnerGap } from '@phosphor-icons/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { DiffFile } from '@/lib/types/diff';
 import { cn } from '@/lib/utils/cn';
 import { CompactChangesSummary } from './approval-dialog/changes-summary';
@@ -158,7 +159,7 @@ export function WorktreeDiffViewer({ worktreeId }: WorktreeDiffViewerProps): Rea
     }
   }, [worktreeId]);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     void fetchDiff();
   }, [fetchDiff]);
 

--- a/src/app/components/features/git-view/git-view.tsx
+++ b/src/app/components/features/git-view/git-view.tsx
@@ -12,9 +12,11 @@ import {
   GitPullRequest,
   WarningCircle,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { Skeleton } from '@/app/components/ui/skeleton';
+import { useEventListener } from '@/app/hooks/use-event-listener';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -284,18 +286,10 @@ function ContextMenu({
   onClose: () => void;
   actions: { label: string; onClick: () => void; danger?: boolean }[];
 }) {
-  useEffect(() => {
-    const handleClick = () => onClose();
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('click', handleClick);
-    document.addEventListener('keydown', handleEscape);
-    return () => {
-      document.removeEventListener('click', handleClick);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [onClose]);
+  useEventListener(document, 'click', () => onClose());
+  useEventListener(document, 'keydown', (e) => {
+    if (e.key === 'Escape') onClose();
+  });
 
   return (
     <div
@@ -458,7 +452,7 @@ export function GitView({ projectId, projectPath }: GitViewProps): React.JSX.Ele
     [projectId, selectedBranch]
   );
 
-  useEffect(() => {
+  useWatchEffect(() => {
     fetchData();
   }, [fetchData]);
 
@@ -488,7 +482,7 @@ export function GitView({ projectId, projectPath }: GitViewProps): React.JSX.Ele
   );
 
   // Effect to fetch commits when branch selection changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (selectedBranch) {
       fetchCommitsForBranch(selectedBranch);
     }

--- a/src/app/components/features/github-app-setup.tsx
+++ b/src/app/components/features/github-app-setup.tsx
@@ -9,9 +9,10 @@ import {
   Trash,
   Warning,
 } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { TextInput } from '@/app/components/ui/text-input';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { useServices } from '@/app/services/service-context';
 import type { TokenInfo } from '@/services/github-token.service';
 
@@ -30,7 +31,7 @@ export function GitHubAppSetup({ onTokenSaved }: GitHubAppSetupProps): React.JSX
   const [isSaving, setIsSaving] = useState(false);
 
   // Load existing token info on mount
-  useEffect(() => {
+  useWatchEffect(() => {
     const loadToken = async () => {
       setIsLoading(true);
       try {
@@ -46,7 +47,7 @@ export function GitHubAppSetup({ onTokenSaved }: GitHubAppSetupProps): React.JSX
       setIsLoading(false);
     };
     void loadToken();
-  }, [services]);
+  }, [services?.githubTokenService]);
 
   const handleSaveToken = async () => {
     if (!token.trim()) {

--- a/src/app/components/features/global-settings.tsx
+++ b/src/app/components/features/global-settings.tsx
@@ -1,6 +1,7 @@
 import { CircleNotch, Eye, EyeSlash, Gear, Key, Palette, Warning } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 import { isValidPATFormat } from '@/lib/crypto/token-encryption';
 
@@ -72,7 +73,7 @@ function ApiKeysSection(): React.JSX.Element {
   const [githubError, setGithubError] = useState<string | null>(null);
 
   // Load saved keys on mount
-  useEffect(() => {
+  useMountEffect(() => {
     const loadAnthropicKey = async () => {
       const result = await apiClient.apiKeys.get('anthropic');
       if (result.ok && result.data.keyInfo) {
@@ -94,7 +95,7 @@ function ApiKeysSection(): React.JSX.Element {
       }
     };
     loadGitHubToken();
-  }, []);
+  });
 
   const handleSaveAnthropicKey = async () => {
     if (!anthropicKey.trim()) return;
@@ -388,7 +389,7 @@ function DefaultsSection(): React.JSX.Element {
   const [maxConcurrentAgents, setMaxConcurrentAgents] = useState('3');
 
   // Load settings from API on mount
-  useEffect(() => {
+  useMountEffect(() => {
     async function loadSettings() {
       setIsLoading(true);
       setError(null);
@@ -414,7 +415,7 @@ function DefaultsSection(): React.JSX.Element {
       }
     }
     loadSettings();
-  }, []);
+  });
 
   const handleSaveDefaults = async () => {
     setIsSaving(true);

--- a/src/app/components/features/new-project-dialog.tsx
+++ b/src/app/components/features/new-project-dialog.tsx
@@ -15,7 +15,7 @@ import {
   WarningCircle,
 } from '@phosphor-icons/react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import {
   Dialog,
@@ -28,6 +28,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/ui/tabs';
 import { TextInput } from '@/app/components/ui/text-input';
 import { Textarea } from '@/app/components/ui/textarea';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { SANDBOX_TYPES } from '@/db/schema/shared/enums';
 import { cn } from '@/lib/utils/cn';
 import type { Result } from '@/lib/utils/result';
@@ -331,7 +332,7 @@ function GitHubRepoList({
   const [showPrivateOnly, setShowPrivateOnly] = useState(false);
 
   // Fetch repos when owner changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!selectedOwner) {
       setRepos([]);
       return;
@@ -626,7 +627,7 @@ export function NewProjectDialog({
   const [hasFetchedOrgs, setHasFetchedOrgs] = useState(false);
 
   // Reset state when dialog closes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!open) {
       setSourceType(initialSource);
       setName('');
@@ -673,7 +674,7 @@ export function NewProjectDialog({
   }, [onFetchOrgs, isGitHubConfigured, hasFetchedOrgs]);
 
   // Fetch orgs when switching to clone tab
-  useEffect(() => {
+  useWatchEffect(() => {
     if (sourceType === 'clone' && isGitHubConfigured && !hasFetchedOrgs) {
       void fetchGitHubOrgs();
     }

--- a/src/app/components/features/new-task-dialog.tsx
+++ b/src/app/components/features/new-task-dialog.tsx
@@ -10,7 +10,9 @@ import {
   X,
 } from '@phosphor-icons/react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import {
   type TaskCreationMessage,
@@ -74,7 +76,7 @@ function useResizableDialog() {
     startSize.current = { ...sizeRef.current };
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!isResizing) return;
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -152,7 +154,7 @@ function useDraggableDialog() {
     startOffset.current = { ...positionRef.current };
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!isDragging) return;
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -335,17 +337,21 @@ function ThinkingIndicator(): React.JSX.Element {
   const [phraseIndex, setPhraseIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
 
-  useEffect(() => {
+  useMountEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
     const interval = setInterval(() => {
       setIsTransitioning(true);
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         setPhraseIndex((prev) => (prev + 1) % THINKING_PHRASES.length);
         setIsTransitioning(false);
       }, 150);
     }, 2000);
 
-    return () => clearInterval(interval);
-  }, []);
+    return () => {
+      clearInterval(interval);
+      clearTimeout(timeoutId);
+    };
+  });
 
   return (
     <div className="flex items-center gap-2 px-3 py-2">
@@ -1024,7 +1030,7 @@ export function NewTaskDialog({
   const pendingQuestionsId = pendingQuestions?.id;
   const prevQuestionsIdRef = useRef<string | undefined>(undefined);
   const answersQuestionsIdRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
+  useWatchEffect(() => {
     console.log('[NewTaskDialog] Questions effect:', {
       pendingQuestionsId,
       prevId: prevQuestionsIdRef.current,
@@ -1046,14 +1052,14 @@ export function NewTaskDialog({
   }, [pendingQuestionsId, pendingQuestions]);
 
   // Start conversation when dialog opens
-  useEffect(() => {
+  useWatchEffect(() => {
     if (open && status === 'idle') {
       startConversation();
     }
   }, [open, status, startConversation]);
 
   // Reset on close
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!open) {
       reset();
       resetPosition();
@@ -1072,7 +1078,7 @@ export function NewTaskDialog({
   }, [open, reset, resetPosition]);
 
   // Handle task creation completion
-  useEffect(() => {
+  useWatchEffect(() => {
     if (createdTaskId) {
       onTaskCreated?.(createdTaskId);
       onOpenChange(false);
@@ -1081,7 +1087,7 @@ export function NewTaskDialog({
 
   // Auto-scroll to bottom when messages change or streaming
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger deps for scroll behavior
-  useEffect(() => {
+  useWatchEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, streamingContent]);
 

--- a/src/app/components/features/plan-session-view/plan-stream-panel.tsx
+++ b/src/app/components/features/plan-session-view/plan-stream-panel.tsx
@@ -1,5 +1,6 @@
 import { Sparkle, User } from '@phosphor-icons/react';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import type { PlanStreamPanelProps, StreamMessage } from './types';
 
@@ -245,8 +246,7 @@ export function PlanStreamPanel({
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to bottom on new messages
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional triggers to re-scroll when content changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }

--- a/src/app/components/features/plan-session-view/use-plan-session.ts
+++ b/src/app/components/features/plan-session-view/use-plan-session.ts
@@ -1,6 +1,7 @@
 import type { StreamResponse } from '@durable-streams/client';
 import { stream as durableStream } from '@durable-streams/client';
-import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { useCallback, useReducer, useRef } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import type {
   PlanCompletedEventData,
@@ -468,8 +469,8 @@ export function usePlanSession(
     }
   }, [taskId]);
 
-  // Initialize on mount
-  useEffect(() => {
+  // Initialize when loadSession changes (e.g., taskId changes)
+  useWatchEffect(() => {
     isMountedRef.current = true;
 
     if (!isInitializedRef.current) {
@@ -477,7 +478,7 @@ export function usePlanSession(
       loadSession();
     }
 
-    // Cleanup on unmount
+    // Cleanup on unmount or when loadSession changes
     return () => {
       isMountedRef.current = false;
       if (unsubscribeRef.current) {

--- a/src/app/components/features/project-picker/index.tsx
+++ b/src/app/components/features/project-picker/index.tsx
@@ -1,6 +1,7 @@
 import { ArrowDown, ArrowUp, Plus, X } from '@phosphor-icons/react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import { ProjectList } from './project-list';
 import { SearchInput } from './search-input';
@@ -42,7 +43,7 @@ export function ProjectPicker({
   });
 
   // Focus search input when modal opens
-  useEffect(() => {
+  useWatchEffect(() => {
     if (open) {
       resetState();
       // Use requestAnimationFrame to ensure the modal is rendered

--- a/src/app/components/features/project-picker/project-list.tsx
+++ b/src/app/components/features/project-picker/project-list.tsx
@@ -1,5 +1,6 @@
 import { FolderOpen, Spinner } from '@phosphor-icons/react';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import { ProjectItem } from './project-item';
 import type { ProjectPickerItem } from './types';
@@ -32,7 +33,7 @@ export function ProjectList({
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
   // Scroll selected item into view
-  useEffect(() => {
+  useWatchEffect(() => {
     const selectedElement = itemRefs.current.get(selectedIndex);
     if (selectedElement && listRef.current) {
       const listRect = listRef.current.getBoundingClientRect();

--- a/src/app/components/features/project-picker/use-project-picker.ts
+++ b/src/app/components/features/project-picker/use-project-picker.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useEventListener } from '@/app/hooks/use-event-listener';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { ProjectPickerItem } from './types';
 
 const RECENT_PROJECTS_KEY = 'agentpane:recent-projects';
@@ -62,7 +64,7 @@ export function useProjectPickerState({
   );
 
   // Reset selected index when items change
-  useEffect(() => {
+  useWatchEffect(() => {
     // Try to keep current selection if possible, otherwise find active project or reset to 0
     if (selectedIndex >= allItems.length) {
       const activeIndex = allItems.findIndex((p) => p.id === selectedProjectId);
@@ -132,18 +134,13 @@ export function useProjectPickerState({
  * Hook to manage global Cmd+P / Ctrl+P keyboard shortcut
  */
 export function useProjectPickerHotkey(onOpen: () => void): void {
-  useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      // Check for Cmd+P (Mac) or Ctrl+P (Windows/Linux)
-      if ((event.metaKey || event.ctrlKey) && event.key === 'p') {
-        event.preventDefault();
-        onOpen();
-      }
+  useEventListener(window, 'keydown', (event) => {
+    // Check for Cmd+P (Mac) or Ctrl+P (Windows/Linux)
+    if ((event.metaKey || event.ctrlKey) && event.key === 'p') {
+      event.preventDefault();
+      onOpen();
     }
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onOpen]);
+  });
 }
 
 /**

--- a/src/app/components/features/project-settings.tsx
+++ b/src/app/components/features/project-settings.tsx
@@ -17,7 +17,7 @@ import {
   Trash,
 } from '@phosphor-icons/react';
 import { Link } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import {
   Select,
@@ -29,6 +29,8 @@ import {
 import { Switch } from '@/app/components/ui/switch';
 import { TextInput } from '@/app/components/ui/text-input';
 import { Textarea } from '@/app/components/ui/textarea';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Project, ProjectConfig } from '@/db/schema';
 import { apiClient } from '@/lib/api/client';
 import { AVAILABLE_MODELS } from '@/lib/constants/models';
@@ -166,7 +168,7 @@ export function ProjectSettings({
   const [isLoadingDefaults, setIsLoadingDefaults] = useState(true);
 
   // Load global defaults on mount
-  useEffect(() => {
+  useMountEffect(() => {
     const loadDefaults = async () => {
       try {
         const result = await apiClient.settings.get(['sandbox.defaults']);
@@ -180,7 +182,7 @@ export function ProjectSettings({
       }
     };
     loadDefaults();
-  }, []);
+  });
 
   // Sandbox configuration - uses existing project config or falls back to global defaults
   const existingSandbox = project.config?.sandbox as ProjectSandboxConfig | undefined | null;
@@ -230,7 +232,7 @@ export function ProjectSettings({
   };
 
   // Update sandbox config when global defaults load (only if no custom config)
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!hasCustomConfig && globalDefaults && !isLoadingDefaults) {
       setSandboxConfig((prev) => ({
         ...prev,

--- a/src/app/components/features/session-history/components/session-timeline.tsx
+++ b/src/app/components/features/session-history/components/session-timeline.tsx
@@ -1,6 +1,8 @@
 import { CheckCircle, Clock, MagnifyingGlass, X } from '@phosphor-icons/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Skeleton, SkeletonText } from '@/app/components/ui/skeleton';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import type { SessionTimelineProps } from '../types';
 import { SessionCard } from './session-card';
@@ -34,8 +36,7 @@ function ProjectSearch({
   }, [projects, searchQuery]);
 
   const filteredProjectsLength = filteredProjects.length;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset when length changes
-  useEffect(() => {
+  useWatchEffect(() => {
     setHighlightedIndex(0);
   }, [filteredProjectsLength]);
 
@@ -75,7 +76,7 @@ function ProjectSearch({
     }
   };
 
-  useEffect(() => {
+  useMountEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (
         inputRef.current &&
@@ -89,7 +90,7 @@ function ProjectSearch({
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  });
 
   return (
     <div className="relative">

--- a/src/app/components/features/session-history/components/stream-viewer.tsx
+++ b/src/app/components/features/session-history/components/stream-viewer.tsx
@@ -1,6 +1,7 @@
 import { CaretDown, CaretRight, Gear } from '@phosphor-icons/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Skeleton, SkeletonText } from '@/app/components/ui/skeleton';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import type { StreamViewerProps } from '../types';
 import { StreamEntry } from './stream-entry';
@@ -29,7 +30,7 @@ export function StreamViewer({
   }, [entries]);
 
   // Scroll to current entry when it changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (currentEntryId && currentEntryRef.current) {
       currentEntryRef.current.scrollIntoView({
         behavior: 'smooth',

--- a/src/app/components/features/session-history/hooks/use-session-events.ts
+++ b/src/app/components/features/session-history/hooks/use-session-events.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import type {
   SessionDetail,
@@ -131,7 +132,7 @@ export function useSessions(projectId: string, filters?: SessionFilters, sort?: 
     }
   }, [projectId, filters, sort]);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     void fetchSessions();
   }, [fetchSessions]);
 
@@ -252,7 +253,7 @@ export function useSessionDetail(sessionId: string | null): UseSessionDetailRetu
     }
   }, [sessionId]);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     void fetchDetail();
   }, [fetchDetail]);
 

--- a/src/app/components/features/session-history/hooks/use-session-replay.ts
+++ b/src/app/components/features/session-history/hooks/use-session-replay.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { SessionEvent } from '@/services/session.service';
 
 export type ReplaySpeed = 1 | 2 | 4;
@@ -94,17 +96,9 @@ export function useSessionReplay({
   const isPlayingRef = useRef(isPlaying);
 
   // Keep refs in sync with state
-  useEffect(() => {
-    speedRef.current = speed;
-  }, [speed]);
-
-  useEffect(() => {
-    totalDurationRef.current = totalDuration;
-  }, [totalDuration]);
-
-  useEffect(() => {
-    isPlayingRef.current = isPlaying;
-  }, [isPlaying]);
+  speedRef.current = speed;
+  totalDurationRef.current = totalDuration;
+  isPlayingRef.current = isPlaying;
 
   // Compute the start time from the first event
   const startTime = useMemo(() => {
@@ -230,7 +224,7 @@ export function useSessionReplay({
   }, [totalDuration, pause]);
 
   // Handle playing state changes - stable animate callback means this only re-runs on isPlaying change
-  useEffect(() => {
+  useWatchEffect(() => {
     if (isPlaying) {
       lastFrameTimeRef.current = 0;
       animationFrameRef.current = requestAnimationFrame(animate);
@@ -245,13 +239,13 @@ export function useSessionReplay({
   }, [isPlaying, animate]);
 
   // Cleanup on unmount
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
-  }, []);
+  });
 
   return {
     isPlaying,

--- a/src/app/components/features/settings-sidebar.tsx
+++ b/src/app/components/features/settings-sidebar.tsx
@@ -13,7 +13,8 @@ import {
   Terminal,
 } from '@phosphor-icons/react';
 import { Link, useRouterState } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 
 type SettingsNavItem = {
@@ -35,7 +36,7 @@ function useSettingsSections(): SettingsSection[] {
   const [githubConnected, setGithubConnected] = useState(false);
   const [hasApiKey, setHasApiKey] = useState(false);
 
-  useEffect(() => {
+  useMountEffect(() => {
     // Check GitHub connection status via API
     const checkGitHub = async () => {
       const result = await apiClient.github.getTokenInfo();
@@ -49,7 +50,7 @@ function useSettingsSections(): SettingsSection[] {
       setHasApiKey(result.ok && result.data.keyInfo !== null);
     };
     checkAnthropicKey();
-  }, []);
+  });
 
   return [
     {

--- a/src/app/components/features/sidebar.tsx
+++ b/src/app/components/features/sidebar.tsx
@@ -17,7 +17,8 @@ import {
   TreeStructure,
 } from '@phosphor-icons/react';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { useProjectContext } from '@/app/providers/project-context';
 import { apiClient } from '@/lib/api/client';
 
@@ -99,17 +100,17 @@ export function Sidebar({ projectId: _projectId }: SidebarProps): React.JSX.Elem
   }, [currentProject, navigate]);
 
   // Cleanup timeout on unmount
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (clickTimeoutRef.current) {
         clearTimeout(clickTimeoutRef.current);
       }
     };
-  }, []);
+  });
 
   // FC-011: Check system health periodically -- compare values before setState
   // to avoid unnecessary re-renders every 30 seconds.
-  useEffect(() => {
+  useMountEffect(() => {
     const checkHealth = async () => {
       const result = await apiClient.system.health();
       const nextHealthy = result.ok && result.data.status === 'healthy';
@@ -122,7 +123,7 @@ export function Sidebar({ projectId: _projectId }: SidebarProps): React.JSX.Elem
     checkHealth();
     const interval = setInterval(checkHealth, 30000); // Check every 30 seconds
     return () => clearInterval(interval);
-  }, []);
+  });
 
   // Admin nav items
   const adminNavItems: NavItem[] = [

--- a/src/app/components/features/task-detail-dialog/index.tsx
+++ b/src/app/components/features/task-detail-dialog/index.tsx
@@ -1,8 +1,9 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { useCallback, useMemo, useReducer, useRef, useState } from 'react';
 import { ContainerAgentPanel } from '@/app/components/features/container-agent-panel';
 import { PlanSessionView } from '@/app/components/features/plan-session-view';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Task, TaskColumn, Worktree } from '@/db/schema';
 import { cn } from '@/lib/utils/cn';
 import { TaskActions } from './task-actions';
@@ -42,7 +43,7 @@ function useDraggable() {
     e.preventDefault();
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!isDragging) return;
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -175,7 +176,7 @@ export function TaskDetailDialog({
   const { elementRef, isDragging, handleMouseDown, reset: resetPosition } = useDraggable();
 
   // Reset state when task changes or dialog closes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!open || !task) {
       setPendingChanges({});
       dispatch({ type: 'CANCEL_EDIT' });
@@ -237,7 +238,7 @@ export function TaskDetailDialog({
   handleSaveRef.current = handleSave;
 
   // Keyboard shortcuts
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!open) return;
 
     function handleKeyDown(e: KeyboardEvent) {

--- a/src/app/components/features/task-detail-dialog/use-task-activity.ts
+++ b/src/app/components/features/task-detail-dialog/use-task-activity.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Task } from '@/db/schema';
 import { apiClient } from '@/lib/api/client';
 import { type SessionCallbacks, type Subscription, subscribeToSession } from '@/lib/streams/client';
@@ -232,7 +233,7 @@ export function useTaskActivity(task: Task | null): {
   const subscriptionRef = useRef<Subscription | null>(null);
 
   // Fetch historical events
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!task?.sessionId) {
       setFetchedActivities([]);
       setIsLoading(false);
@@ -281,7 +282,7 @@ export function useTaskActivity(task: Task | null): {
   }, [task?.sessionId]);
 
   // Subscribe to SSE for in_progress tasks
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!task?.sessionId || task.column !== 'in_progress') {
       subscriptionRef.current?.unsubscribe();
       subscriptionRef.current = null;

--- a/src/app/components/features/terraform/terraform-chat-panel.tsx
+++ b/src/app/components/features/terraform/terraform-chat-panel.tsx
@@ -15,7 +15,9 @@ import {
   TreeStructure,
   WarningCircle,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type {
   ClarifyingQuestion,
   ComposeMessage,
@@ -619,15 +621,14 @@ export function TerraformChatPanel(): React.JSX.Element {
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // Auto-scroll to bottom when messages or compose stage change
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll must trigger on message/stage changes
-  useEffect(() => {
+  useWatchEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, composeStage, composeComplete, matchedModules]);
 
   // Auto-focus input
-  useEffect(() => {
+  useMountEffect(() => {
     inputRef.current?.focus();
-  }, []);
+  });
 
   const handleSubmit = useCallback(async () => {
     const trimmed = input.trim();

--- a/src/app/components/features/terraform/terraform-context.tsx
+++ b/src/app/components/features/terraform/terraform-context.tsx
@@ -1,14 +1,7 @@
 import { stream as durableStream } from '@durable-streams/client';
 import type React from 'react';
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 import type {
   ClarifyingQuestion,
@@ -221,11 +214,11 @@ export function TerraformProvider({ children }: { children: React.ReactNode }): 
   messagesRef.current = messages;
   composeModeRef.current = composeMode;
 
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       isMountedRef.current = false;
     };
-  }, []);
+  });
 
   const loadRegistries = useCallback(async () => {
     try {
@@ -258,10 +251,10 @@ export function TerraformProvider({ children }: { children: React.ReactNode }): 
   }, []);
 
   // Load registries and modules on mount
-  useEffect(() => {
+  useMountEffect(() => {
     void loadRegistries();
     void loadModules();
-  }, [loadRegistries, loadModules]);
+  });
 
   const refreshModules = useCallback(async () => {
     await Promise.all([loadModules(), loadRegistries()]);

--- a/src/app/components/features/terraform/terraform-dependency-diagram.tsx
+++ b/src/app/components/features/terraform/terraform-dependency-diagram.tsx
@@ -7,7 +7,8 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import type { ElkNode } from 'elkjs/lib/elk.bundled.js';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { parseHclDependencies, type TerraformGraph } from '@/lib/terraform/parse-hcl-dependencies';
 import { parseStacksDependencies } from '@/lib/terraform/parse-stacks-dependencies';
 import { getElk } from '@/lib/workflow-dsl/layout';
@@ -162,7 +163,7 @@ function DiagramInner(): React.JSX.Element {
     }
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!graph || graph.nodes.length === 0) {
       setNodes([]);
       setEdges([]);

--- a/src/app/components/features/terraform/terraform-module-detail.tsx
+++ b/src/app/components/features/terraform/terraform-module-detail.tsx
@@ -9,8 +9,9 @@ import {
 } from '@phosphor-icons/react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { TerraformOutput, TerraformVariable } from '@/db/schema';
 import { apiClient } from '@/lib/api/client';
 import { PROVIDER_COLORS, type TerraformModuleView } from '@/lib/terraform/types';
@@ -368,7 +369,7 @@ export function TerraformModuleDetail({ moduleId }: { moduleId: string }): React
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<DetailTab>('overview');
 
-  useEffect(() => {
+  useWatchEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);

--- a/src/app/components/features/terraform/terraform-right-panel.tsx
+++ b/src/app/components/features/terraform/terraform-right-panel.tsx
@@ -1,6 +1,7 @@
 import { Code, Copy, DownloadSimple, FileCode, GitBranch, Sliders } from '@phosphor-icons/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/ui/tabs';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { parseHclVariables } from '@/lib/terraform/parse-hcl-variables';
 import { cn } from '@/lib/utils/cn';
 import { useTerraform } from './terraform-context';
@@ -132,7 +133,7 @@ const shikiPromise = import('shiki');
 function useHighlightedCode(code: string | null): string | null {
   const [html, setHtml] = useState<string | null>(null);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!code) {
       setHtml(null);
       return;

--- a/src/app/components/features/terraform/terraform-settings-panel.tsx
+++ b/src/app/components/features/terraform/terraform-settings-panel.tsx
@@ -1,6 +1,7 @@
 import { ArrowsClockwise, Eye, EyeSlash, Plus, Trash, WarningCircle } from '@phosphor-icons/react';
 import { useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import { useTerraform } from './terraform-context';
 import { formatTimeAgo } from './terraform-utils';
@@ -43,7 +44,7 @@ export function TerraformSettingsPanel(): React.JSX.Element {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [hasToken, setHasToken] = useState(false);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!registry) {
       setOrgName('');
       setSyncInterval(30);

--- a/src/app/components/features/theme-toggle.tsx
+++ b/src/app/components/features/theme-toggle.tsx
@@ -1,5 +1,8 @@
 import { Laptop, Moon, Sun } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useEventListener } from '@/app/hooks/use-event-listener';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 
 export type ThemeMode = 'light' | 'dark' | 'system';
@@ -12,27 +15,20 @@ export function ThemeToggle({ className }: ThemeToggleProps): React.JSX.Element 
   const [theme, setTheme] = useState<ThemeMode>('system');
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
+  useMountEffect(() => {
     const stored = window.localStorage.getItem('theme') as ThemeMode | null;
     if (stored) {
       setTheme(stored);
     }
-  }, []);
+  });
 
-  useEffect(() => {
-    if (!open) return;
+  useEventListener(open ? window : null, 'keydown', (event) => {
+    if (event.key === 'Escape') {
+      setOpen(false);
+    }
+  });
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setOpen(false);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [open]);
-
-  useEffect(() => {
+  useWatchEffect(() => {
     const root = document.documentElement;
     window.localStorage.setItem('theme', theme);
 

--- a/src/app/components/features/workflow-designer/NodeInspector.tsx
+++ b/src/app/components/features/workflow-designer/NodeInspector.tsx
@@ -1,8 +1,9 @@
 import { Trash, Warning } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { TextInput } from '@/app/components/ui/text-input';
 import { Textarea } from '@/app/components/ui/textarea';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import type { WorkflowNode } from '@/lib/workflow-dsl/types';
 
@@ -62,7 +63,7 @@ export function NodeInspector({
 
   // Reset delete confirmation when node changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: We want to reset state when the selected node changes
-  useEffect(() => {
+  useWatchEffect(() => {
     setShowDeleteConfirm(false);
   }, [node?.id]);
 

--- a/src/app/components/features/workflow-designer/SaveWorkflowDialog.tsx
+++ b/src/app/components/features/workflow-designer/SaveWorkflowDialog.tsx
@@ -1,5 +1,5 @@
 import { FloppyDisk, Spinner, WarningCircle, X } from '@phosphor-icons/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import {
   Dialog,
@@ -18,6 +18,7 @@ import {
 } from '@/app/components/ui/select';
 import { TextInput } from '@/app/components/ui/text-input';
 import { Textarea } from '@/app/components/ui/textarea';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Workflow, WorkflowStatus } from '@/db/schema';
 import { cn } from '@/lib/utils/cn';
 
@@ -175,7 +176,7 @@ export function SaveWorkflowDialog({
   const canSubmit = name.trim() && !isSaving;
 
   // Reset form when dialog opens with new workflow data
-  useEffect(() => {
+  useWatchEffect(() => {
     if (open) {
       setName(workflow.name ?? '');
       setDescription(workflow.description ?? '');

--- a/src/app/components/features/workflow-designer/index.tsx
+++ b/src/app/components/features/workflow-designer/index.tsx
@@ -1,6 +1,8 @@
 import { CaretLeft, Warning } from '@phosphor-icons/react';
 import { type Edge, type Node, useEdgesState, useNodesState, type Viewport } from '@xyflow/react';
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import '@xyflow/react/dist/style.css';
 
 import type { Workflow } from '@/db/schema';
@@ -245,7 +247,7 @@ export function WorkflowDesigner({
   const [templates, setTemplates] = useState<TemplateWithContent[]>([]);
 
   // Fetch org templates on mount (for AI generation)
-  useEffect(() => {
+  useMountEffect(() => {
     async function fetchTemplates() {
       try {
         const response = await fetch('/api/templates?scope=org');
@@ -260,10 +262,10 @@ export function WorkflowDesigner({
     }
 
     fetchTemplates();
-  }, []);
+  });
 
   // Fetch saved workflows on mount
-  useEffect(() => {
+  useMountEffect(() => {
     async function fetchWorkflows() {
       try {
         const response = await fetch('/api/workflows');
@@ -289,11 +291,11 @@ export function WorkflowDesigner({
     }
 
     fetchWorkflows();
-  }, []);
+  });
 
   // Increment change counter whenever nodes or edges change
   // biome-ignore lint/correctness/useExhaustiveDependencies: counter must increment on node/edge changes
-  useEffect(() => {
+  useWatchEffect(() => {
     changeCounterRef.current += 1;
   }, [nodes, edges]);
 
@@ -329,7 +331,7 @@ export function WorkflowDesigner({
       setWorkflowName(sourceName);
       setWorkflowDescription(description ?? '');
       setActiveWorkflowId(null); // This is a new workflow, not an update
-      // The change counter will increment via the useEffect watching [nodes, edges]
+      // The change counter will increment via the useWatchEffect watching [nodes, edges]
     },
     [setNodes, setEdges]
   );
@@ -441,7 +443,7 @@ export function WorkflowDesigner({
     setWorkflowDescription('');
     // Sync counters so hasUnsavedChanges becomes false after next render
     savedCounterRef.current = changeCounterRef.current + 1;
-    // The +1 accounts for the upcoming useEffect increment from setNodes/setEdges
+    // The +1 accounts for the upcoming useWatchEffect increment from setNodes/setEdges
   }, [readOnly, setNodes, setEdges]);
 
   // Select a saved workflow to load

--- a/src/app/components/features/worktree-management/hooks/use-keyboard-shortcuts.ts
+++ b/src/app/components/features/worktree-management/hooks/use-keyboard-shortcuts.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { WorktreeListItem } from '../types';
 
 interface UseKeyboardShortcutsOptions {
@@ -40,7 +41,7 @@ export function useKeyboardShortcuts({
   const isKeyboardNavigationRef = useRef(false);
 
   // Update selected index when external selectedId changes (not from keyboard)
-  useEffect(() => {
+  useWatchEffect(() => {
     // Skip if this update was triggered by keyboard navigation
     if (isKeyboardNavigationRef.current) {
       isKeyboardNavigationRef.current = false;
@@ -58,7 +59,7 @@ export function useKeyboardShortcuts({
     return worktrees[selectedIndex];
   }, [worktrees, selectedIndex]);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!enabled || worktrees.length === 0) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -139,7 +140,7 @@ export function useKeyboardShortcuts({
   }, [enabled, worktrees, getSelectedWorktree, onSelect, onOpen, onMerge, onRemove]);
 
   // Notify parent when selection changes via keyboard
-  useEffect(() => {
+  useWatchEffect(() => {
     const selected = worktrees[selectedIndex];
     if (selected && selected.id !== selectedId) {
       onSelect(selected);

--- a/src/app/components/features/worktree-management/hooks/use-worktrees.ts
+++ b/src/app/components/features/worktree-management/hooks/use-worktrees.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import { AUTO_REFRESH_INTERVAL_MS } from '../constants';
 import type { GitDiff, WorktreeListItem } from '../types';
@@ -57,12 +58,12 @@ export function useWorktrees(projectId: string): UseWorktreesReturn {
   );
 
   // Initial fetch
-  useEffect(() => {
+  useWatchEffect(() => {
     void fetchWorktrees();
   }, [fetchWorktrees]);
 
   // Auto-refresh (silent, doesn't clear error or show loading)
-  useEffect(() => {
+  useWatchEffect(() => {
     const interval = setInterval(() => {
       void fetchWorktrees(true);
     }, AUTO_REFRESH_INTERVAL_MS);
@@ -121,7 +122,7 @@ export function useWorktreeDiff(worktreeId: string | null): UseWorktreeDiffRetur
     }
   }, [worktreeId]);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     void fetchDiff();
   }, [fetchDiff]);
 

--- a/src/app/components/features/worktree-management/worktree-management.tsx
+++ b/src/app/components/features/worktree-management/worktree-management.tsx
@@ -6,9 +6,10 @@ import {
   GitFork,
   GitPullRequest,
 } from '@phosphor-icons/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { Skeleton } from '@/app/components/ui/skeleton';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import { CommitDialog } from './dialogs/commit-dialog';
 import { MergeDialog } from './dialogs/merge-dialog';
@@ -243,7 +244,7 @@ function ContextMenu({
   onClose: () => void;
   actions: { label: string; onClick: () => void; danger?: boolean }[];
 }) {
-  useEffect(() => {
+  useWatchEffect(() => {
     const handleClick = () => onClose();
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();

--- a/src/app/components/ui/toast.tsx
+++ b/src/app/components/ui/toast.tsx
@@ -1,7 +1,8 @@
 import { CheckCircle, CircleNotch, Info, Warning, WarningCircle, X } from '@phosphor-icons/react';
 import * as ToastPrimitive from '@radix-ui/react-toast';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useRef, useState, useSyncExternalStore } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 
 // =============================================================================
@@ -223,7 +224,7 @@ function useToastProgress(duration: number, onComplete: () => void) {
   const startTimeRef = useRef<number>(Date.now());
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (duration === 0 || isPaused) return;
 
     startTimeRef.current = Date.now();

--- a/src/app/hooks/AGENTS.md
+++ b/src/app/hooks/AGENTS.md
@@ -1,0 +1,45 @@
+# Hooks — useEffect Ban
+
+Direct `useEffect` is banned in this codebase. Biome enforces this via `noRestrictedImports`.
+
+## Decision Tree
+
+Need an effect? Ask:
+
+1. **Fetching data on route load?** Use a TanStack Router `loader` function
+2. **One-time setup on mount?** `useMountEffect(effect)` — runs once, supports cleanup
+3. **Re-run when deps change?** `useWatchEffect(effect, deps)` — controlled re-execution
+4. **Polling or heartbeat?** `useInterval(callback, delayMs)` — pass `null` to pause
+5. **Delayed action (auto-dismiss)?** `useTimeout(callback, delayMs)` — returns `reset`/`clear`
+6. **DOM event listener?** `useEventListener(target, event, handler, options)`
+7. **Auto-scroll to bottom?** `useAutoScroll()` — returns `containerRef`, `handleScroll`, `scrollToBottom`, `showScrollButton`
+8. **Copy to clipboard with indicator?** `useCopyToClipboard(resetMs?)` — returns `{ copied, copy }`
+9. **Sync with localStorage?** `useLocalStorage(key, initialValue)` — returns `[value, setValue]`
+10. **Keep a callback ref fresh?** `useEffectEvent(callback)` from React 19 — no effect needed
+11. **None of the above?** Create a new factory hook in this directory. Only factory hooks may import `useEffect`.
+
+## Factory Hooks
+
+All factory hooks live in `src/app/hooks/` and are re-exported from `use-effect-factories.ts`.
+
+| Hook | File | Import `useEffect`? |
+|------|------|-------------------|
+| `useMountEffect` | `use-mount-effect.ts` | Yes |
+| `useWatchEffect` | `use-watch-effect.ts` | Yes |
+| `useInterval` | `use-interval.ts` | Yes |
+| `useTimeout` | `use-timeout.ts` | Yes |
+| `useEventListener` | `use-event-listener.ts` | Yes |
+| `useAutoScroll` | `use-auto-scroll.ts` | Yes |
+| `useCopyToClipboard` | `use-copy-to-clipboard.ts` | No (uses `useTimeout`) |
+| `useLocalStorage` | `use-local-storage.ts` | No (uses `useMountEffect`) |
+
+## Adding a New Factory Hook
+
+1. Create `src/app/hooks/use-your-hook.ts`
+2. Add `// biome-ignore lint/style/noRestrictedImports: factory hook` before the `useEffect` import
+3. Add the file to the Biome override in `biome.json` (the factory hooks override block)
+4. Export from `use-effect-factories.ts`
+
+## Why
+
+Direct `useEffect` causes: brittle dependency arrays, infinite loops, hidden coupling, and hard-to-trace execution order. Factory hooks make the intent explicit and the cleanup automatic.

--- a/src/app/hooks/use-agent-stream.ts
+++ b/src/app/hooks/use-agent-stream.ts
@@ -1,8 +1,9 @@
 /**
  * FC-006: Updated to use useSessionSubscription for shared SSE connections.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffectEvent, useMemo, useRef, useState } from 'react';
 import type { ConnectionState, SessionAgentState, SessionCallbacks } from '@/lib/streams/client';
+import { useMountEffect } from './use-mount-effect';
 import { useSessionSubscription } from './use-session-subscription';
 
 export type AgentStreamChunk = {
@@ -37,8 +38,9 @@ export function useAgentStream(sessionId: string): {
   // Build callbacks for the shared subscription
   const callbacks = useRef<SessionCallbacks>({});
 
-  useEffect(() => {
-    callbacks.current = {
+  // useEffectEvent captures the latest setters without needing deps
+  const buildCallbacks = useEffectEvent(
+    (): SessionCallbacks => ({
       onChunk: (event) => {
         setChunks((prev) => [
           ...prev,
@@ -91,8 +93,12 @@ export function useAgentStream(sessionId: string): {
       onDisconnect: () => {
         console.log('[useAgentStream] Disconnected from stream');
       },
-    };
-  }, []);
+    })
+  );
+
+  useMountEffect(() => {
+    callbacks.current = buildCallbacks();
+  });
 
   const { connectionState } = useSessionSubscription(sessionId, callbacks.current);
 

--- a/src/app/hooks/use-auto-scroll.ts
+++ b/src/app/hooks/use-auto-scroll.ts
@@ -1,0 +1,58 @@
+// biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseAutoScrollReturn {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  scrollToBottom: () => void;
+  showScrollButton: boolean;
+  handleScroll: () => void;
+}
+
+/**
+ * Auto-scroll to bottom when content changes, with user-scroll detection.
+ * When the user scrolls up, auto-scroll pauses and a "scroll to bottom" button appears.
+ * Scrolling back to the bottom re-enables auto-scroll.
+ */
+export function useAutoScroll(): UseAutoScrollReturn {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const autoScrollRef = useRef(true);
+  const userScrolledRef = useRef(false);
+  const [showScrollButton, setShowScrollButton] = useState(false);
+
+  // Auto-scroll on every render when pinned to bottom
+  useEffect(() => {
+    if (autoScrollRef.current && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  });
+
+  const handleScroll = useCallback(() => {
+    if (!containerRef.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
+
+    if (!isAtBottom && !userScrolledRef.current) {
+      userScrolledRef.current = true;
+      autoScrollRef.current = false;
+      setShowScrollButton(true);
+    }
+
+    if (isAtBottom && userScrolledRef.current) {
+      userScrolledRef.current = false;
+      autoScrollRef.current = true;
+      setShowScrollButton(false);
+    }
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      autoScrollRef.current = true;
+      userScrolledRef.current = false;
+      setShowScrollButton(false);
+    }
+  }, []);
+
+  return { containerRef, scrollToBottom, showScrollButton, handleScroll };
+}

--- a/src/app/hooks/use-container-agent-statuses.ts
+++ b/src/app/hooks/use-container-agent-statuses.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   type ContainerAgentStarted,
   type ContainerAgentStatus,
@@ -6,6 +6,7 @@ import {
   type Subscription,
   subscribeToSession,
 } from '@/lib/streams/client';
+import { useWatchEffect } from './use-watch-effect';
 
 /**
  * Tracked status for a single agent session
@@ -118,7 +119,7 @@ export function useContainerAgentStatuses(
   sessionsRef.current = sessions;
 
   // Manage subscriptions — sessionsKey drives re-evaluation when sessions change
-  useEffect(() => {
+  useWatchEffect(() => {
     // Reference sessionsKey so the linter sees it's used (it triggers this effect)
     void sessionsKey;
     const currentSessions = sessionsRef.current;

--- a/src/app/hooks/use-container-agent.ts
+++ b/src/app/hooks/use-container-agent.ts
@@ -2,7 +2,7 @@
  * FC-005: Refactored from useState to useReducer with discriminated union actions.
  * FC-006: Uses useSessionSubscription for shared SSE connection.
  */
-import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { useCallback, useEffectEvent, useReducer, useRef } from 'react';
 import type {
   ConnectionState,
   ContainerAgentComplete,
@@ -18,7 +18,9 @@ import type {
   ContainerAgentWorktree,
   SessionCallbacks,
 } from '@/lib/streams/client';
+import { useMountEffect } from './use-mount-effect';
 import { useSessionSubscription } from './use-session-subscription';
+import { useWatchEffect } from './use-watch-effect';
 
 /**
  * Container agent startup stage
@@ -383,13 +385,15 @@ export function useContainerAgent(sessionId: string | null): {
     };
   }, []);
 
-  // Keep callbacks ref in sync
-  useEffect(() => {
-    callbacks.current = buildCallbacks();
-  }, [buildCallbacks]);
+  // Keep callbacks ref in sync — useEffectEvent always sees the latest buildCallbacks
+  const stableBuild = useEffectEvent(() => buildCallbacks());
+
+  useMountEffect(() => {
+    callbacks.current = stableBuild();
+  });
 
   // Reset state when sessionId changes to null
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!sessionId) {
       dispatch({ type: 'RESET' });
     }

--- a/src/app/hooks/use-copy-to-clipboard.ts
+++ b/src/app/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react';
+import { useTimeout } from './use-timeout';
+
+/**
+ * Copy text to clipboard with a timed "copied" indicator.
+ * `copied` resets to false after 2 seconds automatically.
+ */
+export function useCopyToClipboard(resetMs = 2000): {
+  copied: boolean;
+  copy: (text: string) => Promise<void>;
+} {
+  const [copied, setCopied] = useState(false);
+
+  useTimeout(() => setCopied(false), copied ? resetMs : null);
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      setCopied(true);
+    }
+  }, []);
+
+  return { copied, copy };
+}

--- a/src/app/hooks/use-effect-factories.ts
+++ b/src/app/hooks/use-effect-factories.ts
@@ -1,0 +1,8 @@
+export { useAutoScroll } from './use-auto-scroll';
+export { useCopyToClipboard } from './use-copy-to-clipboard';
+export { useEventListener } from './use-event-listener';
+export { useInterval } from './use-interval';
+export { useLocalStorage } from './use-local-storage';
+export { useMountEffect } from './use-mount-effect';
+export { useTimeout } from './use-timeout';
+export { useWatchEffect } from './use-watch-effect';

--- a/src/app/hooks/use-event-listener.ts
+++ b/src/app/hooks/use-event-listener.ts
@@ -1,14 +1,14 @@
 // biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
 import { useEffect, useRef } from 'react';
 
-type EventTarget = Window | Document | HTMLElement | null;
+type ListenerTarget = Window | Document | Element | null;
 
 /**
  * Attaches an event listener with automatic cleanup.
  * The handler always uses the latest closure (no stale values).
  */
 export function useEventListener<K extends keyof WindowEventMap>(
-  target: EventTarget,
+  target: ListenerTarget,
   event: K,
   handler: (event: WindowEventMap[K]) => void,
   options?: boolean | AddEventListenerOptions

--- a/src/app/hooks/use-event-listener.ts
+++ b/src/app/hooks/use-event-listener.ts
@@ -1,0 +1,27 @@
+// biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
+import { useEffect, useRef } from 'react';
+
+type EventTarget = Window | Document | HTMLElement | null;
+
+/**
+ * Attaches an event listener with automatic cleanup.
+ * The handler always uses the latest closure (no stale values).
+ */
+export function useEventListener<K extends keyof WindowEventMap>(
+  target: EventTarget,
+  event: K,
+  handler: (event: WindowEventMap[K]) => void,
+  options?: boolean | AddEventListenerOptions
+): void {
+  const savedHandler = useRef(handler);
+  savedHandler.current = handler;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: target, event, and options are the reactive deps
+  useEffect(() => {
+    if (!target) return;
+
+    const listener = (e: Event) => savedHandler.current(e as WindowEventMap[K]);
+    target.addEventListener(event, listener, options);
+    return () => target.removeEventListener(event, listener, options);
+  }, [target, event, options]);
+}

--- a/src/app/hooks/use-interval.ts
+++ b/src/app/hooks/use-interval.ts
@@ -1,0 +1,21 @@
+// biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
+import { useEffect, useRef } from 'react';
+
+/**
+ * Runs a callback on a recurring interval. Pass `null` as delay to pause.
+ * The callback is always called with the latest closure (no stale values).
+ */
+export function useInterval(callback: () => void, delayMs: number | null): void {
+  const savedCallback = useRef(callback);
+
+  // Always keep the ref pointing at the latest callback
+  savedCallback.current = callback;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: delay is the only reactive dep
+  useEffect(() => {
+    if (delayMs === null) return;
+
+    const id = window.setInterval(() => savedCallback.current(), delayMs);
+    return () => window.clearInterval(id);
+  }, [delayMs]);
+}

--- a/src/app/hooks/use-keyboard-shortcuts.ts
+++ b/src/app/hooks/use-keyboard-shortcuts.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
+import { useEventListener } from './use-event-listener';
+import { useWatchEffect } from './use-watch-effect';
 
 // =============================================================================
 // Types
@@ -209,7 +211,7 @@ function matchesShortcut(event: KeyboardEvent, shortcut: Shortcut): boolean {
 export function useKeyboardShortcuts(shortcuts: Shortcut[], context: ShortcutsContextValue): void {
   const { registerShortcut, isEnabled } = context;
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!isEnabled) return;
 
     // Register all shortcuts and collect unregister functions
@@ -261,8 +263,5 @@ export function useGlobalKeyboardHandler(getShortcuts: () => Shortcut[], isEnabl
     [getShortcuts, isEnabled]
   );
 
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown, true);
-    return () => window.removeEventListener('keydown', handleKeyDown, true);
-  }, [handleKeyDown]);
+  useEventListener(typeof window !== 'undefined' ? window : null, 'keydown', handleKeyDown, true);
 }

--- a/src/app/hooks/use-local-storage.ts
+++ b/src/app/hooks/use-local-storage.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+import { useMountEffect } from './use-mount-effect';
+
+/**
+ * Sync a value with localStorage. Reads stored value on mount,
+ * writes to localStorage on every update.
+ */
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
+
+  // Hydrate from localStorage on mount (avoids SSR mismatch)
+  useMountEffect(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item !== null) {
+        setStoredValue(JSON.parse(item) as T);
+      }
+    } catch (error) {
+      console.warn(`[useLocalStorage] Failed to read key "${key}":`, error);
+    }
+  });
+
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      setStoredValue((prev) => {
+        const nextValue = value instanceof Function ? value(prev) : value;
+        try {
+          window.localStorage.setItem(key, JSON.stringify(nextValue));
+        } catch (error) {
+          console.warn(`[useLocalStorage] Failed to write key "${key}":`, error);
+        }
+        return nextValue;
+      });
+    },
+    [key]
+  );
+
+  return [storedValue, setValue];
+}

--- a/src/app/hooks/use-mount-effect.ts
+++ b/src/app/hooks/use-mount-effect.ts
@@ -1,0 +1,11 @@
+// biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
+import { useEffect } from 'react';
+
+/**
+ * Runs an effect exactly once on mount. For syncing with external systems.
+ * This is the only sanctioned way to run a mount-only effect.
+ */
+export function useMountEffect(effect: () => void | (() => void)): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only by design
+  useEffect(effect, []);
+}

--- a/src/app/hooks/use-presence.ts
+++ b/src/app/hooks/use-presence.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useWatchEffect } from './use-watch-effect';
 
 export type PresenceUser = {
   userId: string;
@@ -15,7 +16,8 @@ export function usePresence(
 } {
   const [users, setUsers] = useState<PresenceUser[]>([]);
 
-  useEffect(() => {
+  // Fetch + poll presence, restarting when sessionId changes
+  useWatchEffect(() => {
     let mounted = true;
 
     const refresh = async () => {

--- a/src/app/hooks/use-sandbox-status.ts
+++ b/src/app/hooks/use-sandbox-status.ts
@@ -1,5 +1,4 @@
 import { eq } from '@tanstack/db';
-import { useEffect } from 'react';
 import { useCollectionQuery } from '@/lib/db/use-collection-query';
 import {
   refreshSandboxStatus,
@@ -8,6 +7,7 @@ import {
   startSandboxStatusSync,
   stopSandboxStatusSync,
 } from '@/lib/sandbox-status';
+import { useWatchEffect } from './use-watch-effect';
 
 export type { SandboxStatus };
 
@@ -33,7 +33,7 @@ export function useSandboxStatus(projectId: string): {
   );
 
   // Start/stop sync when projectId changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!projectId) return;
 
     startSandboxStatusSync(projectId);

--- a/src/app/hooks/use-session-subscription.ts
+++ b/src/app/hooks/use-session-subscription.ts
@@ -7,13 +7,14 @@
  *
  * Consumers: use-session.ts, use-agent-stream.ts, use-container-agent.ts
  */
-import { useEffect, useRef, useState } from 'react';
+import { useEffectEvent, useRef, useState } from 'react';
 import {
   type ConnectionState,
   type SessionCallbacks,
   type Subscription,
   subscribeToSession,
 } from '@/lib/streams/client';
+import { useWatchEffect } from './use-watch-effect';
 
 /**
  * Subscribe to a session's SSE stream with automatic ref-counting.
@@ -32,14 +33,11 @@ export function useSessionSubscription(
 ): { connectionState: ConnectionState } {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
   const subscriptionRef = useRef<Subscription | null>(null);
-  const callbacksRef = useRef<SessionCallbacks>(callbacks);
 
-  // Keep callbacks ref up-to-date without re-subscribing
-  useEffect(() => {
-    callbacksRef.current = callbacks;
-  });
+  // useEffectEvent always sees the latest callbacks without re-subscribing
+  const getCallbacks = useEffectEvent(() => callbacks);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!sessionId) {
       setConnectionState('disconnected');
       return;
@@ -47,7 +45,7 @@ export function useSessionSubscription(
 
     setConnectionState('connecting');
 
-    // Wrap callbacks to always use the latest ref
+    // Wrap callbacks to always use the latest ref via useEffectEvent
     const proxiedCallbacks: SessionCallbacks = {};
     const keys: Array<keyof SessionCallbacks> = [
       'onChunk',
@@ -76,7 +74,7 @@ export function useSessionSubscription(
     for (const key of keys) {
       // biome-ignore lint/suspicious/noExplicitAny: generic callback proxy
       (proxiedCallbacks as any)[key] = (event: any) => {
-        const cb = callbacksRef.current[key];
+        const cb = getCallbacks()[key];
         if (cb) {
           // biome-ignore lint/suspicious/noExplicitAny: generic callback proxy
           (cb as any)(event);
@@ -86,17 +84,17 @@ export function useSessionSubscription(
 
     // Add connection lifecycle callbacks
     proxiedCallbacks.onError = (error) => {
-      callbacksRef.current.onError?.(error);
+      getCallbacks().onError?.(error);
     };
     proxiedCallbacks.onConnectionStateChange = (nextState) => {
       setConnectionState(nextState);
-      callbacksRef.current.onConnectionStateChange?.(nextState);
+      getCallbacks().onConnectionStateChange?.(nextState);
     };
     proxiedCallbacks.onReconnect = () => {
-      callbacksRef.current.onReconnect?.();
+      getCallbacks().onReconnect?.();
     };
     proxiedCallbacks.onDisconnect = () => {
-      callbacksRef.current.onDisconnect?.();
+      getCallbacks().onDisconnect?.();
     };
 
     const subscription = subscribeToSession(sessionId, proxiedCallbacks);

--- a/src/app/hooks/use-session.ts
+++ b/src/app/hooks/use-session.ts
@@ -18,11 +18,13 @@
  * If the app grows to have deeply nested data dependencies or shared cross-route
  * cache requirements, TanStack Query should be reconsidered.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffectEvent, useRef, useState } from 'react';
 import { SessionErrors } from '@/lib/errors/session-errors';
 import type { ConnectionState, SessionCallbacks } from '@/lib/streams/client';
 import { err, ok, type Result } from '@/lib/utils/result';
+import { useInterval } from './use-interval';
 import { useSessionSubscription } from './use-session-subscription';
+import { useWatchEffect } from './use-watch-effect';
 
 export type SessionEvent = {
   type: string;
@@ -135,29 +137,56 @@ export function useSession(
     }
   }, [sessionId, userId]);
 
-  // Keep refs to join/leave so the subscription effect only depends on sessionId
-  const joinRef = useRef(join);
-  const leaveRef = useRef(leave);
-  useEffect(() => {
-    joinRef.current = join;
-  }, [join]);
-  useEffect(() => {
-    leaveRef.current = leave;
-  }, [leave]);
+  // useEffectEvent keeps the latest join/leave closures stable across renders
+  const stableJoin = useEffectEvent(() => join());
+  const stableLeave = useEffectEvent(() => leave());
 
-  // Join on mount, leave on unmount
-  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionId triggers re-join when session changes
-  useEffect(() => {
-    void joinRef.current();
+  // Join on mount, leave on unmount — re-run when sessionId changes
+  useWatchEffect(() => {
+    void stableJoin();
     return () => {
-      void leaveRef.current();
+      void stableLeave();
     };
   }, [sessionId]);
 
   // Build session-specific callbacks
   const callbacks = useRef<SessionCallbacks>({});
 
-  useEffect(() => {
+  const stableOnReconnect = useEffectEvent(() => {
+    console.log('[useSession] Reconnected to session stream');
+    // RS-006: Fetch missed events from the REST API on reconnect.
+    // The durable streams client tracks its last offset and will resume
+    // from there, but if the gap is too large events may be lost.
+    // Fetch missed events from the database as a safety net.
+    // FC-006: subscription is now managed by useSessionSubscription;
+    // offset tracking is internal, so we always fetch from offset 0 on reconnect.
+    const lastOff = 0;
+    if (lastOff > 0) {
+      fetch(`/api/sessions/${sessionId}/events?offset=${lastOff}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((json) => {
+          if (!json?.ok || !Array.isArray(json.data)) return;
+          // Events are already ordered by offset from the API.
+          // Re-apply any we may have missed during the disconnect gap.
+          for (const evt of json.data) {
+            if (evt.type === 'chunk' && evt.data?.text) {
+              setState((prev) => {
+                let chunks = [...prev.chunks, { text: evt.data.text, timestamp: evt.timestamp }];
+                if (chunks.length > MAX_CHUNKS) {
+                  chunks = chunks.slice(chunks.length - MAX_CHUNKS);
+                }
+                return { ...prev, chunks };
+              });
+            }
+          }
+        })
+        .catch(() => {
+          // Best-effort -- ignore fetch errors on reconnect gap detection
+        });
+    }
+  });
+
+  useWatchEffect(() => {
     callbacks.current = {
       onChunk: (event) => {
         setState((prev) => {
@@ -228,40 +257,7 @@ export function useSession(
       },
 
       onReconnect: () => {
-        console.log('[useSession] Reconnected to session stream');
-        // RS-006: Fetch missed events from the REST API on reconnect.
-        // The durable streams client tracks its last offset and will resume
-        // from there, but if the gap is too large events may be lost.
-        // Fetch missed events from the database as a safety net.
-        // FC-006: subscription is now managed by useSessionSubscription;
-        // offset tracking is internal, so we always fetch from offset 0 on reconnect.
-        const lastOff = 0;
-        if (lastOff > 0) {
-          fetch(`/api/sessions/${sessionId}/events?offset=${lastOff}`)
-            .then((res) => (res.ok ? res.json() : null))
-            .then((json) => {
-              if (!json?.ok || !Array.isArray(json.data)) return;
-              // Events are already ordered by offset from the API.
-              // Re-apply any we may have missed during the disconnect gap.
-              for (const evt of json.data) {
-                if (evt.type === 'chunk' && evt.data?.text) {
-                  setState((prev) => {
-                    let chunks = [
-                      ...prev.chunks,
-                      { text: evt.data.text, timestamp: evt.timestamp },
-                    ];
-                    if (chunks.length > MAX_CHUNKS) {
-                      chunks = chunks.slice(chunks.length - MAX_CHUNKS);
-                    }
-                    return { ...prev, chunks };
-                  });
-                }
-              }
-            })
-            .catch(() => {
-              // Best-effort -- ignore fetch errors on reconnect gap detection
-            });
-        }
+        stableOnReconnect();
       },
 
       onDisconnect: () => {
@@ -273,23 +269,21 @@ export function useSession(
   const { connectionState } = useSessionSubscription(sessionId, callbacks.current);
 
   // Presence heartbeat at 10s interval (per spec)
-  useEffect(() => {
-    const updatePresence = async () => {
-      try {
-        await fetch(`/api/sessions/${sessionId}/presence`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ userId }),
-        });
-      } catch {
-        // Ignore presence update errors
-      }
-    };
+  const heartbeat = useEffectEvent(async () => {
+    try {
+      await fetch(`/api/sessions/${sessionId}/presence`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+    } catch {
+      // Ignore presence update errors
+    }
+  });
 
-    const interval = window.setInterval(updatePresence, PRESENCE_HEARTBEAT_INTERVAL);
-
-    return () => window.clearInterval(interval);
-  }, [sessionId, userId]);
+  useInterval(() => {
+    void heartbeat();
+  }, PRESENCE_HEARTBEAT_INTERVAL);
 
   // FC-006: lastOffset is no longer directly tracked via subscriptionRef;
   // it is managed internally by useSessionSubscription. Return 0 for compat.

--- a/src/app/hooks/use-timeout.ts
+++ b/src/app/hooks/use-timeout.ts
@@ -1,0 +1,40 @@
+// biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Runs a callback after a delay. Pass `null` as delay to disable.
+ * Returns `reset` (restart the timer) and `clear` (cancel without firing).
+ */
+export function useTimeout(
+  callback: () => void,
+  delayMs: number | null
+): { reset: () => void; clear: () => void } {
+  const savedCallback = useRef(callback);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  savedCallback.current = callback;
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clear();
+    if (delayMs !== null) {
+      timerRef.current = setTimeout(() => savedCallback.current(), delayMs);
+    }
+  }, [delayMs, clear]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: delay is the only reactive dep
+  useEffect(() => {
+    if (delayMs === null) return;
+
+    timerRef.current = setTimeout(() => savedCallback.current(), delayMs);
+    return clear;
+  }, [delayMs, clear]);
+
+  return { reset, clear };
+}

--- a/src/app/hooks/use-topology-stream.ts
+++ b/src/app/hooks/use-topology-stream.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import type { TopologyAction } from '@/app/components/features/agent-topology/topology-context';
 import type {
   SessionCallbacks,
@@ -8,6 +8,8 @@ import type {
 } from '@/lib/streams/client';
 import { subscribeToSession } from '@/lib/streams/client';
 import type { TopologyNode } from '@/lib/topology/types';
+import { useMountEffect } from './use-mount-effect';
+import { useWatchEffect } from './use-watch-effect';
 
 /**
  * Map a role string from the backend to a TopologyAgentRole.
@@ -80,14 +82,14 @@ export function useTopologyStream(
   );
 
   // Clean up any pending rAF on unmount
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (rafIdRef.current !== null) {
         cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;
       }
     };
-  }, []);
+  });
 
   const handleSpawned = useCallback(
     (event: { data: TopologyAgentSpawned }) => {
@@ -153,7 +155,7 @@ export function useTopologyStream(
     [dispatch]
   );
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!sessionId) {
       console.debug('[useTopologyStream] no sessionId, skipping');
       return;

--- a/src/app/hooks/use-watch-effect.ts
+++ b/src/app/hooks/use-watch-effect.ts
@@ -1,0 +1,14 @@
+// biome-ignore lint/style/noRestrictedImports: factory hook — only file allowed to import useEffect
+import { type DependencyList, useEffect } from 'react';
+
+/**
+ * Runs an effect that re-executes when specific dependencies change.
+ * Use this for effects that need to re-subscribe or re-sync when a value
+ * like `sessionId` changes. The deps array is managed by the caller.
+ *
+ * This is the sanctioned way to run a dependency-based effect.
+ */
+export function useWatchEffect(effect: () => void | (() => void), deps: DependencyList): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps managed by caller
+  useEffect(effect, deps);
+}

--- a/src/app/providers/project-context.tsx
+++ b/src/app/providers/project-context.tsx
@@ -13,7 +13,7 @@ import {
   type ProjectPickerItem,
   useRecentProjects,
 } from '@/app/components/features/project-picker';
-import { apiClient, type ProjectSummaryItem } from '@/lib/api/client';
+import { apiClient, type ProjectListItem, type ProjectSummaryItem } from '@/lib/api/client';
 
 // =============================================================================
 // Types
@@ -97,7 +97,12 @@ export function ProjectContextProvider({
   const [isNewProjectDialogOpen, setIsNewProjectDialogOpen] = useState(false);
 
   // Project data states
-  const [projectSummaries, setProjectSummaries] = useState<ProjectSummaryItem[]>([]);
+  // Lightweight project list for the picker (just id, name, path)
+  const [projectList, setProjectList] = useState<ProjectListItem[]>([]);
+  // Summary for current project only (task counts, running agents)
+  const [currentProjectSummary, setCurrentProjectSummary] = useState<ProjectSummaryItem | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>(undefined);
 
@@ -108,14 +113,14 @@ export function ProjectContextProvider({
   // Recent projects from localStorage
   const { recentProjectIds, addRecentProject } = useRecentProjects();
 
-  // Fetch all projects
+  // Fetch lightweight project list (just id, name, path) for the picker
   const fetchProjects = useCallback(async () => {
     setIsLoading(true);
     setError(undefined);
     try {
-      const result = await apiClient.projects.listWithSummaries({ limit: 100 });
+      const result = await apiClient.projects.list({ limit: 100 });
       if (result.ok) {
-        setProjectSummaries(result.data.items);
+        setProjectList(result.data.items);
       } else {
         setError(new Error(result.error.message));
       }
@@ -134,17 +139,35 @@ export function ProjectContextProvider({
     }
   }, [projectId, fetchProjects]);
 
-  // Current project from summaries
-  const currentProject = useMemo(() => {
-    if (!projectId) return null;
-    return projectSummaries.find((p) => p.project.id === projectId) ?? null;
-  }, [projectId, projectSummaries]);
+  // Fetch summary data only for the current project when projectId changes
+  useEffect(() => {
+    if (!projectId) {
+      setCurrentProjectSummary(null);
+      return;
+    }
+    const fetchCurrentSummary = async () => {
+      try {
+        const result = await apiClient.projects.listWithSummaries({ limit: 100 });
+        if (result.ok) {
+          const summary = result.data.items.find((p) => p.project.id === projectId) ?? null;
+          setCurrentProjectSummary(summary);
+        }
+      } catch {
+        // Summary fetch failure is non-critical
+      }
+    };
+    void fetchCurrentSummary();
+  }, [projectId]);
 
-  // Convert summaries to picker items
+  // Current project from summary
+  const currentProject = useMemo(() => {
+    return currentProjectSummary ?? null;
+  }, [currentProjectSummary]);
+
+  // Convert lightweight project list to picker items
   const allProjects = useMemo<ProjectPickerItem[]>(() => {
     const colors = ['blue', 'green', 'purple', 'orange', 'red'] as const;
-    return projectSummaries.map((summary) => {
-      const { project } = summary;
+    return projectList.map((project) => {
       // Derive icon color from project name hash for consistency
       const hash = project.name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
       const color = colors[hash % colors.length] ?? 'blue';
@@ -160,15 +183,15 @@ export function ProjectContextProvider({
         },
         isActive: project.id === projectId,
         stats: {
-          activeAgents: summary.runningAgents.length,
-          totalTasks: summary.taskCounts.total,
-          backlogTasks: summary.taskCounts.backlog,
-          inProgressTasks: summary.taskCounts.inProgress,
+          activeAgents: 0,
+          totalTasks: 0,
+          backlogTasks: 0,
+          inProgressTasks: 0,
         },
         lastAccessedAt: project.updatedAt ?? new Date(),
       };
     });
-  }, [projectSummaries, projectId]);
+  }, [projectList, projectId]);
 
   // Recent projects filtered from all
   const recentProjects = useMemo<ProjectPickerItem[]>(() => {

--- a/src/app/providers/project-context.tsx
+++ b/src/app/providers/project-context.tsx
@@ -4,7 +4,6 @@ import {
   type ReactNode,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -13,6 +12,7 @@ import {
   type ProjectPickerItem,
   useRecentProjects,
 } from '@/app/components/features/project-picker';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient, type ProjectListItem, type ProjectSummaryItem } from '@/lib/api/client';
 
 // =============================================================================
@@ -133,14 +133,14 @@ export function ProjectContextProvider({
   }, []);
 
   // FC-001: Deferred fetch -- only runs when projectId is present or picker opens
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!hasFetched.current && projectId) {
       void fetchProjects();
     }
   }, [projectId, fetchProjects]);
 
   // Fetch summary data only for the current project when projectId changes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!projectId) {
       setCurrentProjectSummary(null);
       return;

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -12,6 +12,12 @@ export const router = createRouter({
   routeTree,
   context: { services: null, bootstrap: null } satisfies RouterContext,
   defaultPreload: 'intent',
+  defaultPendingMs: 200,
+  defaultPendingComponent: () => (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <div className="animate-pulse text-fg-muted text-sm">Loading…</div>
+    </div>
+  ),
 });
 
 declare module '@tanstack/react-router' {

--- a/src/app/routes/agents/$agentId.tsx
+++ b/src/app/routes/agents/$agentId.tsx
@@ -1,9 +1,10 @@
 import { Gear } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AgentConfigDialog } from '@/app/components/features/agent-config-dialog';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { Button } from '@/app/components/ui/button';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 // Agent type for client-side display
 type ClientAgent = {
@@ -43,7 +44,7 @@ function AgentDetailPage(): React.JSX.Element {
   const [showConfig, setShowConfig] = useState(false);
 
   // Fetch agent from API on mount (fallback if loader didn't run)
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.agent) return;
     const doFetch = async () => {
       const result = await fetchAgentById(agentId);

--- a/src/app/routes/agents/$agentId.tsx
+++ b/src/app/routes/agents/$agentId.tsx
@@ -15,32 +15,43 @@ type ClientAgent = {
   config?: Record<string, unknown>;
 };
 
+async function fetchAgentById(agentId: string): Promise<ClientAgent | null> {
+  try {
+    const response = await fetch(`/api/agents/${agentId}`);
+    const data = await response.json();
+    return data.ok ? (data.data as ClientAgent) : null;
+  } catch {
+    return null;
+  }
+}
+
 export const Route = createFileRoute('/agents/$agentId')({
+  loader: async ({ params }: { params: { agentId: string } }) => {
+    const agent = await fetchAgentById(params.agentId);
+    return { agent };
+  },
   component: AgentDetailPage,
 });
 
 function AgentDetailPage(): React.JSX.Element {
   const { agentId } = Route.useParams();
-  const [agent, setAgent] = useState<ClientAgent | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { agent: ClientAgent | null } | undefined;
+  const [agent, setAgent] = useState<ClientAgent | null>(
+    () => (loaderData?.agent as ClientAgent) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.agent);
   const [showConfig, setShowConfig] = useState(false);
 
-  // Fetch agent from API on mount
+  // Fetch agent from API on mount (fallback if loader didn't run)
   useEffect(() => {
-    const fetchAgent = async () => {
-      try {
-        const response = await fetch(`/api/agents/${agentId}`);
-        const data = await response.json();
-        if (data.ok) {
-          setAgent(data.data);
-        }
-      } catch {
-        // API may not be ready
-      }
+    if (loaderData?.agent) return;
+    const doFetch = async () => {
+      const result = await fetchAgentById(agentId);
+      if (result) setAgent(result);
       setIsLoading(false);
     };
-    fetchAgent();
-  }, [agentId]);
+    doFetch();
+  }, [agentId, loaderData]);
 
   if (isLoading) {
     return (

--- a/src/app/routes/agents/index.tsx
+++ b/src/app/routes/agents/index.tsx
@@ -1,9 +1,10 @@
 import { Funnel, Play, Robot } from '@phosphor-icons/react';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { Button } from '@/app/components/ui/button';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 // Agent type for client-side display
@@ -45,7 +46,7 @@ function AgentsPage(): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   // Fetch agents and projects from API on mount (fallback if loader data is empty)
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderAgents.length > 0 || loaderProjects.length > 0) return;
 
     const fetchData = async () => {

--- a/src/app/routes/catalog/$workflowId.tsx
+++ b/src/app/routes/catalog/$workflowId.tsx
@@ -1,10 +1,11 @@
 import { ArrowLeft, PencilSimple, Spinner, Trash } from '@phosphor-icons/react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorkflowDesigner } from '@/app/components/features/workflow-designer';
 import { Button } from '@/app/components/ui/button';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Workflow } from '@/db/schema';
 
 export const Route = createFileRoute('/catalog/$workflowId')({
@@ -63,7 +64,7 @@ function WorkflowDetailPage(): React.JSX.Element {
   }, [workflowId]);
 
   // Load workflow on mount
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.workflow) return;
     fetchWorkflow();
   }, [fetchWorkflow, loaderData]);

--- a/src/app/routes/catalog/$workflowId.tsx
+++ b/src/app/routes/catalog/$workflowId.tsx
@@ -8,6 +8,15 @@ import { Button } from '@/app/components/ui/button';
 import type { Workflow } from '@/db/schema';
 
 export const Route = createFileRoute('/catalog/$workflowId')({
+  loader: async ({ params }: { params: { workflowId: string } }) => {
+    try {
+      const response = await fetch(`/api/workflows/${params.workflowId}`);
+      const result = await response.json();
+      return { workflow: result.ok ? result.data : null };
+    } catch {
+      return { workflow: null };
+    }
+  },
   component: WorkflowDetailPage,
 });
 
@@ -18,8 +27,11 @@ export const Route = createFileRoute('/catalog/$workflowId')({
 function WorkflowDetailPage(): React.JSX.Element {
   const navigate = useNavigate();
   const { workflowId } = Route.useParams();
-  const [workflow, setWorkflow] = useState<Workflow | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { workflow: Workflow | null } | undefined;
+  const [workflow, setWorkflow] = useState<Workflow | null>(
+    () => (loaderData?.workflow as Workflow) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.workflow);
   const [error, setError] = useState<{ message: string; code?: string } | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -52,8 +64,9 @@ function WorkflowDetailPage(): React.JSX.Element {
 
   // Load workflow on mount
   useEffect(() => {
+    if (loaderData?.workflow) return;
     fetchWorkflow();
-  }, [fetchWorkflow]);
+  }, [fetchWorkflow, loaderData]);
 
   // Handle navigate back to catalog
   const handleBack = useCallback(() => {

--- a/src/app/routes/catalog/index.tsx
+++ b/src/app/routes/catalog/index.tsx
@@ -26,6 +26,19 @@ import type { WorkflowEdge, WorkflowNode } from '@/lib/workflow-dsl/types';
 type WorkflowStatus = 'draft' | 'published' | 'archived';
 
 export const Route = createFileRoute('/catalog/')({
+  loader: async () => {
+    try {
+      const response = await fetch('/api/workflows');
+      if (!response.ok) return { workflows: [] };
+      const result = await response.json();
+      if (result.ok) {
+        return { workflows: result.data.items ?? [] };
+      }
+      return { workflows: [] };
+    } catch {
+      return { workflows: [] };
+    }
+  },
   component: CatalogPage,
 });
 
@@ -402,11 +415,31 @@ function DetailPanel({
 
 function CatalogPage(): React.JSX.Element {
   const navigate = useNavigate();
-  const [workflows, setWorkflows] = useState<WorkflowListItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { workflows: Workflow[] } | undefined;
+  const [workflows, setWorkflows] = useState<WorkflowListItem[]>(() => {
+    const raw = loaderData?.workflows as Workflow[] | undefined;
+    if (!raw?.length) return [];
+    return raw.map((w) => ({
+      id: w.id,
+      name: w.name,
+      description: w.description,
+      status: w.status as WorkflowStatus | null,
+      nodes: (w.nodes ?? []) as WorkflowNode[],
+      edges: (w.edges ?? []) as WorkflowEdge[],
+      createdAt: w.createdAt as unknown as string,
+      updatedAt: w.updatedAt as unknown as string,
+    }));
+  });
+  const [isLoading, setIsLoading] = useState(() => {
+    const raw = loaderData?.workflows as unknown[] | undefined;
+    return !raw || raw.length === 0;
+  });
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(() => {
+    const raw = loaderData?.workflows as Workflow[] | undefined;
+    return raw?.[0]?.id ?? null;
+  });
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [updatingStatusId, setUpdatingStatusId] = useState<string | null>(null);
 
@@ -455,12 +488,13 @@ function CatalogPage(): React.JSX.Element {
   }, []);
 
   useEffect(() => {
+    if (loaderData?.workflows && (loaderData.workflows as unknown[]).length > 0) return;
     fetchWorkflows().then((items) => {
       if (items.length > 0) {
         setSelectedId((current) => current ?? items[0]?.id ?? null);
       }
     });
-  }, [fetchWorkflows]);
+  }, [fetchWorkflows, loaderData]);
 
   const filteredWorkflows = useMemo(() => {
     if (!searchQuery.trim()) return workflows;

--- a/src/app/routes/catalog/index.tsx
+++ b/src/app/routes/catalog/index.tsx
@@ -7,7 +7,7 @@ import {
   Trash,
 } from '@phosphor-icons/react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorkflowPreviewSvg } from '@/app/components/features/workflow-preview';
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/app/components/ui/select';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Workflow } from '@/db/schema';
 import { cn } from '@/lib/utils/cn';
 import type { WorkflowEdge, WorkflowNode } from '@/lib/workflow-dsl/types';
@@ -487,7 +488,7 @@ function CatalogPage(): React.JSX.Element {
     }
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.workflows && (loaderData.workflows as unknown[]).length > 0) return;
     fetchWorkflows().then((items) => {
       if (items.length > 0) {

--- a/src/app/routes/cli-monitor/index.tsx
+++ b/src/app/routes/cli-monitor/index.tsx
@@ -1,6 +1,6 @@
 import { FolderOpen, Terminal } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { CardsRightPanel } from '@/app/components/features/cli-monitor/cards-right-panel';
 import { useCliMonitor } from '@/app/components/features/cli-monitor/cli-monitor-context';
 import type {
@@ -12,6 +12,8 @@ import {
   getSessionTokenTotal,
 } from '@/app/components/features/cli-monitor/cli-monitor-utils';
 import { SummaryStrip } from '@/app/components/features/cli-monitor/summary-strip';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 // -- Constants --
 
@@ -45,11 +47,11 @@ function InstallState() {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
     };
-  }, []);
+  });
 
   const handleCopy = useCallback(async () => {
     await navigator.clipboard.writeText('npx @agentpane/cli-monitor');
@@ -213,7 +215,7 @@ function ActiveState({
   const sessionListRef = useRef<HTMLDivElement | null>(null);
   const selectedSession = sessions.find((s) => s.sessionId === selectedSessionId);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (selectedSessionId && !sessions.some((s) => s.sessionId === selectedSessionId)) {
       setSelectedSessionId(null);
     }
@@ -229,7 +231,7 @@ function ActiveState({
     [selectedSessionId]
   );
 
-  useEffect(() => {
+  useMountEffect(() => {
     const el = loadMoreRef.current;
     if (!el) return;
     const observer = new IntersectionObserver(
@@ -242,7 +244,7 @@ function ActiveState({
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
+  });
 
   const flatSessions = useMemo(() => sessions.filter((s) => !s.isSubagent), [sessions]);
 
@@ -252,7 +254,7 @@ function ActiveState({
   const selectedSessionIdRef = useRef(selectedSessionId);
   selectedSessionIdRef.current = selectedSessionId;
 
-  useEffect(() => {
+  useWatchEffect(() => {
     const el = sessionListRef.current;
     if (!el) return;
     const handler = (e: KeyboardEvent) => {
@@ -280,7 +282,7 @@ function ActiveState({
     return () => el.removeEventListener('keydown', handler);
   }, [flatSessions]);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (focusedIndex < 0) return;
     const el = sessionListRef.current?.querySelector(`[data-session-index="${focusedIndex}"]`);
     if (el) {

--- a/src/app/routes/cli-monitor/terminal.tsx
+++ b/src/app/routes/cli-monitor/terminal.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useCliMonitor } from '@/app/components/features/cli-monitor/cli-monitor-context';
 import { SessionPicker } from '@/app/components/features/cli-monitor/session-picker';
 import { TerminalGrid } from '@/app/components/features/cli-monitor/terminal-grid';
 import { TerminalStatusBar } from '@/app/components/features/cli-monitor/terminal-status-bar';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 export const Route = createFileRoute('/cli-monitor/terminal')({
   component: TerminalView,
@@ -29,7 +30,7 @@ function TerminalView(): React.JSX.Element {
   );
 
   // Auto-assign first 4 sessions on mount or when session IDs actually change
-  useEffect(() => {
+  useWatchEffect(() => {
     if (activeIdsKey === prevActiveIdsRef.current) return;
     prevActiveIdsRef.current = activeIdsKey;
 

--- a/src/app/routes/cli-monitor/timeline.tsx
+++ b/src/app/routes/cli-monitor/timeline.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useCliMonitor } from '@/app/components/features/cli-monitor/cli-monitor-context';
 import { SummaryStrip } from '@/app/components/features/cli-monitor/summary-strip';
 import { TimelineDetailPanel } from '@/app/components/features/cli-monitor/timeline-detail-panel';
 import { TimelineSwimlane } from '@/app/components/features/cli-monitor/timeline-swimlane';
 import type { TimeRange } from '@/app/components/features/cli-monitor/timeline-time-axis';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 export const Route = createFileRoute('/cli-monitor/timeline')({
   component: TimelineView,
@@ -20,7 +21,7 @@ function TimelineView(): React.JSX.Element {
   const selectedSession = sessions.find((s) => s.sessionId === selectedSessionId);
 
   // Close detail panel if session disappears
-  useEffect(() => {
+  useWatchEffect(() => {
     if (selectedSessionId && !sessions.some((s) => s.sessionId === selectedSessionId)) {
       setSelectedSessionId(null);
     }

--- a/src/app/routes/designer/index.tsx
+++ b/src/app/routes/designer/index.tsx
@@ -1,9 +1,10 @@
 import { Spinner } from '@phosphor-icons/react';
 import { createFileRoute, useSearch } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorkflowDesigner } from '@/app/components/features/workflow-designer';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Workflow } from '@/db/schema';
 
 export const Route = createFileRoute('/designer/')({
@@ -45,7 +46,7 @@ function DesignerPage(): React.JSX.Element {
     }
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     if (workflowId) {
       fetchWorkflow(workflowId);
     }

--- a/src/app/routes/events/sources.tsx
+++ b/src/app/routes/events/sources.tsx
@@ -1,10 +1,11 @@
 import { Plugs, Plus } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { AddSourceDialog } from '@/app/components/features/events/add-source-dialog';
 import { EventSourceCard } from '@/app/components/features/events/event-source-card';
 import { Button } from '@/app/components/ui/button';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 import type { CreateEventSourceInput, EventSource } from '@/lib/events/types';
 
@@ -26,7 +27,7 @@ function EventSourcesPage(): React.JSX.Element {
     }
   }, []);
 
-  useEffect(() => {
+  useMountEffect(() => {
     async function load() {
       const [sourcesRes, teamsRes] = await Promise.all([
         apiClient.events.sources.list(),
@@ -37,7 +38,7 @@ function EventSourcesPage(): React.JSX.Element {
       setIsLoading(false);
     }
     load();
-  }, []);
+  });
 
   const handleAdd = useCallback(
     async (data: CreateEventSourceInput) => {

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -1,8 +1,9 @@
 import { MagnifyingGlass, Plus } from '@phosphor-icons/react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 
 // Lazy-load heavy dialog component (FC-012)
 const NewProjectDialog = React.lazy(() =>
@@ -85,7 +86,7 @@ function Dashboard(): React.JSX.Element {
 
   // Check if global settings are configured (API key is required, GitHub PAT is optional)
   // Batch all mount API calls with Promise.all to avoid 4 separate re-renders
-  useEffect(() => {
+  useMountEffect(() => {
     const loadInitialData = async () => {
       const [keyResult, githubResult, reposResult, configsResult] = await Promise.all([
         apiClient.apiKeys.get('anthropic').catch((error) => {
@@ -126,7 +127,7 @@ function Dashboard(): React.JSX.Element {
       }
     };
     loadInitialData();
-  }, []);
+  });
 
   // Polling interval ref for project updates
   const pollingIntervalRef = useRef<number | null>(null);
@@ -135,8 +136,7 @@ function Dashboard(): React.JSX.Element {
 
   // FC-021: Polling (5s active, 30s idle) chosen over SSE because dashboard has no single session to subscribe to
   // Skip initial fetch if loader already provided data
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect — loaderProjects is stable from the route loader
-  useEffect(() => {
+  useMountEffect(() => {
     const fetchProjects = async () => {
       if (isFetchingRef.current) {
         console.debug('[Home] fetchProjects skipped — already in-flight');
@@ -206,7 +206,7 @@ function Dashboard(): React.JSX.Element {
         currentIntervalMsRef.current = null;
       }
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  });
 
   const handleCreateProject = useCallback(
     async (data: {

--- a/src/app/routes/marketplace/index.tsx
+++ b/src/app/routes/marketplace/index.tsx
@@ -1,11 +1,12 @@
 import { ArrowsClockwise, Plus, PuzzlePiece, Spinner } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { AddMarketplaceDialog } from '@/app/components/features/add-marketplace-dialog';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { type CachedPlugin, MarketplaceCard } from '@/app/components/features/marketplace-card';
 import { Button } from '@/app/components/ui/button';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 
 // Marketplace syncs with: https://github.com/anthropics/claude-plugins-official
@@ -158,7 +159,7 @@ function MarketplacePage(): React.JSX.Element {
     }
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     fetchData();
   }, [fetchData]);
 

--- a/src/app/routes/marketplace/index.tsx
+++ b/src/app/routes/marketplace/index.tsx
@@ -13,6 +13,17 @@ import { apiClient } from '@/lib/api/client';
 //   - /external_plugins (third-party community plugins)
 
 export const Route = createFileRoute('/marketplace/')({
+  loader: async () => {
+    await apiClient.marketplaces.seed();
+    const [marketplacesRes, pluginsRes] = await Promise.all([
+      apiClient.marketplaces.list(),
+      apiClient.marketplaces.listPlugins({}),
+    ]);
+    return {
+      marketplaces: marketplacesRes.ok ? marketplacesRes.data.items : [],
+      plugins: pluginsRes.ok ? pluginsRes.data.items : [],
+    };
+  },
   component: MarketplacePage,
 });
 
@@ -46,9 +57,16 @@ type PluginItem = {
 };
 
 function MarketplacePage(): React.JSX.Element {
-  const [marketplaces, setMarketplaces] = useState<MarketplaceItem[]>([]);
-  const [plugins, setPlugins] = useState<PluginItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as
+    | { marketplaces: MarketplaceItem[]; plugins: PluginItem[] }
+    | undefined;
+  const [marketplaces, setMarketplaces] = useState<MarketplaceItem[]>(
+    () => (loaderData?.marketplaces as MarketplaceItem[]) ?? []
+  );
+  const [plugins, setPlugins] = useState<PluginItem[]>(
+    () => (loaderData?.plugins as PluginItem[]) ?? []
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.marketplaces);
   const [error, setError] = useState<string | null>(null);
 
   // UI state

--- a/src/app/routes/projects/$projectId/git.tsx
+++ b/src/app/routes/projects/$projectId/git.tsx
@@ -5,17 +5,25 @@ import { LayoutShell } from '@/app/components/features/layout-shell';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 export const Route = createFileRoute('/projects/$projectId/git')({
+  loader: async ({ params }: { params: { projectId: string } }) => {
+    const result = await apiClient.projects.get(params.projectId);
+    return { project: result.ok ? result.data : null };
+  },
   component: ProjectGitPage,
 });
 
 function ProjectGitPage(): React.JSX.Element {
   const { projectId } = Route.useParams();
-  const [project, setProject] = useState<ProjectListItem | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { project: ProjectListItem | null } | undefined;
+  const [project, setProject] = useState<ProjectListItem | null>(
+    () => (loaderData?.project as ProjectListItem) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.project);
   const [error, setError] = useState<string | null>(null);
 
   // Fetch project from API
   useEffect(() => {
+    if (loaderData?.project) return;
     const fetchProject = async () => {
       try {
         const result = await apiClient.projects.get(projectId);
@@ -33,7 +41,7 @@ function ProjectGitPage(): React.JSX.Element {
       }
     };
     void fetchProject();
-  }, [projectId]);
+  }, [projectId, loaderData]);
 
   if (isLoading) {
     return (

--- a/src/app/routes/projects/$projectId/git.tsx
+++ b/src/app/routes/projects/$projectId/git.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { GitView } from '@/app/components/features/git-view';
 import { LayoutShell } from '@/app/components/features/layout-shell';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 export const Route = createFileRoute('/projects/$projectId/git')({
@@ -22,7 +23,7 @@ function ProjectGitPage(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   // Fetch project from API
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.project) return;
     const fetchProject = async () => {
       try {

--- a/src/app/routes/projects/$projectId/index.tsx
+++ b/src/app/routes/projects/$projectId/index.tsx
@@ -1,9 +1,10 @@
 import { GearSix } from '@phosphor-icons/react';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useState } from 'react';
 import { ApprovalDialog } from '@/app/components/features/approval-dialog';
 import { KanbanBoard } from '@/app/components/features/kanban-board';
 import { LayoutShell } from '@/app/components/features/layout-shell';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 // Lazy-load heavy dialog components (FC-012)
 const NewTaskDialog = React.lazy(() =>
@@ -136,7 +137,7 @@ function ProjectKanban(): React.JSX.Element {
   }, [projectId]);
 
   // Fetch on mount and when projectId changes (skip if loader already provided data)
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.project) return;
     fetchData();
   }, [fetchData, loaderData]);

--- a/src/app/routes/projects/$projectId/settings.tsx
+++ b/src/app/routes/projects/$projectId/settings.tsx
@@ -14,6 +14,10 @@ import type { Project, ProjectConfig } from '@/db/schema';
 import { apiClient } from '@/lib/api/client';
 
 export const Route = createFileRoute('/projects/$projectId/settings')({
+  loader: async ({ params }: { params: { projectId: string } }) => {
+    const result = await apiClient.projects.get(params.projectId);
+    return { project: result.ok ? result.data : null };
+  },
   component: ProjectSettingsPage,
 });
 
@@ -21,8 +25,11 @@ function ProjectSettingsPage(): React.JSX.Element {
   const { projectId } = Route.useParams();
   const navigate = useNavigate();
   const router = useRouter();
-  const [project, setProject] = useState<Project | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { project: Project | null } | undefined;
+  const [project, setProject] = useState<Project | null>(
+    () => (loaderData?.project as unknown as Project) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.project);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
 
   const handleBack = () => {
@@ -36,6 +43,7 @@ function ProjectSettingsPage(): React.JSX.Element {
 
   // Fetch project from API on mount
   useEffect(() => {
+    if (loaderData?.project) return;
     const fetchProject = async () => {
       const result = await apiClient.projects.get(projectId);
       if (result.ok) {
@@ -44,7 +52,7 @@ function ProjectSettingsPage(): React.JSX.Element {
       setIsLoading(false);
     };
     fetchProject();
-  }, [projectId]);
+  }, [projectId, loaderData]);
 
   const handleSave = async (input: {
     name?: string;

--- a/src/app/routes/projects/$projectId/settings.tsx
+++ b/src/app/routes/projects/$projectId/settings.tsx
@@ -1,7 +1,9 @@
 import { ArrowLeft } from '@phosphor-icons/react';
 import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { LayoutShell } from '@/app/components/features/layout-shell';
+import { useTimeout } from '@/app/hooks/use-timeout';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 
 // Lazy-load heavy settings component (FC-012)
 const ProjectSettings = React.lazy(() =>
@@ -41,8 +43,11 @@ function ProjectSettingsPage(): React.JSX.Element {
     }
   };
 
+  // Auto-dismiss saved status
+  useTimeout(() => setSaveStatus('idle'), saveStatus === 'saved' ? 2000 : null);
+
   // Fetch project from API on mount
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.project) return;
     const fetchProject = async () => {
       const result = await apiClient.projects.get(projectId);
@@ -72,8 +77,6 @@ function ProjectSettingsPage(): React.JSX.Element {
       if (result.ok) {
         setProject(result.data as unknown as Project);
         setSaveStatus('saved');
-        // Reset status after 2 seconds
-        setTimeout(() => setSaveStatus('idle'), 2000);
       } else {
         setSaveStatus('error');
         console.error('Failed to save project settings:', result.error);

--- a/src/app/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/src/app/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, useRouter } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { TaskDetailDialog } from '@/app/components/features/task-detail-dialog';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Task } from '@/db/schema';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
@@ -43,7 +44,7 @@ function TaskDetailRoute(): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(!loaderData?.task);
 
   // Fetch task and project from API on mount
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.task) return;
     const fetchData = async () => {
       const [taskResult, projectResult] = await Promise.all([

--- a/src/app/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/src/app/routes/projects/$projectId/tasks/$taskId.tsx
@@ -14,18 +14,37 @@ type ClientTask = Pick<
 };
 
 export const Route = createFileRoute('/projects/$projectId/tasks/$taskId')({
+  loader: async ({ params }: { params: { projectId: string; taskId: string } }) => {
+    const [taskResult, projectResult] = await Promise.all([
+      apiClient.tasks.get(params.taskId),
+      apiClient.projects.get(params.projectId),
+    ]);
+    const task = taskResult.ok ? taskResult.data : null;
+    return {
+      task: task && (task as ClientTask).projectId === params.projectId ? task : null,
+      project: projectResult.ok ? projectResult.data : null,
+    };
+  },
   component: TaskDetailRoute,
 });
 
 function TaskDetailRoute(): React.JSX.Element {
   const router = useRouter();
   const { projectId, taskId } = Route.useParams();
-  const [task, setTask] = useState<ClientTask | null>(null);
-  const [project, setProject] = useState<ProjectListItem | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as
+    | { task: ClientTask | null; project: ProjectListItem | null }
+    | undefined;
+  const [task, setTask] = useState<ClientTask | null>(
+    () => (loaderData?.task as ClientTask) ?? null
+  );
+  const [project, setProject] = useState<ProjectListItem | null>(
+    () => (loaderData?.project as ProjectListItem) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.task);
 
   // Fetch task and project from API on mount
   useEffect(() => {
+    if (loaderData?.task) return;
     const fetchData = async () => {
       const [taskResult, projectResult] = await Promise.all([
         apiClient.tasks.get(taskId),
@@ -44,7 +63,7 @@ function TaskDetailRoute(): React.JSX.Element {
       setIsLoading(false);
     };
     fetchData();
-  }, [projectId, taskId]);
+  }, [projectId, taskId, loaderData]);
 
   if (isLoading) {
     return (

--- a/src/app/routes/projects/$projectId/worktrees.tsx
+++ b/src/app/routes/projects/$projectId/worktrees.tsx
@@ -5,17 +5,25 @@ import { WorktreeManagement } from '@/app/components/features/worktree-managemen
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 export const Route = createFileRoute('/projects/$projectId/worktrees')({
+  loader: async ({ params }: { params: { projectId: string } }) => {
+    const result = await apiClient.projects.get(params.projectId);
+    return { project: result.ok ? result.data : null };
+  },
   component: ProjectWorktreesPage,
 });
 
 function ProjectWorktreesPage(): React.JSX.Element {
   const { projectId } = Route.useParams();
-  const [project, setProject] = useState<ProjectListItem | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { project: ProjectListItem | null } | undefined;
+  const [project, setProject] = useState<ProjectListItem | null>(
+    () => (loaderData?.project as ProjectListItem) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData?.project);
   const [error, setError] = useState<string | null>(null);
 
   // Fetch project from API
   useEffect(() => {
+    if (loaderData?.project) return;
     const fetchProject = async () => {
       try {
         const result = await apiClient.projects.get(projectId);
@@ -33,7 +41,7 @@ function ProjectWorktreesPage(): React.JSX.Element {
       }
     };
     void fetchProject();
-  }, [projectId]);
+  }, [projectId, loaderData]);
 
   if (isLoading) {
     return (

--- a/src/app/routes/projects/$projectId/worktrees.tsx
+++ b/src/app/routes/projects/$projectId/worktrees.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorktreeManagement } from '@/app/components/features/worktree-management';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 export const Route = createFileRoute('/projects/$projectId/worktrees')({
@@ -22,7 +23,7 @@ function ProjectWorktreesPage(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   // Fetch project from API
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.project) return;
     const fetchProject = async () => {
       try {

--- a/src/app/routes/projects/index.tsx
+++ b/src/app/routes/projects/index.tsx
@@ -1,8 +1,9 @@
 import { MagnifyingGlass, Plus, SortAscending } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 
 // Lazy-load heavy dialog component (FC-012)
 const NewProjectDialog = React.lazy(() =>
@@ -89,7 +90,7 @@ function ProjectsPage(): React.JSX.Element {
 
   // Check if global settings are configured (API key is required, GitHub PAT is optional)
   // Batch all mount API calls with Promise.all to avoid 4 separate re-renders
-  useEffect(() => {
+  useMountEffect(() => {
     const loadInitialData = async () => {
       const [keyResult, githubResult, reposResult, configsResult] = await Promise.all([
         apiClient.apiKeys.get('anthropic').catch((error) => {
@@ -128,7 +129,7 @@ function ProjectsPage(): React.JSX.Element {
       }
     };
     loadInitialData();
-  }, []);
+  });
 
   // Polling interval ref for project updates
   const pollingIntervalRef = useRef<number | null>(null);
@@ -136,8 +137,7 @@ function ProjectsPage(): React.JSX.Element {
   const isFetchingRef = useRef(false);
 
   // Fetch projects with summaries from API on mount and poll when agents are running
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect — initial data is stable from the route loader
-  useEffect(() => {
+  useMountEffect(() => {
     const fetchProjects = async () => {
       if (isFetchingRef.current) {
         console.debug('[Projects] fetchProjects skipped — already in-flight');
@@ -188,7 +188,7 @@ function ProjectsPage(): React.JSX.Element {
         currentIntervalMsRef.current = null;
       }
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  });
 
   const handleCreateProject = useCallback(
     async (data: {

--- a/src/app/routes/queue/index.tsx
+++ b/src/app/routes/queue/index.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { QueueStatus } from '@/app/components/features/queue-status';
 import { QueueWaitingState } from '@/app/components/features/queue-waiting-state';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 
 // Queue position type for client-side display
 type ClientQueuePosition = {
@@ -21,7 +22,7 @@ function QueuePage(): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(true);
 
   // Fetch queue from API on mount
-  useEffect(() => {
+  useMountEffect(() => {
     const fetchQueue = async () => {
       // TODO: [CQ-018] Add API endpoint for queue status
       // For now, just show empty state
@@ -29,7 +30,7 @@ function QueuePage(): React.JSX.Element {
       setIsLoading(false);
     };
     fetchQueue();
-  }, []);
+  });
 
   if (isLoading) {
     return (

--- a/src/app/routes/sessions/$sessionId.tsx
+++ b/src/app/routes/sessions/$sessionId.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { AgentSessionView } from '@/app/components/features/agent-session-view';
 import { ContainerAgentPanel } from '@/app/components/features/container-agent-panel';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 
 // Session type for client-side display
@@ -86,13 +88,13 @@ function SessionPage(): React.JSX.Element {
   const userId = 'current-user';
 
   // Cleanup timeout on unmount
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (errorTimeoutRef.current) {
         clearTimeout(errorTimeoutRef.current);
       }
     };
-  }, []);
+  });
 
   const showTemporaryError = useCallback((message: string) => {
     // Clear any existing timeout to avoid stale clears
@@ -145,7 +147,7 @@ function SessionPage(): React.JSX.Element {
   }, [session?.taskId, navigate, showTemporaryError]);
 
   // Fetch session from API on mount if not already loaded by route loader
-  useEffect(() => {
+  useWatchEffect(() => {
     // Skip if loader already provided data
     if (initialSession || loaderData.sessionError) return;
 

--- a/src/app/routes/sessions/index.tsx
+++ b/src/app/routes/sessions/index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { SessionHistory } from '@/app/components/features/session-history';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 
 // Session data shape from API
@@ -58,7 +59,7 @@ function SessionsPage(): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(!loaderData?.sessions);
 
   // Fetch sessions and projects from API on mount
-  useEffect(() => {
+  useMountEffect(() => {
     if (loaderData?.sessions) return;
     const fetchData = async () => {
       try {
@@ -84,7 +85,7 @@ function SessionsPage(): React.JSX.Element {
       setIsLoading(false);
     };
     fetchData();
-  }, [loaderData]);
+  });
 
   // Filter sessions by selected project
   const filteredSessions = useMemo(() => {

--- a/src/app/routes/sessions/index.tsx
+++ b/src/app/routes/sessions/index.tsx
@@ -24,18 +24,42 @@ interface Project {
 }
 
 export const Route = createFileRoute('/sessions/')({
+  loader: async () => {
+    const [sessionsResult, projectsResult] = await Promise.all([
+      apiClient.sessions.list(),
+      apiClient.projects.list(),
+    ]);
+    return {
+      sessions: sessionsResult.ok
+        ? Array.isArray(sessionsResult.data)
+          ? sessionsResult.data
+          : []
+        : [],
+      projects: projectsResult.ok
+        ? Array.isArray(projectsResult.data)
+          ? projectsResult.data
+          : ((projectsResult.data as { items?: Project[] }).items ?? [])
+        : [],
+    };
+  },
   component: SessionsPage,
 });
 
 function SessionsPage(): React.JSX.Element {
   const navigate = useNavigate();
-  const [sessions, setSessions] = useState<ApiSession[]>([]);
-  const [projects, setProjects] = useState<Project[]>([]);
+  const loaderData = Route.useLoaderData() as
+    | { sessions: ApiSession[]; projects: Project[] }
+    | undefined;
+  const [sessions, setSessions] = useState<ApiSession[]>(
+    () => (loaderData?.sessions as ApiSession[]) ?? []
+  );
+  const [projects, setProjects] = useState<Project[]>(() => loaderData?.projects ?? []);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(!loaderData?.sessions);
 
   // Fetch sessions and projects from API on mount
   useEffect(() => {
+    if (loaderData?.sessions) return;
     const fetchData = async () => {
       try {
         const [sessionsResult, projectsResult] = await Promise.all([
@@ -60,7 +84,7 @@ function SessionsPage(): React.JSX.Element {
       setIsLoading(false);
     };
     fetchData();
-  }, []);
+  }, [loaderData]);
 
   // Filter sessions by selected project
   const filteredSessions = useMemo(() => {

--- a/src/app/routes/settings/api-keys.tsx
+++ b/src/app/routes/settings/api-keys.tsx
@@ -11,9 +11,10 @@ import {
   Warning,
 } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 import { isValidPATFormat } from '@/lib/crypto/token-encryption';
 
@@ -187,7 +188,7 @@ function ApiKeysSettingsPage(): React.JSX.Element {
   const [githubError, setGithubError] = useState<string | null>(null);
 
   // Load saved keys on mount
-  useEffect(() => {
+  useMountEffect(() => {
     if (loaderData?.anthropicKey !== undefined) return;
     const loadKeys = async () => {
       const [keyResult, tokenResult] = await Promise.all([
@@ -203,7 +204,7 @@ function ApiKeysSettingsPage(): React.JSX.Element {
       }
     };
     loadKeys();
-  }, [loaderData]);
+  });
 
   const handleSaveAnthropicKey = async () => {
     if (!anthropicKey.trim()) return;

--- a/src/app/routes/settings/api-keys.tsx
+++ b/src/app/routes/settings/api-keys.tsx
@@ -18,6 +18,24 @@ import { apiClient } from '@/lib/api/client';
 import { isValidPATFormat } from '@/lib/crypto/token-encryption';
 
 export const Route = createFileRoute('/settings/api-keys')({
+  loader: async () => {
+    const [keyResult, tokenResult] = await Promise.all([
+      apiClient.apiKeys.get('anthropic'),
+      apiClient.github.getTokenInfo(),
+    ]);
+    return {
+      anthropicKey:
+        keyResult.ok && keyResult.data.keyInfo ? keyResult.data.keyInfo.maskedKey : null,
+      githubToken:
+        tokenResult.ok && tokenResult.data.tokenInfo
+          ? tokenResult.data.tokenInfo.maskedToken
+          : null,
+      githubLogin:
+        tokenResult.ok && tokenResult.data.tokenInfo
+          ? tokenResult.data.tokenInfo.githubLogin
+          : null,
+    };
+  },
   component: ApiKeysSettingsPage,
 });
 
@@ -146,21 +164,31 @@ function KeyInputCard({
 // ============================================================================
 
 function ApiKeysSettingsPage(): React.JSX.Element {
+  const loaderData = Route.useLoaderData() as
+    | { anthropicKey: string | null; githubToken: string | null; githubLogin: string | null }
+    | undefined;
   const [anthropicKey, setAnthropicKey] = useState('');
   const [showAnthropicKey, setShowAnthropicKey] = useState(false);
-  const [savedAnthropicKey, setSavedAnthropicKey] = useState<string | null>(null);
+  const [savedAnthropicKey, setSavedAnthropicKey] = useState<string | null>(
+    () => (loaderData?.anthropicKey as string) ?? null
+  );
   const [isSavingAnthropic, setIsSavingAnthropic] = useState(false);
   const [anthropicError, setAnthropicError] = useState<string | null>(null);
 
   const [githubPat, setGithubPat] = useState('');
   const [showGithubPat, setShowGithubPat] = useState(false);
-  const [savedGithubPat, setSavedGithubPat] = useState<string | null>(null);
-  const [githubLogin, setGithubLogin] = useState<string | null>(null);
+  const [savedGithubPat, setSavedGithubPat] = useState<string | null>(
+    () => (loaderData?.githubToken as string) ?? null
+  );
+  const [githubLogin, setGithubLogin] = useState<string | null>(
+    () => (loaderData?.githubLogin as string) ?? null
+  );
   const [isSavingGithub, setIsSavingGithub] = useState(false);
   const [githubError, setGithubError] = useState<string | null>(null);
 
   // Load saved keys on mount
   useEffect(() => {
+    if (loaderData?.anthropicKey !== undefined) return;
     const loadKeys = async () => {
       const [keyResult, tokenResult] = await Promise.all([
         apiClient.apiKeys.get('anthropic'),
@@ -175,7 +203,7 @@ function ApiKeysSettingsPage(): React.JSX.Element {
       }
     };
     loadKeys();
-  }, []);
+  }, [loaderData]);
 
   const handleSaveAnthropicKey = async () => {
     if (!anthropicKey.trim()) return;

--- a/src/app/routes/settings/appearance.tsx
+++ b/src/app/routes/settings/appearance.tsx
@@ -1,8 +1,9 @@
 import type { Icon } from '@phosphor-icons/react';
 import { Check, Desktop, Moon, Palette, Sun, Swatches } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ConfigSection } from '@/app/components/ui/config-section';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 
 type Theme = 'light' | 'dark' | 'system';
@@ -102,14 +103,14 @@ function AppearanceSettingsPage(): React.JSX.Element {
     return (stored as Theme) || 'system';
   });
 
-  useEffect(() => {
+  useWatchEffect(() => {
     applyTheme(theme);
   }, [theme]);
 
   const handleThemeChange = (newTheme: Theme) => {
     setTheme(newTheme);
     localStorage.setItem('theme', newTheme);
-    // applyTheme is handled by the useEffect on theme change
+    // applyTheme is handled by the useWatchEffect on theme change
   };
 
   const themeLabel = theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System';

--- a/src/app/routes/settings/cli-monitor.tsx
+++ b/src/app/routes/settings/cli-monitor.tsx
@@ -1,9 +1,11 @@
 import type { Icon } from '@phosphor-icons/react';
 import { Check, CircleNotch, Database, Terminal, Timer, Warning } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useTimeout } from '@/app/hooks/use-timeout';
 import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -76,7 +78,10 @@ function CliMonitorSettingsPage(): React.JSX.Element {
   const [retentionDays, setRetentionDays] = useState('7');
   const [saved, setSaved] = useState(false);
 
-  useEffect(() => {
+  // Auto-dismiss saved indicator
+  useTimeout(() => setSaved(false), saved ? 2000 : null);
+
+  useMountEffect(() => {
     async function loadSettings() {
       setIsLoading(true);
       setError(null);
@@ -97,7 +102,7 @@ function CliMonitorSettingsPage(): React.JSX.Element {
       }
     }
     loadSettings();
-  }, []);
+  });
 
   const isSavingRef = useRef(false);
   const handleSave = useCallback(async () => {
@@ -111,7 +116,6 @@ function CliMonitorSettingsPage(): React.JSX.Element {
       });
       if (result.ok) {
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
       } else {
         setError('Failed to save settings. Please try again.');
       }

--- a/src/app/routes/settings/github.tsx
+++ b/src/app/routes/settings/github.tsx
@@ -10,9 +10,10 @@ import {
   LockKey,
 } from '@phosphor-icons/react';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { cn } from '@/lib/utils/cn';
 
 export const Route = createFileRoute('/settings/github')({
@@ -55,7 +56,7 @@ function GitHubSettingsPage(): React.JSX.Element {
   const [hasGitHubToken, setHasGitHubToken] = useState<boolean | null>(null);
 
   // Check if GitHub PAT is configured
-  useEffect(() => {
+  useMountEffect(() => {
     const checkToken = async () => {
       try {
         const savedToken = localStorage.getItem('github_pat');
@@ -65,7 +66,7 @@ function GitHubSettingsPage(): React.JSX.Element {
       }
     };
     checkToken();
-  }, []);
+  });
 
   // Loading state
   if (hasGitHubToken === null) {

--- a/src/app/routes/settings/model-optimizations.tsx
+++ b/src/app/routes/settings/model-optimizations.tsx
@@ -14,11 +14,13 @@ import {
   Warning,
 } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
 import { ModelSelector } from '@/app/components/ui/model-selector';
 import { ToolAccessSelector } from '@/app/components/ui/tool-access-selector';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useTimeout } from '@/app/hooks/use-timeout';
 import { apiClient } from '@/lib/api/client';
 import {
   DEFAULT_AGENT_MODEL,
@@ -161,8 +163,11 @@ function ModelOptimizationsPage(): React.JSX.Element {
   const [saved, setSaved] = useState(false);
   const [showAgentTools, setShowAgentTools] = useState(false);
 
+  // Auto-dismiss saved indicator
+  useTimeout(() => setSaved(false), saved ? 2000 : null);
+
   // Load settings from API on mount
-  useEffect(() => {
+  useMountEffect(() => {
     async function loadSettings() {
       setIsLoading(true);
       setError(null);
@@ -204,7 +209,7 @@ function ModelOptimizationsPage(): React.JSX.Element {
       }
     }
     loadSettings();
-  }, []);
+  });
 
   const isSavingRef = useRef(false);
   const handleSave = useCallback(async () => {
@@ -224,7 +229,6 @@ function ModelOptimizationsPage(): React.JSX.Element {
       });
       if (result.ok) {
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
       } else {
         console.error('Failed to save settings:', result.error);
         setError('Failed to save settings. Please try again.');

--- a/src/app/routes/settings/preferences.tsx
+++ b/src/app/routes/settings/preferences.tsx
@@ -15,9 +15,11 @@ import {
   Warning,
 } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useTimeout } from '@/app/hooks/use-timeout';
 import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -166,8 +168,11 @@ function PreferencesSettingsPage(): React.JSX.Element {
 
   const [saved, setSaved] = useState(false);
 
+  // Auto-dismiss saved indicator
+  useTimeout(() => setSaved(false), saved ? 2000 : null);
+
   // Load settings from API on mount
-  useEffect(() => {
+  useMountEffect(() => {
     async function loadSettings() {
       setIsLoading(true);
       setError(null);
@@ -206,7 +211,7 @@ function PreferencesSettingsPage(): React.JSX.Element {
       }
     }
     loadSettings();
-  }, []);
+  });
 
   const isSavingRef = useRef(false);
   const handleSave = useCallback(async () => {
@@ -223,7 +228,6 @@ function PreferencesSettingsPage(): React.JSX.Element {
       });
       if (result.ok) {
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
       } else {
         console.error('Failed to save settings:', result.error);
         setError('Failed to save settings. Please try again.');

--- a/src/app/routes/settings/prompts.tsx
+++ b/src/app/routes/settings/prompts.tsx
@@ -17,8 +17,10 @@ import {
   WarningCircle,
 } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
+import { useTimeout } from '@/app/hooks/use-timeout';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import type { PromptCategory, PromptCategoryInfo, PromptDefinition } from '@/lib/prompts';
 import {
@@ -351,8 +353,11 @@ function SystemPromptsPage(): React.JSX.Element {
   const allPrompts = useMemo(() => Object.values(PROMPT_REGISTRY), []);
   const settingsKeys = useMemo(() => getPromptSettingsKeys(), []);
 
+  // Auto-dismiss saved indicator
+  useTimeout(() => setSaved(false), saved ? 2000 : null);
+
   // Load saved overrides from settings
-  useEffect(() => {
+  useWatchEffect(() => {
     if (loaderData?.promptOverrides) return;
     async function load() {
       setIsLoading(true);
@@ -426,7 +431,6 @@ function SystemPromptsPage(): React.JSX.Element {
       if (result.ok) {
         setSavedEdits({ ...edits });
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
       } else {
         setError('Failed to save settings. Please try again.');
       }

--- a/src/app/routes/settings/prompts.tsx
+++ b/src/app/routes/settings/prompts.tsx
@@ -30,6 +30,21 @@ import {
 import { cn } from '@/lib/utils/cn';
 
 export const Route = createFileRoute('/settings/prompts')({
+  loader: async () => {
+    const keys = getPromptSettingsKeys();
+    const result = await apiClient.settings.get(keys);
+    if (result.ok) {
+      const loaded: Record<string, string> = {};
+      for (const prompt of Object.values(PROMPT_REGISTRY)) {
+        const val = result.data.settings[prompt.settingsKey];
+        if (typeof val === 'string' && val.length > 0) {
+          loaded[prompt.id] = val;
+        }
+      }
+      return { promptOverrides: loaded };
+    }
+    return { promptOverrides: null };
+  },
   component: SystemPromptsPage,
 });
 
@@ -315,15 +330,22 @@ function CategorySection({
 // ============================================================================
 
 function SystemPromptsPage(): React.JSX.Element {
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as
+    | { promptOverrides: Record<string, string> | null }
+    | undefined;
+  const [isLoading, setIsLoading] = useState(!loaderData?.promptOverrides);
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Stores current edit values — empty string means "use default"
-  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [edits, setEdits] = useState<Record<string, string>>(
+    () => (loaderData?.promptOverrides as Record<string, string>) ?? {}
+  );
   // Stores the last-saved values to detect dirty state
-  const [savedEdits, setSavedEdits] = useState<Record<string, string>>({});
+  const [savedEdits, setSavedEdits] = useState<Record<string, string>>(
+    () => (loaderData?.promptOverrides as Record<string, string>) ?? {}
+  );
 
   const promptsByCategory = useMemo(() => getPromptsByCategory(), []);
   const allPrompts = useMemo(() => Object.values(PROMPT_REGISTRY), []);
@@ -331,6 +353,7 @@ function SystemPromptsPage(): React.JSX.Element {
 
   // Load saved overrides from settings
   useEffect(() => {
+    if (loaderData?.promptOverrides) return;
     async function load() {
       setIsLoading(true);
       setError(null);
@@ -356,7 +379,7 @@ function SystemPromptsPage(): React.JSX.Element {
       }
     }
     load();
-  }, [allPrompts, settingsKeys]);
+  }, [allPrompts, settingsKeys, loaderData]);
 
   const handleEdit = useCallback((promptId: string, value: string) => {
     const def = PROMPT_REGISTRY[promptId];

--- a/src/app/routes/settings/sandbox.tsx
+++ b/src/app/routes/settings/sandbox.tsx
@@ -22,11 +22,14 @@ import {
   X,
 } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { z } from 'zod';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
 import { Switch } from '@/app/components/ui/switch';
+import { useInterval } from '@/app/hooks/use-interval';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import {
   apiClient,
   type CreateSandboxConfigInput,
@@ -406,12 +409,12 @@ function SandboxSettingsPage(): React.JSX.Element {
   // Timeout refs for cleanup on unmount
   const defaultsSavedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const providerSavedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       clearTimeout(defaultsSavedTimerRef.current);
       clearTimeout(providerSavedTimerRef.current);
     };
-  }, []);
+  });
 
   // K8s configuration state
   const [k8sStatus, setK8sStatus] = useState<K8sStatus | null>(null);
@@ -685,7 +688,7 @@ function SandboxSettingsPage(): React.JSX.Element {
     }
   };
 
-  useEffect(() => {
+  useWatchEffect(() => {
     loadConfigs();
     loadDefaultSettings();
   }, [loadConfigs, loadDefaultSettings]);
@@ -766,7 +769,7 @@ function SandboxSettingsPage(): React.JSX.Element {
   }, [k8sConfigPath, k8sContext]);
 
   // Load K8s info when provider changes to kubernetes
-  useEffect(() => {
+  useWatchEffect(() => {
     if (selectedProvider === 'kubernetes') {
       loadK8sContexts();
       loadK8sStatus();
@@ -775,7 +778,7 @@ function SandboxSettingsPage(): React.JSX.Element {
 
   // Auto-install CRDs when CRDs are missing but cluster is reachable.
   // Uses a 60-second cooldown to prevent infinite retry loops.
-  useEffect(() => {
+  useWatchEffect(() => {
     if (
       autoInstallCRDs &&
       !controllerLoading &&
@@ -827,13 +830,7 @@ function SandboxSettingsPage(): React.JSX.Element {
   ]);
 
   // Periodic K8s status polling for real-time auto-heal feedback
-  useEffect(() => {
-    if (selectedProvider !== 'kubernetes') return;
-    const interval = setInterval(() => {
-      loadK8sStatus();
-    }, 30_000);
-    return () => clearInterval(interval);
-  }, [selectedProvider, loadK8sStatus]);
+  useInterval(loadK8sStatus, selectedProvider === 'kubernetes' ? 30_000 : null);
 
   // Start minikube manually from the UI
   const handleStartMinikube = async () => {
@@ -917,7 +914,7 @@ function SandboxSettingsPage(): React.JSX.Element {
   }, []);
 
   // Load Nomad info when provider changes to nomad
-  useEffect(() => {
+  useWatchEffect(() => {
     if (selectedProvider === 'nomad') {
       loadNomadStatus();
       loadNomadNamespaces();
@@ -926,13 +923,7 @@ function SandboxSettingsPage(): React.JSX.Element {
   }, [selectedProvider, loadNomadStatus, loadNomadNamespaces, loadNomadDatacenters]);
 
   // Periodic Nomad status polling
-  useEffect(() => {
-    if (selectedProvider !== 'nomad') return;
-    const interval = setInterval(() => {
-      loadNomadStatus();
-    }, 30_000);
-    return () => clearInterval(interval);
-  }, [selectedProvider, loadNomadStatus]);
+  useInterval(loadNomadStatus, selectedProvider === 'nomad' ? 30_000 : null);
 
   const handleSaveProvider = async () => {
     setIsSavingProvider(true);

--- a/src/app/routes/settings/system.tsx
+++ b/src/app/routes/settings/system.tsx
@@ -14,9 +14,11 @@ import {
   X,
 } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button } from '@/app/components/ui/button';
 import { ConfigSection } from '@/app/components/ui/config-section';
+import { useInterval } from '@/app/hooks/use-interval';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import { cn } from '@/lib/utils/cn';
 
@@ -170,11 +172,10 @@ function SystemHealthPage(): React.JSX.Element {
     setIsLoading(false);
   }, []);
 
-  useEffect(() => {
+  useWatchEffect(() => {
     checkHealth();
-    const interval = setInterval(checkHealth, 30000);
-    return () => clearInterval(interval);
   }, [checkHealth]);
+  useInterval(checkHealth, 30000);
 
   const overallStatus =
     frontendHealth?.status === 'ok' && backendHealth?.status === 'healthy' ? 'healthy' : 'degraded';

--- a/src/app/routes/templates/org.tsx
+++ b/src/app/routes/templates/org.tsx
@@ -1,6 +1,6 @@
 import { Buildings, Plus, Spinner } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   AddTemplateDialog,
   type CreateTemplateInput,
@@ -9,6 +9,7 @@ import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { TemplateCard } from '@/app/components/features/template-card';
 import { Button } from '@/app/components/ui/button';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import type { Template } from '@/db/schema';
 import { apiClient } from '@/lib/api/client';
 import type { GitHubOrg, GitHubRepo } from '@/services/github-token.service';
@@ -30,7 +31,7 @@ function OrgTemplatesPage(): React.JSX.Element {
   const [isGitHubConfigured, setIsGitHubConfigured] = useState(false);
 
   // Fetch org templates and check GitHub status on mount
-  useEffect(() => {
+  useMountEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
 
@@ -51,7 +52,7 @@ function OrgTemplatesPage(): React.JSX.Element {
       setIsLoading(false);
     };
     fetchData();
-  }, []);
+  });
 
   // GitHub callbacks
   const handleFetchOrgs = useCallback(async (): Promise<GitHubOrg[]> => {

--- a/src/app/routes/templates/project.tsx
+++ b/src/app/routes/templates/project.tsx
@@ -1,6 +1,6 @@
 import { CaretDown, Files, Plus, Spinner } from '@phosphor-icons/react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   AddTemplateDialog,
   type CreateTemplateInput,
@@ -9,6 +9,8 @@ import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { TemplateCard } from '@/app/components/features/template-card';
 import { Button } from '@/app/components/ui/button';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Template } from '@/db/schema';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 import type { GitHubOrg, GitHubRepo } from '@/services/github-token.service';
@@ -68,7 +70,7 @@ function ProjectTemplatesPage(): React.JSX.Element {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Click-outside handler for dropdown
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!showProjectDropdown) return;
 
     const handleClickOutside = (event: MouseEvent) => {
@@ -82,7 +84,7 @@ function ProjectTemplatesPage(): React.JSX.Element {
   }, [showProjectDropdown]);
 
   // Fetch projects and GitHub status on mount
-  useEffect(() => {
+  useMountEffect(() => {
     const fetchInitialData = async () => {
       const [projectsResult, healthResult] = await Promise.all([
         apiClient.projects.list({ limit: 100 }),
@@ -98,7 +100,7 @@ function ProjectTemplatesPage(): React.JSX.Element {
       }
     };
     fetchInitialData();
-  }, []);
+  });
 
   // GitHub callbacks
   const handleFetchOrgs = useCallback(async (): Promise<GitHubOrg[]> => {
@@ -112,7 +114,7 @@ function ProjectTemplatesPage(): React.JSX.Element {
   }, []);
 
   // Fetch templates
-  useEffect(() => {
+  useWatchEffect(() => {
     const fetchTemplates = async () => {
       setIsLoading(true);
       const options: { scope: 'project'; projectId?: string } = { scope: 'project' };

--- a/src/app/routes/terraform/index.tsx
+++ b/src/app/routes/terraform/index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { TerraformChatPanel } from '@/app/components/features/terraform/terraform-chat-panel';
 import { TerraformRightPanel } from '@/app/components/features/terraform/terraform-right-panel';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 
 export const Route = createFileRoute('/terraform/')({
   component: TerraformComposeView,
@@ -14,11 +15,11 @@ function TerraformComposeView(): React.JSX.Element {
 
   const cleanupRef = useRef<(() => void) | null>(null);
 
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       cleanupRef.current?.();
     };
-  }, []);
+  });
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/app/routes/worktrees/index.tsx
+++ b/src/app/routes/worktrees/index.tsx
@@ -6,16 +6,24 @@ import { WorktreeManagement } from '@/app/components/features/worktree-managemen
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 export const Route = createFileRoute('/worktrees/')({
+  loader: async () => {
+    const result = await apiClient.projects.list({ limit: 1 });
+    return { project: result.ok ? (result.data.items[0] ?? null) : null };
+  },
   component: WorktreesPage,
 });
 
 function WorktreesPage(): React.JSX.Element {
-  const [project, setProject] = useState<ProjectListItem | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const loaderData = Route.useLoaderData() as { project: ProjectListItem | null } | undefined;
+  const [project, setProject] = useState<ProjectListItem | null>(
+    () => (loaderData?.project as ProjectListItem) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(!loaderData);
   const [error, setError] = useState<string | null>(null);
 
   // Fetch project from API on mount
   useEffect(() => {
+    if (loaderData?.project !== undefined) return;
     const fetchData = async () => {
       try {
         const projectsResult = await apiClient.projects.list({ limit: 1 });
@@ -33,7 +41,7 @@ function WorktreesPage(): React.JSX.Element {
       }
     };
     void fetchData();
-  }, []);
+  }, [loaderData]);
 
   if (isLoading) {
     return (

--- a/src/app/routes/worktrees/index.tsx
+++ b/src/app/routes/worktrees/index.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorktreeManagement } from '@/app/components/features/worktree-management';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient, type ProjectListItem } from '@/lib/api/client';
 
 export const Route = createFileRoute('/worktrees/')({
@@ -22,7 +23,7 @@ function WorktreesPage(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   // Fetch project from API on mount
-  useEffect(() => {
+  useMountEffect(() => {
     if (loaderData?.project !== undefined) return;
     const fetchData = async () => {
       try {
@@ -41,7 +42,7 @@ function WorktreesPage(): React.JSX.Element {
       }
     };
     void fetchData();
-  }, [loaderData]);
+  });
 
   if (isLoading) {
     return (

--- a/src/lib/bootstrap/hooks.ts
+++ b/src/lib/bootstrap/hooks.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { BootstrapService } from './service.js';
 import type { BootstrapContext, BootstrapState } from './types.js';
 
@@ -16,7 +17,7 @@ export const useBootstrap = (): {
   const [context, setContext] = useState<BootstrapContext | null>(null);
   const serviceRef = useRef<BootstrapService | null>(null);
 
-  useEffect(() => {
+  useMountEffect(() => {
     const service = new BootstrapService();
     serviceRef.current = service;
     const unsubscribe = service.subscribe(setState);
@@ -28,7 +29,7 @@ export const useBootstrap = (): {
     });
 
     return unsubscribe;
-  }, []);
+  });
 
   const retry = useCallback(async () => {
     if (!serviceRef.current) {

--- a/src/lib/hooks/use-settings.ts
+++ b/src/lib/hooks/use-settings.ts
@@ -3,7 +3,8 @@
  * Provides caching and easy access to common settings like task creation model and tools.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 import { DEFAULT_TASK_CREATION_MODEL, getFullModelId } from '@/lib/constants/models';
 import { DEFAULT_TASK_CREATION_TOOLS } from '@/lib/constants/tools';
@@ -210,7 +211,7 @@ export function useSettings(): UseSettingsReturn {
   const [settings, setSettings] = useState<Record<string, unknown>>({});
 
   // Load settings on mount
-  useEffect(() => {
+  useMountEffect(() => {
     const loadSettings = async () => {
       setIsLoading(true);
       setError(null);
@@ -223,8 +224,8 @@ export function useSettings(): UseSettingsReturn {
         setIsLoading(false);
       }
     };
-    loadSettings();
-  }, []);
+    void loadSettings();
+  });
 
   // Derived values
   const taskCreationModel =

--- a/src/lib/sessions/hooks/use-session-data.ts
+++ b/src/lib/sessions/hooks/use-session-data.ts
@@ -8,7 +8,9 @@
  */
 
 import { eq } from '@tanstack/db';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { useInterval } from '@/app/hooks/use-interval';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { useCollectionQuery } from '../../db/use-collection-query.js';
 import {
   agentStateCollection,
@@ -68,10 +70,7 @@ export function usePendingToolCalls(sessionId: string): ToolCallEvent[] {
 export function useSessionPresence(sessionId: string, maxAgeMs = 30000): PresenceEvent[] {
   const [now, setNow] = useState(Date.now());
 
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 5000);
-    return () => clearInterval(interval);
-  }, []);
+  useInterval(() => setNow(Date.now()), 5000);
 
   const cutoff = now - maxAgeMs;
 
@@ -163,7 +162,7 @@ export function useSessionData(sessionId: string): UseSessionDataResult {
   const syncStartedRef = useRef(false);
 
   // Start syncing when the hook mounts
-  useEffect(() => {
+  useWatchEffect(() => {
     if (syncStartedRef.current) return;
 
     syncStartedRef.current = true;

--- a/src/lib/task-creation/hooks.ts
+++ b/src/lib/task-creation/hooks.ts
@@ -1,5 +1,6 @@
 import { eq } from '@tanstack/db';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { apiClient } from '@/lib/api/client';
 import { getTaskCreationToolsAsync } from '@/lib/constants/tools';
 import { useCollectionQuery } from '@/lib/db/use-collection-query';
@@ -147,7 +148,7 @@ export function useTaskCreation(projectId: string): UseTaskCreationReturn {
 
   // Clear isAnswering when questions change or streaming starts
   // This handles the gap between API response and SSE stream starting
-  useEffect(() => {
+  useWatchEffect(() => {
     if (!submittedQuestionsIdRef.current) return;
 
     // Clear loading state when:
@@ -164,7 +165,7 @@ export function useTaskCreation(projectId: string): UseTaskCreationReturn {
   }, [pendingQuestions?.id, isStreaming]);
 
   // Cleanup on unmount
-  useEffect(() => {
+  useWatchEffect(() => {
     return () => {
       if (sessionId) {
         stopTaskCreationSync(sessionId);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
       routesDirectory: './src/app/routes',
       generatedRouteTree: './src/app/routeTree.gen.ts',
       routeFileIgnorePattern: '.*\\/api\\/.*',
+      autoCodeSplitting: true,
     }),
     react(),
     serverOnlyStubs(),


### PR DESCRIPTION
## Summary

Eliminates all direct `useEffect` usage across the frontend codebase (**108 files, 98 call sites**) and enforces the ban via Biome linting. Inspired by [Factory's "Why we banned useEffect"](https://factory.dev/blog/ban-react-useeffect) approach.

### What changed

- **8 purpose-built factory hooks** replace every `useEffect` pattern:

| Hook | Replaces | Files |
|------|----------|-------|
| `useMountEffect(effect)` | `useEffect(fn, [])` | ~15 |
| `useWatchEffect(effect, deps)` | `useEffect(fn, [deps])` | ~40 |
| `useInterval(cb, ms \| null)` | `setInterval` in effects | ~10 |
| `useTimeout(cb, ms \| null)` | `setTimeout` in effects | ~10 |
| `useEventListener(target, event, handler)` | `addEventListener`/`removeEventListener` | ~6 |
| `useAutoScroll()` | scroll-to-bottom + pin detection | ~8 |
| `useCopyToClipboard(ms?)` | copy + timed indicator | ~8 |
| `useLocalStorage(key, initial)` | localStorage sync in effects | ~3 |

- **React 19 `useEffectEvent`** replaces all ref-sync patterns (8 files)
- **Biome `noRestrictedImports`** rule bans `import { useEffect } from 'react'` at error level
- Override exempts 6 factory hook files + test files
- **Decision tree** in `src/app/hooks/AGENTS.md` guides developers to the right hook

### Review-driven fixes

After 4 parallel Opus review agents (code, silent-failures, types, comments):
- Fixed stale closure in `use-plan-session` (→ `useWatchEffect([loadSession])`)
- Fixed stale `onClose` in git-view ContextMenu (→ `useEventListener`)
- Fixed race condition in `use-presence` (consolidated fetch+interval lifecycle)
- Fixed orphaned `setTimeout` in ThinkingIndicator
- Fixed `useWatchEffect([])` → `useMountEffect` in workflow-designer
- Added `console.warn` in `useLocalStorage` catch blocks

### Verification

- Biome check: 765 files, 0 errors
- TypeScript: passes
- Vitest: 213 test files, 6276 tests passed, 0 failures
- Only 6 files import `useEffect` (all factory hooks)

## Test plan

- [x] `npx biome check --max-diagnostics=500 --diagnostic-level=error` — zero violations
- [x] `npx vitest run` — 6276 tests pass
- [x] TypeScript compilation passes (pre-commit hook)
- [ ] Manual smoke test: navigate routes, trigger polling, check SSE streams, verify scroll behavior
- [ ] Verify copy-to-clipboard works across browsers
- [ ] Verify theme toggle persists across refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)