### PR TITLE
feat: improve live task view with status-colored gradient cards

### DIFF
--- a/specs/application/wireframes/task-card-proposals/option-a-left-border.html
+++ b/specs/application/wireframes/task-card-proposals/option-a-left-border.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Option A — Left Border Accent</title>
+  <link rel="stylesheet" href="../design-tokens.css">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Geist:wght@400;500;600&display=swap');
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: var(--bg-canvas);
+      color: var(--fg-default);
+      font-family: 'Geist', -apple-system, sans-serif;
+      padding: 32px;
+    }
+
+    h2 {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--fg-subtle);
+      margin-bottom: 16px;
+    }
+
+    .description {
+      font-size: 13px;
+      color: var(--fg-muted);
+      margin-bottom: 24px;
+      line-height: 1.5;
+      max-width: 400px;
+    }
+
+    .sidebar {
+      width: 320px;
+      background: var(--bg-default);
+      border: 1px solid var(--border-default);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    /* Header */
+    .header {
+      padding: 12px 12px 10px;
+      border-bottom: 1px solid var(--border-default);
+    }
+    .header-top {
+      display: flex; justify-content: space-between; align-items: center;
+      margin-bottom: 8px;
+    }
+    .header-title {
+      font-size: 10px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--fg-subtle);
+    }
+    .sort-label {
+      font-size: 10px; color: var(--fg-subtle);
+    }
+
+    /* Search */
+    .search {
+      width: 100%; padding: 6px 10px 6px 30px;
+      background: var(--bg-subtle); border: 1px solid var(--border-default);
+      border-radius: 6px; color: var(--fg-default); font-size: 13px;
+      outline: none; font-family: inherit;
+    }
+    .search::placeholder { color: var(--fg-subtle); }
+    .search-wrap { position: relative; margin-bottom: 8px; }
+    .search-icon {
+      position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+      color: var(--fg-subtle); font-size: 12px;
+    }
+
+    /* Filter chips */
+    .chips { display: flex; gap: 4px; flex-wrap: wrap; }
+    .chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 8px; border-radius: 99px; font-size: 10px; font-weight: 500;
+      background: var(--bg-subtle); color: var(--fg-subtle);
+      border: 1px solid transparent;
+    }
+    .chip-dot { width: 6px; height: 6px; border-radius: 50%; }
+
+    /* Task list */
+    .task-list { padding: 6px; display: flex; flex-direction: column; gap: 3px; }
+
+    /* === TASK CARD — Option A === */
+    .task-card {
+      position: relative;
+      padding: 10px 12px 10px 16px;
+      border-radius: 6px;
+      border: 1px solid var(--border-default);
+      cursor: pointer;
+      transition: all 0.15s ease;
+      overflow: hidden;
+    }
+
+    /* Left border accent — 3px solid color bar */
+    .task-card::before {
+      content: '';
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 3px;
+      border-radius: 6px 0 0 6px;
+    }
+
+    /* Status-specific styles */
+    .task-card[data-status="backlog"] {
+      background: rgba(110, 118, 129, 0.04);
+    }
+    .task-card[data-status="backlog"]::before {
+      background: var(--fg-subtle);
+      opacity: 0.4;
+    }
+
+    .task-card[data-status="queued"] {
+      background: rgba(56, 139, 253, 0.04);
+    }
+    .task-card[data-status="queued"]::before {
+      background: var(--accent-fg);
+    }
+
+    .task-card[data-status="active"] {
+      background: rgba(46, 160, 67, 0.05);
+    }
+    .task-card[data-status="active"]::before {
+      background: var(--success-fg);
+    }
+
+    .task-card[data-status="review"] {
+      background: rgba(187, 128, 9, 0.05);
+    }
+    .task-card[data-status="review"]::before {
+      background: var(--attention-fg);
+    }
+
+    .task-card[data-status="error"] {
+      background: rgba(248, 81, 73, 0.06);
+      border-color: rgba(248, 81, 73, 0.2);
+    }
+    .task-card[data-status="error"]::before {
+      background: var(--danger-fg);
+    }
+
+    .task-card[data-status="done"] {
+      background: rgba(163, 113, 247, 0.04);
+    }
+    .task-card[data-status="done"]::before {
+      background: var(--done-fg);
+      opacity: 0.6;
+    }
+
+    .task-card:hover {
+      border-color: var(--fg-subtle);
+    }
+
+    .task-card.selected {
+      border-color: var(--accent-fg);
+      background: var(--accent-muted);
+    }
+    .task-card.selected::before {
+      background: var(--accent-fg) !important;
+      opacity: 1 !important;
+    }
+
+    /* Card content */
+    .card-header {
+      display: flex; align-items: flex-start; gap: 8px;
+    }
+    .priority-icon {
+      width: 16px; height: 16px; margin-top: 2px; flex-shrink: 0;
+    }
+    .task-title {
+      font-size: 13px; font-weight: 500; line-height: 1.35;
+      color: var(--fg-default);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      flex: 1;
+    }
+    .card-footer {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-top: 6px;
+    }
+    .task-id {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px; color: var(--fg-subtle);
+    }
+
+    /* Status badge — pill with icon */
+    .status-badge {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 8px; border-radius: 99px;
+      font-size: 10px; font-weight: 500;
+    }
+    .status-badge .badge-dot {
+      width: 5px; height: 5px; border-radius: 50%;
+    }
+
+    .badge-planning { background: rgba(247, 120, 186, 0.12); color: #f778ba; }
+    .badge-planning .badge-dot { background: #f778ba; }
+
+    .badge-error { background: rgba(248, 81, 73, 0.12); color: #f85149; }
+    .badge-error .badge-dot { background: #f85149; }
+
+    .badge-running { background: rgba(46, 160, 67, 0.12); color: #3fb950; }
+    .badge-running .badge-dot { background: #3fb950; animation: pulse 1.5s infinite; }
+
+    .badge-completed { background: rgba(163, 113, 247, 0.12); color: #a371f7; }
+    .badge-completed .badge-dot { background: #a371f7; }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+
+    /* Agent running bar */
+    .agent-running {
+      display: flex; align-items: center; gap: 6px;
+      margin-top: 6px; padding: 3px 0;
+      font-size: 10px; font-weight: 500; color: var(--success-fg);
+    }
+    .agent-running .pulse-dot {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--success-fg);
+      animation: pulse 1.5s infinite;
+    }
+
+    /* Footer */
+    .sidebar-footer {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 8px 12px; border-top: 1px solid var(--border-default);
+      font-size: 10px; color: var(--fg-subtle);
+    }
+  </style>
+</head>
+<body>
+  <h2>Option A — Left Border Accent</h2>
+  <p class="description">
+    Bold 3px colored left border per status with subtle background tinting.
+    Status badges use pill shape with colored dot indicators. Error cards get a tinted border.
+    Clean and scannable — the left edge creates a strong color column for instant recognition.
+  </p>
+
+  <div class="sidebar">
+    <div class="header">
+      <div class="header-top">
+        <span class="header-title">Tasks</span>
+        <span class="sort-label">⇅ Status</span>
+      </div>
+      <div class="search-wrap">
+        <span class="search-icon">⌕</span>
+        <input class="search" placeholder="Search tasks…">
+      </div>
+      <div class="chips">
+        <span class="chip"><span class="chip-dot" style="background:var(--fg-subtle)"></span> Backlog</span>
+        <span class="chip"><span class="chip-dot" style="background:var(--accent-fg)"></span> Queued</span>
+        <span class="chip"><span class="chip-dot" style="background:var(--success-fg)"></span> Active</span>
+        <span class="chip" style="background:var(--attention-muted);color:var(--attention-fg);border-color:rgba(210,153,34,0.3)">
+          <span class="chip-dot" style="background:var(--attention-fg)"></span> Review <span style="opacity:0.7">9</span>
+        </span>
+        <span class="chip"><span class="chip-dot" style="background:var(--done-fg)"></span> Done <span style="opacity:0.7">5</span></span>
+      </div>
+    </div>
+
+    <div class="task-list">
+      <!-- Active + agent running -->
+      <div class="task-card" data-status="active">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+          <span class="task-title">Build AWS Web App Terraform Module</span>
+        </div>
+        <div class="agent-running">
+          <span class="pulse-dot"></span>
+          Agent running…
+        </div>
+      </div>
+
+      <!-- Review / Plan ready -->
+      <div class="task-card" data-status="review">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+          <span class="task-title">Build AWS Terraform Module with Docs</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-LA6</span>
+          <span class="status-badge badge-planning"><span class="badge-dot"></span> Plan ready</span>
+        </div>
+      </div>
+
+      <!-- Review / Plan ready -->
+      <div class="task-card" data-status="review">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+          <span class="task-title">Create reusable Terraform S3 module</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-M3W</span>
+          <span class="status-badge badge-planning"><span class="badge-dot"></span> Plan ready</span>
+        </div>
+      </div>
+
+      <!-- Error -->
+      <div class="task-card" data-status="error">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--danger-fg)" opacity="0.9"/></svg>
+          <span class="task-title">Create reusable Terraform module for S3</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-UZ3</span>
+          <span class="status-badge badge-error"><span class="badge-dot"></span> Error</span>
+        </div>
+      </div>
+
+      <!-- Queued -->
+      <div class="task-card" data-status="queued">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><rect x="3" y="6" width="10" height="4" rx="1" fill="var(--accent-fg)" opacity="0.7"/></svg>
+          <span class="task-title">Build reusable S3 module with versioning</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-Q20</span>
+          <span class="status-badge" style="background:var(--accent-muted);color:var(--accent-fg)"><span class="badge-dot" style="background:var(--accent-fg)"></span> Queued</span>
+        </div>
+      </div>
+
+      <!-- Backlog -->
+      <div class="task-card" data-status="backlog">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><rect x="3" y="6" width="10" height="4" rx="1" fill="var(--fg-subtle)" opacity="0.5"/></svg>
+          <span class="task-title">Create reusable Terraform module for AWS</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-ZVG</span>
+          <span style="font-size:10px;font-weight:500;color:var(--fg-subtle)">P1</span>
+        </div>
+      </div>
+
+      <!-- Selected card -->
+      <div class="task-card selected" data-status="review">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+          <span class="task-title">Build reusable S3 module for AWS</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-VXI</span>
+          <span class="status-badge badge-planning"><span class="badge-dot"></span> Plan ready</span>
+        </div>
+      </div>
+
+      <!-- Done -->
+      <div class="task-card" data-status="done">
+        <div class="card-header">
+          <svg class="priority-icon" viewBox="0 0 16 16"><circle cx="8" cy="8" r="5" fill="var(--done-fg)" opacity="0.5"/></svg>
+          <span class="task-title">Create S3 module with encryption</span>
+        </div>
+        <div class="card-footer">
+          <span class="task-id">#TSK-5B6</span>
+          <span class="status-badge badge-completed"><span class="badge-dot"></span> Completed</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="sidebar-footer">
+      <span>8 tasks</span>
+      <span>👁 Done (5)</span>
+      <span>↑↓ navigate</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/specs/application/wireframes/task-card-proposals/option-b-gradient-strip.html
+++ b/specs/application/wireframes/task-card-proposals/option-b-gradient-strip.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Option B — Gradient Strip</title>
+  <link rel="stylesheet" href="../design-tokens.css">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Geist:wght@400;500;600&display=swap');
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: var(--bg-canvas);
+      color: var(--fg-default);
+      font-family: 'Geist', -apple-system, sans-serif;
+      padding: 32px;
+    }
+
+    h2 {
+      font-size: 11px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: var(--fg-subtle); margin-bottom: 16px;
+    }
+    .description {
+      font-size: 13px; color: var(--fg-muted); margin-bottom: 24px;
+      line-height: 1.5; max-width: 420px;
+    }
+
+    .sidebar {
+      width: 320px; background: var(--bg-default);
+      border: 1px solid var(--border-default); border-radius: 8px; overflow: hidden;
+    }
+
+    .header {
+      padding: 12px 12px 10px; border-bottom: 1px solid var(--border-default);
+    }
+    .header-top {
+      display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;
+    }
+    .header-title {
+      font-size: 10px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--fg-subtle);
+    }
+    .sort-label { font-size: 10px; color: var(--fg-subtle); }
+
+    .search {
+      width: 100%; padding: 6px 10px 6px 30px;
+      background: var(--bg-subtle); border: 1px solid var(--border-default);
+      border-radius: 6px; color: var(--fg-default); font-size: 13px;
+      outline: none; font-family: inherit;
+    }
+    .search::placeholder { color: var(--fg-subtle); }
+    .search-wrap { position: relative; margin-bottom: 8px; }
+    .search-icon {
+      position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+      color: var(--fg-subtle); font-size: 12px;
+    }
+
+    .chips { display: flex; gap: 4px; flex-wrap: wrap; }
+    .chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 8px; border-radius: 99px; font-size: 10px; font-weight: 500;
+      background: var(--bg-subtle); color: var(--fg-subtle);
+      border: 1px solid transparent;
+    }
+    .chip-dot { width: 6px; height: 6px; border-radius: 50%; }
+
+    .task-list { padding: 6px; display: flex; flex-direction: column; gap: 3px; }
+
+    /* === TASK CARD — Option B: Gradient Strip === */
+    .task-card {
+      position: relative;
+      padding: 10px 12px;
+      border-radius: 6px;
+      border: 1px solid var(--border-default);
+      cursor: pointer;
+      transition: all 0.15s ease;
+      overflow: hidden;
+    }
+
+    /* Gradient fade from left edge */
+    .task-card::before {
+      content: '';
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 40%;
+      pointer-events: none;
+      opacity: 0.08;
+    }
+
+    /* Top status strip — thin colored line at top */
+    .task-card::after {
+      content: '';
+      position: absolute;
+      left: 0; right: 0; top: 0;
+      height: 2px;
+    }
+
+    /* Status variations */
+    .task-card[data-status="backlog"]::before {
+      background: linear-gradient(to right, var(--fg-subtle), transparent);
+      opacity: 0.04;
+    }
+    .task-card[data-status="backlog"]::after {
+      background: var(--fg-subtle); opacity: 0.3;
+    }
+
+    .task-card[data-status="queued"]::before {
+      background: linear-gradient(to right, var(--accent-fg), transparent);
+    }
+    .task-card[data-status="queued"]::after {
+      background: var(--accent-fg);
+    }
+
+    .task-card[data-status="active"]::before {
+      background: linear-gradient(to right, var(--success-fg), transparent);
+      opacity: 0.1;
+    }
+    .task-card[data-status="active"]::after {
+      background: var(--success-fg);
+    }
+
+    .task-card[data-status="review"]::before {
+      background: linear-gradient(to right, var(--attention-fg), transparent);
+    }
+    .task-card[data-status="review"]::after {
+      background: var(--attention-fg);
+    }
+
+    .task-card[data-status="error"]::before {
+      background: linear-gradient(to right, var(--danger-fg), transparent);
+      opacity: 0.1;
+    }
+    .task-card[data-status="error"]::after {
+      background: var(--danger-fg);
+    }
+    .task-card[data-status="error"] {
+      border-color: rgba(248, 81, 73, 0.25);
+    }
+
+    .task-card[data-status="done"]::before {
+      background: linear-gradient(to right, var(--done-fg), transparent);
+      opacity: 0.05;
+    }
+    .task-card[data-status="done"]::after {
+      background: var(--done-fg); opacity: 0.5;
+    }
+
+    .task-card:hover { border-color: var(--fg-subtle); }
+
+    .task-card.selected {
+      border-color: var(--accent-fg);
+      background: var(--accent-muted);
+    }
+    .task-card.selected::before {
+      background: linear-gradient(to right, var(--accent-fg), transparent) !important;
+      opacity: 0.12 !important;
+    }
+    .task-card.selected::after {
+      background: var(--accent-fg) !important;
+      opacity: 1 !important;
+    }
+
+    /* Card content */
+    .card-row-1 {
+      display: flex; align-items: center; gap: 6px; margin-bottom: 4px;
+    }
+    .status-tag {
+      display: inline-flex; align-items: center; gap: 3px;
+      padding: 1px 6px; border-radius: 3px;
+      font-size: 9px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .tag-backlog { background: rgba(110,118,129,0.1); color: var(--fg-subtle); }
+    .tag-queued { background: var(--accent-muted); color: var(--accent-fg); }
+    .tag-active { background: var(--success-muted); color: var(--success-fg); }
+    .tag-review { background: var(--attention-muted); color: var(--attention-fg); }
+    .tag-error { background: var(--danger-muted); color: var(--danger-fg); }
+    .tag-done { background: var(--done-muted); color: var(--done-fg); }
+
+    .task-id {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 10px; color: var(--fg-subtle);
+    }
+
+    .card-header {
+      display: flex; align-items: flex-start; gap: 8px;
+    }
+    .priority-icon {
+      width: 14px; height: 14px; margin-top: 2px; flex-shrink: 0;
+    }
+    .task-title {
+      font-size: 13px; font-weight: 500; line-height: 1.35;
+      color: var(--fg-default);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;
+    }
+
+    /* Agent run status */
+    .run-status {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 7px; border-radius: 99px;
+      font-size: 10px; font-weight: 500;
+    }
+    .run-planning { background: rgba(247,120,186,0.12); color: #f778ba; }
+    .run-error { background: rgba(248,81,73,0.12); color: #f85149; }
+    .run-running { background: rgba(46,160,67,0.12); color: #3fb950; }
+
+    .card-footer {
+      display: flex; align-items: center; justify-content: flex-end; margin-top: 6px;
+    }
+
+    .agent-running {
+      display: flex; align-items: center; gap: 6px;
+      margin-top: 6px; font-size: 10px; font-weight: 500; color: var(--success-fg);
+    }
+    .pulse-dot {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--success-fg); animation: pulse 1.5s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; } 50% { opacity: 0.3; }
+    }
+
+    .sidebar-footer {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 8px 12px; border-top: 1px solid var(--border-default);
+      font-size: 10px; color: var(--fg-subtle);
+    }
+  </style>
+</head>
+<body>
+  <h2>Option B — Gradient Strip + Status Tag</h2>
+  <p class="description">
+    Colored gradient wash fading from the left edge with a 2px top strip.
+    Each card shows an uppercase status tag inline with the task ID.
+    Bolder visual footprint — the gradient creates atmospheric status zones.
+    Error cards get both a red gradient and highlighted border.
+  </p>
+
+  <div class="sidebar">
+    <div class="header">
+      <div class="header-top">
+        <span class="header-title">Tasks</span>
+        <span class="sort-label">⇅ Status</span>
+      </div>
+      <div class="search-wrap">
+        <span class="search-icon">⌕</span>
+        <input class="search" placeholder="Search tasks…">
+      </div>
+      <div class="chips">
+        <span class="chip"><span class="chip-dot" style="background:var(--fg-subtle)"></span> Backlog</span>
+        <span class="chip"><span class="chip-dot" style="background:var(--accent-fg)"></span> Queued</span>
+        <span class="chip"><span class="chip-dot" style="background:var(--success-fg)"></span> Active</span>
+        <span class="chip" style="background:var(--attention-muted);color:var(--attention-fg);border-color:rgba(210,153,34,0.3)">
+          <span class="chip-dot" style="background:var(--attention-fg)"></span> Review <span style="opacity:0.7">9</span>
+        </span>
+        <span class="chip"><span class="chip-dot" style="background:var(--done-fg)"></span> Done <span style="opacity:0.7">5</span></span>
+      </div>
+    </div>
+
+    <div class="task-list">
+      <!-- Active + running -->
+      <div class="task-card" data-status="active">
+        <div class="card-row-1">
+          <span class="status-tag tag-active">● Active</span>
+          <span class="task-id">#TSK-9YZ</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Build AWS Web App Terraform Module</span>
+        </div>
+        <div class="agent-running">
+          <span class="pulse-dot"></span> Agent running…
+        </div>
+      </div>
+
+      <!-- Review / plan ready -->
+      <div class="task-card" data-status="review">
+        <div class="card-row-1">
+          <span class="status-tag tag-review">⚡ Review</span>
+          <span class="task-id">#TSK-LA6</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Build AWS Terraform Module with Docs</span>
+        </div>
+        <div class="card-footer">
+          <span class="run-status run-planning">⚡ Plan ready</span>
+        </div>
+      </div>
+
+      <!-- Review -->
+      <div class="task-card" data-status="review">
+        <div class="card-row-1">
+          <span class="status-tag tag-review">⚡ Review</span>
+          <span class="task-id">#TSK-M3W</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Create reusable Terraform S3 module with encryption</span>
+        </div>
+        <div class="card-footer">
+          <span class="run-status run-planning">⚡ Plan ready</span>
+        </div>
+      </div>
+
+      <!-- Error -->
+      <div class="task-card" data-status="error">
+        <div class="card-row-1">
+          <span class="status-tag tag-error">⚠ Error</span>
+          <span class="task-id">#TSK-UZ3</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Create reusable Terraform module for S3</span>
+        </div>
+        <div class="card-footer">
+          <span class="run-status run-error">⚠ Error</span>
+        </div>
+      </div>
+
+      <!-- Queued -->
+      <div class="task-card" data-status="queued">
+        <div class="card-row-1">
+          <span class="status-tag tag-queued">◉ Queued</span>
+          <span class="task-id">#TSK-Q20</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Build reusable S3 module with versioning</span>
+        </div>
+      </div>
+
+      <!-- Selected -->
+      <div class="task-card selected" data-status="review">
+        <div class="card-row-1">
+          <span class="status-tag tag-review">⚡ Review</span>
+          <span class="task-id">#TSK-VXI</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Build reusable Terraform S3 module</span>
+        </div>
+        <div class="card-footer">
+          <span class="run-status run-planning">⚡ Plan ready</span>
+        </div>
+      </div>
+
+      <!-- Backlog -->
+      <div class="task-card" data-status="backlog">
+        <div class="card-row-1">
+          <span class="status-tag tag-backlog">○ Backlog</span>
+          <span class="task-id">#TSK-ZVG</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Create reusable Terraform module for AWS</span>
+        </div>
+      </div>
+
+      <!-- Done -->
+      <div class="task-card" data-status="done">
+        <div class="card-row-1">
+          <span class="status-tag tag-done">✓ Done</span>
+          <span class="task-id">#TSK-5B6</span>
+        </div>
+        <div class="card-header">
+          <span class="task-title">Create S3 module with encryption</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="sidebar-footer">
+      <span>8 tasks</span>
+      <span>👁 Done (5)</span>
+      <span>↑↓ navigate</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/specs/application/wireframes/task-card-proposals/option-c-status-rail.html
+++ b/specs/application/wireframes/task-card-proposals/option-c-status-rail.html
@@ -1,0 +1,381 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Option C — Status Rail</title>
+  <link rel="stylesheet" href="../design-tokens.css">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Geist:wght@400;500;600&display=swap');
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: var(--bg-canvas);
+      color: var(--fg-default);
+      font-family: 'Geist', -apple-system, sans-serif;
+      padding: 32px;
+    }
+
+    h2 {
+      font-size: 11px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: var(--fg-subtle); margin-bottom: 16px;
+    }
+    .description {
+      font-size: 13px; color: var(--fg-muted); margin-bottom: 24px;
+      line-height: 1.5; max-width: 420px;
+    }
+
+    .sidebar {
+      width: 320px; background: var(--bg-default);
+      border: 1px solid var(--border-default); border-radius: 8px; overflow: hidden;
+    }
+
+    .header {
+      padding: 12px 12px 10px; border-bottom: 1px solid var(--border-default);
+    }
+    .header-top {
+      display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;
+    }
+    .header-title {
+      font-size: 10px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--fg-subtle);
+    }
+    .sort-label { font-size: 10px; color: var(--fg-subtle); }
+
+    .search {
+      width: 100%; padding: 6px 10px 6px 30px;
+      background: var(--bg-subtle); border: 1px solid var(--border-default);
+      border-radius: 6px; color: var(--fg-default); font-size: 13px;
+      outline: none; font-family: inherit;
+    }
+    .search::placeholder { color: var(--fg-subtle); }
+    .search-wrap { position: relative; margin-bottom: 8px; }
+    .search-icon {
+      position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+      color: var(--fg-subtle); font-size: 12px;
+    }
+
+    .chips { display: flex; gap: 4px; flex-wrap: wrap; }
+    .chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 8px; border-radius: 99px; font-size: 10px; font-weight: 500;
+      background: var(--bg-subtle); color: var(--fg-subtle);
+      border: 1px solid transparent;
+    }
+    .chip-dot { width: 6px; height: 6px; border-radius: 50%; }
+
+    .task-list { padding: 6px; display: flex; flex-direction: column; gap: 2px; }
+
+    /* === TASK CARD — Option C: Status Rail === */
+    .task-card {
+      position: relative;
+      display: flex;
+      border-radius: 6px;
+      border: 1px solid var(--border-default);
+      cursor: pointer;
+      transition: all 0.15s ease;
+      overflow: hidden;
+    }
+
+    /* Left rail — thin colored strip */
+    .status-rail {
+      width: 4px;
+      flex-shrink: 0;
+      position: relative;
+    }
+
+    /* Status dot on the rail */
+    .status-rail::after {
+      content: '';
+      position: absolute;
+      top: 14px; left: 50%;
+      transform: translateX(-50%);
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      border: 2px solid var(--bg-default);
+    }
+
+    .card-content {
+      flex: 1;
+      padding: 8px 12px 8px 10px;
+      min-width: 0;
+    }
+
+    /* Status colors */
+    .task-card[data-status="backlog"] .status-rail {
+      background: var(--fg-subtle); opacity: 0.2;
+    }
+    .task-card[data-status="backlog"] .status-rail::after {
+      background: var(--fg-subtle); opacity: 0.5;
+    }
+
+    .task-card[data-status="queued"] .status-rail {
+      background: var(--accent-fg); opacity: 0.4;
+    }
+    .task-card[data-status="queued"] .status-rail::after {
+      background: var(--accent-fg);
+    }
+
+    .task-card[data-status="active"] .status-rail {
+      background: var(--success-fg);
+    }
+    .task-card[data-status="active"] .status-rail::after {
+      background: var(--success-fg);
+      box-shadow: 0 0 6px rgba(63, 185, 80, 0.5);
+    }
+
+    .task-card[data-status="review"] .status-rail {
+      background: var(--attention-fg); opacity: 0.7;
+    }
+    .task-card[data-status="review"] .status-rail::after {
+      background: var(--attention-fg);
+    }
+
+    .task-card[data-status="error"] .status-rail {
+      background: var(--danger-fg);
+    }
+    .task-card[data-status="error"] .status-rail::after {
+      background: var(--danger-fg);
+      box-shadow: 0 0 6px rgba(248, 81, 73, 0.4);
+    }
+    .task-card[data-status="error"] {
+      border-color: rgba(248, 81, 73, 0.2);
+    }
+
+    .task-card[data-status="done"] .status-rail {
+      background: var(--done-fg); opacity: 0.4;
+    }
+    .task-card[data-status="done"] .status-rail::after {
+      background: var(--done-fg);
+    }
+
+    .task-card:hover {
+      border-color: var(--fg-subtle);
+    }
+
+    .task-card.selected {
+      border-color: var(--accent-fg);
+      background: var(--accent-muted);
+    }
+    .task-card.selected .status-rail {
+      background: var(--accent-fg) !important;
+      opacity: 1 !important;
+    }
+    .task-card.selected .status-rail::after {
+      background: var(--accent-fg) !important;
+      opacity: 1 !important;
+      box-shadow: 0 0 6px rgba(88, 166, 255, 0.4);
+    }
+
+    /* Card content */
+    .card-header {
+      display: flex; align-items: flex-start; gap: 6px;
+    }
+    .priority-icon {
+      width: 14px; height: 14px; margin-top: 1px; flex-shrink: 0;
+    }
+    .task-title {
+      font-size: 13px; font-weight: 500; line-height: 1.3;
+      color: var(--fg-default);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;
+    }
+
+    .card-footer {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-top: 5px;
+    }
+    .task-id {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 10px; color: var(--fg-subtle);
+    }
+
+    /* Compact status chip */
+    .status-chip {
+      display: inline-flex; align-items: center; gap: 3px;
+      padding: 1px 6px; border-radius: 3px;
+      font-size: 9px; font-weight: 600;
+    }
+    .chip-planning { background: rgba(247,120,186,0.1); color: #f778ba; }
+    .chip-error { background: rgba(248,81,73,0.1); color: #f85149; }
+    .chip-queued { background: var(--accent-muted); color: var(--accent-fg); }
+    .chip-done { background: var(--done-muted); color: var(--done-fg); }
+
+    .agent-running {
+      display: flex; align-items: center; gap: 5px;
+      margin-top: 4px; font-size: 10px; font-weight: 500; color: var(--success-fg);
+    }
+    .pulse-dot {
+      width: 5px; height: 5px; border-radius: 50%;
+      background: var(--success-fg); animation: pulse 1.5s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; } 50% { opacity: 0.3; }
+    }
+
+    .sidebar-footer {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 8px 12px; border-top: 1px solid var(--border-default);
+      font-size: 10px; color: var(--fg-subtle);
+    }
+  </style>
+</head>
+<body>
+  <h2>Option C — Status Rail with Dot Indicator</h2>
+  <p class="description">
+    A 4px colored rail runs along the left edge with an 8px status dot indicator.
+    Cleanest and most refined option — the rail creates a subtle but consistent
+    color column. Active and error states get a glow on the dot. Cards are compact
+    with inline status chips. Minimal visual noise, maximum scannability.
+  </p>
+
+  <div class="sidebar">
+    <div class="header">
+      <div class="header-top">
+        <span class="header-title">Tasks</span>
+        <span class="sort-label">⇅ Status</span>
+      </div>
+      <div class="search-wrap">
+        <span class="search-icon">⌕</span>
+        <input class="search" placeholder="Search tasks…">
+      </div>
+      <div class="chips">
+        <span class="chip"><span class="chip-dot" style="background:var(--fg-subtle)"></span> Backlog</span>
+        <span class="chip"><span class="chip-dot" style="background:var(--accent-fg)"></span> Queued</span>
+        <span class="chip"><span class="chip-dot" style="background:var(--success-fg)"></span> Active</span>
+        <span class="chip" style="background:var(--attention-muted);color:var(--attention-fg);border-color:rgba(210,153,34,0.3)">
+          <span class="chip-dot" style="background:var(--attention-fg)"></span> Review <span style="opacity:0.7">9</span>
+        </span>
+        <span class="chip"><span class="chip-dot" style="background:var(--done-fg)"></span> Done <span style="opacity:0.7">5</span></span>
+      </div>
+    </div>
+
+    <div class="task-list">
+      <!-- Active + running -->
+      <div class="task-card" data-status="active">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+            <span class="task-title">Build AWS Web App Terraform Module</span>
+          </div>
+          <div class="agent-running">
+            <span class="pulse-dot"></span> Agent running…
+          </div>
+        </div>
+      </div>
+
+      <!-- Review -->
+      <div class="task-card" data-status="review">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+            <span class="task-title">Build AWS Terraform Module with Docs</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-LA6</span>
+            <span class="status-chip chip-planning">⚡ Plan ready</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Review -->
+      <div class="task-card" data-status="review">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+            <span class="task-title">Create reusable Terraform S3 module</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-M3W</span>
+            <span class="status-chip chip-planning">⚡ Plan ready</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Error -->
+      <div class="task-card" data-status="error">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--danger-fg)" opacity="0.9"/></svg>
+            <span class="task-title">Create reusable Terraform module for S3</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-UZ3</span>
+            <span class="status-chip chip-error">⚠ Error</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Queued -->
+      <div class="task-card" data-status="queued">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><rect x="3" y="6" width="10" height="4" rx="1" fill="var(--accent-fg)" opacity="0.7"/></svg>
+            <span class="task-title">Build reusable S3 module with versioning</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-Q20</span>
+            <span class="status-chip chip-queued">Queued</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Selected -->
+      <div class="task-card selected" data-status="review">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><polygon points="8,2 14,14 2,14" fill="var(--attention-fg)" opacity="0.8"/></svg>
+            <span class="task-title">Build reusable Terraform S3 module</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-VXI</span>
+            <span class="status-chip chip-planning">⚡ Plan ready</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Backlog -->
+      <div class="task-card" data-status="backlog">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><rect x="3" y="6" width="10" height="4" rx="1" fill="var(--fg-subtle)" opacity="0.5"/></svg>
+            <span class="task-title">Create reusable Terraform module for AWS</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-ZVG</span>
+            <span style="font-size:10px;font-weight:500;color:var(--fg-subtle)">P1</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Done -->
+      <div class="task-card" data-status="done">
+        <div class="status-rail"></div>
+        <div class="card-content">
+          <div class="card-header">
+            <svg class="priority-icon" viewBox="0 0 16 16"><circle cx="8" cy="8" r="5" fill="var(--done-fg)" opacity="0.5"/></svg>
+            <span class="task-title">Create S3 module with encryption</span>
+          </div>
+          <div class="card-footer">
+            <span class="task-id">#TSK-5B6</span>
+            <span class="status-chip chip-done">✓ Done</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sidebar-footer">
+      <span>8 tasks</span>
+      <span>👁 Done (5)</span>
+      <span>↑↓ navigate</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/app/components/features/live-task-view/audit-trail-panel.tsx
+++ b/src/app/components/features/live-task-view/audit-trail-panel.tsx
@@ -75,16 +75,18 @@ function getStatusBadge(column: string, agentStatus?: string | null) {
 
   switch (column) {
     case 'backlog':
-      return { label: 'Backlog', className: 'bg-fg-subtle/15 text-fg-subtle' };
+      return { label: 'Backlog', className: 'bg-[var(--fg-muted)]/15 text-[var(--fg-muted)]' };
+    case 'queued':
+      return { label: 'Queued', className: 'bg-accent/15 text-accent' };
     case 'in_progress':
-      return { label: 'In Progress', className: 'bg-accent/15 text-accent' };
+      return { label: 'In Progress', className: 'bg-attention/15 text-attention' };
     case 'waiting_approval':
-      return { label: 'Waiting Approval', className: 'bg-attention/15 text-attention' };
+      return { label: 'Waiting Approval', className: 'bg-done/15 text-done' };
     case 'done':
     case 'verified':
-      return { label: 'Done', className: 'bg-success/15 text-success' };
+      return { label: 'Verified', className: 'bg-success/15 text-success' };
     default:
-      return { label: column, className: 'bg-fg-subtle/15 text-fg-subtle' };
+      return { label: column, className: 'bg-[var(--fg-muted)]/15 text-[var(--fg-muted)]' };
   }
 }
 

--- a/src/app/components/features/live-task-view/index.tsx
+++ b/src/app/components/features/live-task-view/index.tsx
@@ -427,8 +427,8 @@ const PIPELINE_STEPS = [
   { id: 'backlog', label: 'Backlog' },
   { id: 'queued', label: 'Queued' },
   { id: 'in_progress', label: 'In Progress' },
-  { id: 'waiting_approval', label: 'Review' },
-  { id: 'verified', label: 'Done' },
+  { id: 'waiting_approval', label: 'Waiting Approval' },
+  { id: 'verified', label: 'Verified' },
 ] as const;
 
 function TaskStatusPipeline({

--- a/src/app/components/features/live-task-view/task-list-sidebar.tsx
+++ b/src/app/components/features/live-task-view/task-list-sidebar.tsx
@@ -60,13 +60,13 @@ const columnSortOrder: Record<string, number> = {
   verified: 4,
 };
 
-/** Column filter chip definitions with their visual styles. */
+/** Column filter chip definitions — colors match kanban COLUMN_HEADER_STYLES. */
 const FILTER_COLUMNS = [
   {
     id: 'backlog',
     label: 'Backlog',
-    dotColor: 'bg-fg-subtle',
-    activeClass: 'bg-fg-subtle/15 text-fg-muted border-fg-subtle/30',
+    dotColor: 'bg-[var(--fg-muted)]',
+    activeClass: 'bg-[var(--fg-muted)]/15 text-[var(--fg-muted)] border-[var(--fg-muted)]/30',
   },
   {
     id: 'queued',
@@ -76,33 +76,82 @@ const FILTER_COLUMNS = [
   },
   {
     id: 'in_progress',
-    label: 'Active',
-    dotColor: 'bg-success',
-    activeClass: 'bg-success/15 text-success border-success/30',
-  },
-  {
-    id: 'waiting_approval',
-    label: 'Review',
+    label: 'In Progress',
     dotColor: 'bg-attention',
     activeClass: 'bg-attention/15 text-attention border-attention/30',
   },
   {
-    id: 'verified',
-    label: 'Done',
+    id: 'waiting_approval',
+    label: 'Waiting Approval',
     dotColor: 'bg-done',
     activeClass: 'bg-done/15 text-done border-done/30',
+  },
+  {
+    id: 'verified',
+    label: 'Verified',
+    dotColor: 'bg-success',
+    activeClass: 'bg-success/15 text-success border-success/30',
   },
 ] as const;
 
 /** Completed column identifiers (codebase uses both 'done' and 'verified'). */
 const COMPLETED_COLUMNS = new Set(['done', 'verified']);
 
-/** Priority label mapping. */
-const priorityLabels: Record<string, string> = {
-  high: 'P0',
-  medium: 'P1',
-  low: 'P2',
+interface CardStyle {
+  gradientColor: string;
+  tagClass: string;
+  tagLabel: string;
+  borderClass?: string;
+}
+
+/**
+ * Column-based visual styles for task cards.
+ * Gradient rgba values match COLUMN_HEADER_STYLES in kanban-board/constants.ts.
+ */
+const COLUMN_CARD_STYLES: Record<string, CardStyle> = {
+  backlog: {
+    gradientColor: 'rgba(139,148,158,0.12)',
+    tagClass: 'bg-[var(--fg-muted)]/15 text-[var(--fg-muted)]',
+    tagLabel: 'Backlog',
+  },
+  queued: {
+    gradientColor: 'rgba(88,166,255,0.12)',
+    tagClass: 'bg-[var(--accent-muted)] text-[var(--accent-fg)]',
+    tagLabel: 'Queued',
+  },
+  in_progress: {
+    gradientColor: 'rgba(210,153,34,0.12)',
+    tagClass: 'bg-[var(--attention-muted)] text-[var(--attention-fg)]',
+    tagLabel: 'In Progress',
+  },
+  waiting_approval: {
+    gradientColor: 'rgba(163,113,247,0.12)',
+    tagClass: 'bg-[var(--done-muted)] text-[var(--done-fg)]',
+    tagLabel: 'Waiting Approval',
+  },
+  done: {
+    gradientColor: 'rgba(63,185,80,0.12)',
+    tagClass: 'bg-[var(--success-muted)] text-[var(--success-fg)]',
+    tagLabel: 'Verified',
+  },
+  verified: {
+    gradientColor: 'rgba(63,185,80,0.12)',
+    tagClass: 'bg-[var(--success-muted)] text-[var(--success-fg)]',
+    tagLabel: 'Verified',
+  },
 };
+
+/** Fallback card style for unknown columns. */
+const DEFAULT_CARD_STYLE: CardStyle = {
+  gradientColor: 'rgba(139,148,158,0.12)',
+  tagClass: 'bg-[var(--fg-muted)]/15 text-[var(--fg-muted)]',
+  tagLabel: 'Backlog',
+};
+
+/** Card style for a given column. */
+function getCardStyle(column: string): CardStyle {
+  return COLUMN_CARD_STYLES[column] ?? DEFAULT_CARD_STYLE;
+}
 
 /** Get icon and label for last agent run status (same as kanban-card.tsx) */
 function getLastRunStatusInfo(status: string | null | undefined): {
@@ -352,12 +401,12 @@ export function TaskListSidebar({
           className={cn(
             'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium transition-all duration-150',
             showCompleted
-              ? 'bg-done/10 text-done'
+              ? 'bg-success/10 text-success'
               : 'text-fg-subtle hover:text-fg-muted hover:bg-surface-subtle'
           )}
         >
           {showCompleted ? <Eye className="h-3 w-3" /> : <EyeSlash className="h-3 w-3" />}
-          Done ({columnCounts.verified ?? 0})
+          Verified ({columnCounts.verified ?? 0})
         </button>
 
         <span className="flex items-center gap-1 text-[10px] text-fg-subtle">
@@ -387,47 +436,74 @@ function TaskCard({
   const isAgentRunning =
     task.column === 'in_progress' && (Boolean(task.agentId) || Boolean(task.sessionId));
   const lastRunStatus = getLastRunStatusInfo(task.lastAgentStatus);
+  const isError = task.lastAgentStatus === 'error';
+
+  // Pick card style — error overrides column style
+  const style = isError
+    ? {
+        gradientColor: 'rgba(248,81,73,0.12)',
+        tagClass: 'bg-[var(--danger-muted)] text-[var(--danger-fg)]',
+        tagLabel: 'Error',
+        borderClass: 'border-danger/20' as string | undefined,
+      }
+    : getCardStyle(task.column);
+
+  const gradientStyle = isSelected
+    ? {
+        background: 'linear-gradient(to right, rgba(88,166,255,0.10), transparent 60%)',
+      }
+    : {
+        background: `linear-gradient(to right, ${style.gradientColor}, transparent 60%)`,
+      };
 
   return (
     <button
       type="button"
       onClick={() => onSelect(task.id)}
       className={cn(
-        'w-full rounded-md border bg-surface p-3 text-left transition-all duration-150',
-        isSelected ? 'border-accent bg-accent-muted' : 'border-border hover:border-fg-subtle'
+        'relative w-full overflow-hidden rounded-md border p-3 text-left transition-all duration-150',
+        isSelected
+          ? 'border-accent bg-accent-muted'
+          : cn('border-border hover:border-fg-subtle', style.borderClass)
       )}
     >
-      {/* Header: priority icon + title */}
-      <div className="flex items-start gap-2">
-        <PriorityIcon priority={priority} className="mt-1" />
+      {/* Gradient wash overlay */}
+      <div className="pointer-events-none absolute inset-0 rounded-md" style={gradientStyle} />
+
+      {/* Row 1: Status tag + task ID */}
+      <div className="relative flex items-center gap-2 mb-1.5">
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded-sm px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide',
+            isSelected ? 'bg-accent/15 text-accent' : style.tagClass
+          )}
+        >
+          {style.tagLabel}
+        </span>
+        <span className="font-mono text-[10px] text-fg-subtle">{formatTaskId(task.id)}</span>
+      </div>
+
+      {/* Row 2: Priority icon + title */}
+      <div className="relative flex items-start gap-2">
+        <PriorityIcon priority={priority} className="mt-0.5" />
         <div className="flex-1 text-sm font-medium leading-snug text-fg truncate">{task.title}</div>
       </div>
 
-      {/* Footer: task ID + status badge */}
-      <div className="flex items-center justify-between mt-2">
-        <span className="font-mono text-xs text-fg-muted">{formatTaskId(task.id)}</span>
+      {/* Row 3: Agent running indicator */}
+      {isAgentRunning && (
+        <div className={cn('relative', agentStatusVariants({ status: 'running' }))}>
+          <div className="w-1.5 h-1.5 bg-current rounded-full animate-pulse" />
+          <span>Agent running...</span>
+        </div>
+      )}
 
-        {/* Last run status (matches kanban card) */}
-        {lastRunStatus && !isAgentRunning && (
+      {/* Row 3: Last run status badge */}
+      {lastRunStatus && !isAgentRunning && (
+        <div className="relative flex items-center justify-end mt-1.5">
           <div className={lastRunStatusVariants({ status: lastRunStatus.status })}>
             {lastRunStatus.icon}
             <span>{lastRunStatus.label}</span>
           </div>
-        )}
-
-        {/* Priority label */}
-        {!lastRunStatus && !isAgentRunning && (
-          <span className="text-[10px] font-medium text-fg-subtle">
-            {priorityLabels[priority] ?? 'P1'}
-          </span>
-        )}
-      </div>
-
-      {/* Agent running indicator (matches kanban card) */}
-      {isAgentRunning && (
-        <div className={agentStatusVariants({ status: 'running' })}>
-          <div className="w-1.5 h-1.5 bg-current rounded-full animate-pulse" />
-          <span>Agent running...</span>
         </div>
       )}
     </button>

--- a/src/app/components/features/skill-picker.tsx
+++ b/src/app/components/features/skill-picker.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Tag } from '@phosphor-icons/react';
+import { BookOpen, MagnifyingGlass, Tag } from '@phosphor-icons/react';
 import { useCallback, useMemo, useState } from 'react';
 import {
   Select,
@@ -101,6 +101,7 @@ export function SkillPicker({
   const [skills, setSkills] = useState<Skill[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Fetch skills when codespaceId changes
   useWatchEffect(() => {
@@ -154,6 +155,20 @@ export function SkillPicker({
     }));
   }, [filteredSkills]);
 
+  // Apply search query on top of tag-filtered grouped skills
+  const displayedGroups = useMemo(() => {
+    if (!searchQuery.trim()) return groupedSkills;
+    const q = searchQuery.toLowerCase().trim();
+    return groupedSkills
+      .map((group) => ({
+        ...group,
+        items: group.items.filter(
+          (s) => s.name.toLowerCase().includes(q) || s.description?.toLowerCase().includes(q)
+        ),
+      }))
+      .filter((group) => group.items.length > 0);
+  }, [groupedSkills, searchQuery]);
+
   // Toggle a tag filter
   const toggleTag = useCallback((tag: string) => {
     setSelectedTags((prev) => {
@@ -200,7 +215,23 @@ export function SkillPicker({
           <SelectValue placeholder={getDisplayValue()}>{getDisplayValue()}</SelectValue>
         </div>
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="max-w-[480px]">
+        {/* Search input */}
+        <div className="px-2 py-1.5 border-b border-border">
+          <div className="relative">
+            <MagnifyingGlass className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-fg-muted" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              placeholder="Search skills…"
+              className="w-full rounded-md border border-border bg-surface-subtle py-1 pl-7 pr-2 text-xs text-fg placeholder:text-fg-subtle focus:border-accent focus:outline-none"
+            />
+          </div>
+        </div>
+
         {/* No skill option */}
         <SelectItem value="__none__" className="flex flex-col items-start">
           <div className="font-medium">No skill</div>
@@ -209,7 +240,7 @@ export function SkillPicker({
 
         {/* Tag filter chips — only shown when tags exist */}
         {allTags.length > 0 && (
-          <div className="px-2 py-1.5 flex flex-wrap gap-1 border-b border-border-default">
+          <div className="px-2 py-1.5 flex flex-wrap gap-1 border-b border-border">
             <Tag className="h-3 w-3 text-fg-subtle flex-shrink-0 mt-0.5" weight="bold" />
             {allTags.map((tag) => (
               <button
@@ -225,7 +256,7 @@ export function SkillPicker({
                   'border cursor-pointer select-none',
                   selectedTags.has(tag)
                     ? 'bg-accent-subtle border-accent text-accent'
-                    : 'bg-bg-subtle border-border-default text-fg-muted hover:border-border-emphasis'
+                    : 'bg-surface-subtle border-border text-fg-muted hover:border-fg-subtle'
                 )}
               >
                 {tag}
@@ -235,24 +266,30 @@ export function SkillPicker({
         )}
 
         {/* Grouped skills */}
-        {groupedSkills.map((group) => (
+        {displayedGroups.map((group) => (
           <div key={group.sourceType}>
             {/* Group header */}
-            <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+            <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-fg-subtle border-b border-border/50">
               {group.label}
             </div>
             {group.items.map((skill) => (
-              <SelectItem key={skill.id} value={skill.id} className="flex flex-col items-start">
-                <div className="font-medium">{skill.name}</div>
+              <SelectItem
+                key={skill.id}
+                value={skill.id}
+                className="flex flex-col items-start border-b border-border/30 last:border-b-0"
+              >
+                <div className="font-medium text-[13px]">{skill.name}</div>
                 {skill.description && (
-                  <div className="text-[11px] text-fg-muted line-clamp-1">{skill.description}</div>
+                  <div className="text-[11px] text-fg-muted line-clamp-2 leading-relaxed mt-0.5">
+                    {skill.description}
+                  </div>
                 )}
                 {skill.tags && skill.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mt-0.5">
+                  <div className="flex flex-wrap gap-1 mt-1">
                     {skill.tags.map((tag) => (
                       <span
                         key={tag}
-                        className="inline-flex items-center rounded-full bg-bg-subtle px-1.5 py-px text-[9px] text-fg-subtle"
+                        className="inline-flex items-center rounded-full bg-surface-subtle px-1.5 py-px text-[9px] text-fg-subtle border border-border/50"
                       >
                         {tag}
                       </span>
@@ -264,12 +301,13 @@ export function SkillPicker({
           </div>
         ))}
 
-        {/* Empty state when tag filters eliminate all results */}
+        {/* Empty state when filters eliminate all results */}
         {!isLoading &&
-          allTags.length > 0 &&
-          selectedTags.size > 0 &&
-          filteredSkills.length === 0 && (
-            <div className="px-2 py-2 text-xs text-fg-muted">No skills match the selected tags</div>
+          displayedGroups.length === 0 &&
+          (filteredSkills.length === 0 || searchQuery) && (
+            <div className="px-2 py-4 text-center text-xs text-fg-muted">
+              No skills match {searchQuery ? `"${searchQuery}"` : 'the selected tags'}
+            </div>
           )}
 
         {isLoading && <div className="px-2 py-2 text-xs text-fg-muted">Loading skills...</div>}

--- a/tests/components/live-task-view.test.tsx
+++ b/tests/components/live-task-view.test.tsx
@@ -326,15 +326,14 @@ describe('AuditTrailPanel', () => {
     sessionCallbacksById.clear();
   });
 
-  it('shows a Done badge for verified tasks', () => {
+  it('shows a Verified badge for verified tasks', () => {
     render(
       <AuditTrailPanel
         task={createTask({ column: 'verified', title: 'Verified task', sessionId: null })}
       />
     );
 
-    expect(screen.getByText('Done')).toBeInTheDocument();
-    expect(screen.queryByText(/^verified$/)).not.toBeInTheDocument();
+    expect(screen.getByText('Verified')).toBeInTheDocument();
   });
 
   it('appends live events in the Events tab after the initial fetch', async () => {


### PR DESCRIPTION
## Summary
- Add gradient wash backgrounds and uppercase status tags to task cards for instant status scanning
- Align all status labels and colors to match the kanban board exactly (Backlog=gray, Queued=blue, In Progress=amber, Waiting Approval=purple, Verified=green)
- Fix pipeline stepper labels: "Review" → "Waiting Approval", "Done" → "Verified"
- Fix audit trail badge colors to match kanban column definitions
- Improve skill picker: add search, cap width at 480px, 2-line descriptions, visual separation between items

## Changes
- `task-list-sidebar.tsx` — gradient wash cards with status tags, kanban-aligned colors
- `index.tsx` — pipeline stepper labels aligned to kanban
- `audit-trail-panel.tsx` — status badge labels and colors aligned to kanban
- `skill-picker.tsx` — search input, max-width, line-clamp-2 descriptions, item borders
- `live-task-view.test.tsx` — updated test assertion for "Verified" badge
- `specs/application/wireframes/task-card-proposals/` — 3 design wireframes

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx @biomejs/biome check` — zero issues
- [x] `npx vitest run tests/components/live-task-view.test.tsx` — 6/6 pass
- [x] Pre-commit hooks pass (Biome, TypeScript, secrets)
- [ ] Visual: verify gradient cards render with correct colors per status
- [ ] Visual: verify pipeline stepper shows "Waiting Approval" and "Verified"
- [ ] Visual: verify skill picker search filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)