### PR TITLE
fix: add missing skill_id/skill_name migration to bootstrap runner

### DIFF
--- a/src/lib/bootstrap/__tests__/migration-ordering.test.ts
+++ b/src/lib/bootstrap/__tests__/migration-ordering.test.ts
@@ -99,6 +99,36 @@ describe('Migration ordering', () => {
     db.close();
   });
 
+  it('adds skill_id and skill_name columns to tasks table', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+
+    runMigrations(db, MIGRATIONS);
+
+    const tasksCols = db.prepare("PRAGMA table_info('tasks')").all() as {
+      name: string;
+    }[];
+    const colNames = tasksCols.map((c) => c.name);
+    expect(colNames).toContain('skill_id');
+    expect(colNames).toContain('skill_name');
+
+    // Verify we can insert a task with skill columns
+    db.prepare(`INSERT INTO projects (id, name, path) VALUES ('p1', 'Test', '/test')`).run();
+    db.prepare(
+      `INSERT INTO tasks (id, project_id, title, skill_id, skill_name)
+       VALUES ('t1', 'p1', 'Skill Task', 'terraform-stacks', 'Terraform Stacks')`
+    ).run();
+
+    const task = db.prepare(`SELECT skill_id, skill_name FROM tasks WHERE id = 't1'`).get() as {
+      skill_id: string;
+      skill_name: string;
+    };
+    expect(task.skill_id).toBe('terraform-stacks');
+    expect(task.skill_name).toBe('Terraform Stacks');
+
+    db.close();
+  });
+
   it('only applies pending migrations on existing database', () => {
     const db = new Database(':memory:');
     db.pragma('foreign_keys = ON');

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -133,4 +133,14 @@ export const MIGRATIONS: Migration[] = [
     name: 'project-folders-alter-columns',
     statements: [...PROJECT_FOLDERS_ALTER_STATEMENTS],
   },
+
+  // 21. Add skill_id and skill_name columns to tasks table
+  {
+    version: 21,
+    name: 'task-skill-columns',
+    statements: [
+      `ALTER TABLE tasks ADD COLUMN skill_id TEXT`,
+      `ALTER TABLE tasks ADD COLUMN skill_name TEXT`,
+    ],
+  },
 ];

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -53,6 +53,8 @@ const sampleTask: Task = {
   rejectionCount: 0,
   rejectionReason: null,
   modelOverride: null,
+  skillId: null,
+  skillName: null,
   planOptions: null,
   plan: null,
   createdAt: '2026-01-01T00:00:00Z',

--- a/tests/factories/task.factory.ts
+++ b/tests/factories/task.factory.ts
@@ -35,6 +35,8 @@ export function buildTask(codespaceId: string, options: TaskFactoryOptions = {})
     approvedBy: options.withApproval ? 'test-user' : (options.approvedBy ?? null),
     rejectionCount: options.withRejection ? 1 : (options.rejectionCount ?? 0),
     rejectionReason: options.withRejection ? 'Test rejection' : (options.rejectionReason ?? null),
+    skillId: options.skillId ?? null,
+    skillName: options.skillName ?? null,
     startedAt: options.startedAt ?? null,
     completedAt: options.completedAt ?? null,
   };


### PR DESCRIPTION
## Summary
- Bootstrap migration runner ended at v20, never adding `skill_id`/`skill_name` columns to the tasks table
- Drizzle schema defined these columns, so ORM inserts included them, causing `Database insert failed: table tasks has no column named skill_id`
- Adds migration v21 with idempotent ALTER TABLE statements
- Adds regression test verifying columns exist and accept data after migration
- Updates test fixtures (`sampleTask`, task factory) to include skill fields

## Test plan
- [x] Migration ordering tests pass (5/5) — includes new regression test
- [x] Task API tests pass (12/12)
- [x] TypeScript type check clean
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)