### PR TITLE
Add PostgreSQL schema migrations and backup infrastructure

### DIFF
--- a/scripts/backup-db-pg.sh
+++ b/scripts/backup-db-pg.sh
@@ -16,6 +16,9 @@ MAX_BACKUPS="${MAX_BACKUPS:-7}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 BACKUP_FILE="${BACKUP_DIR}/agentpane_pg_${TIMESTAMP}.dump"
 
+# Clean up partial backup on failure
+trap 'rm -f "$BACKUP_FILE"' ERR
+
 # Ensure backup directory exists
 mkdir -p "$BACKUP_DIR"
 
@@ -29,7 +32,7 @@ echo "Backup complete: $BACKUP_FILE ($SIZE bytes)"
 
 # Verify backup integrity
 echo "Verifying backup integrity..."
-pg_restore --list "$BACKUP_FILE" > /dev/null 2>&1
+pg_restore --list "$BACKUP_FILE" > /dev/null
 echo "Backup verification passed."
 
 # Clean up old backups (keep last MAX_BACKUPS)

--- a/scripts/backup-db-pg.sh
+++ b/scripts/backup-db-pg.sh
@@ -16,6 +16,15 @@ MAX_BACKUPS="${MAX_BACKUPS:-7}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 BACKUP_FILE="${BACKUP_DIR}/agentpane_pg_${TIMESTAMP}.dump"
 
+# Validate MAX_BACKUPS is a positive integer
+if ! [[ "$MAX_BACKUPS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: MAX_BACKUPS must be a positive integer, got: $MAX_BACKUPS" >&2
+  exit 1
+fi
+
+# Restrict backup file permissions (owner-only read/write)
+umask 077
+
 # Clean up partial backup on failure
 trap 'rm -f "$BACKUP_FILE"' ERR
 
@@ -23,8 +32,9 @@ trap 'rm -f "$BACKUP_FILE"' ERR
 mkdir -p "$BACKUP_DIR"
 
 # Create compressed backup using custom format
+# Use --dbname= to prevent flag injection via DATABASE_URL
 echo "Creating PostgreSQL backup..."
-pg_dump "$DATABASE_URL" --format=custom --compress=6 --file="$BACKUP_FILE"
+pg_dump --dbname="$DATABASE_URL" --format=custom --compress=6 --file="$BACKUP_FILE"
 
 # Verify backup
 SIZE=$(stat -f%z "$BACKUP_FILE" 2>/dev/null || stat --format=%s "$BACKUP_FILE" 2>/dev/null || echo "unknown")
@@ -40,7 +50,7 @@ BACKUP_COUNT=$(find "$BACKUP_DIR" -name "agentpane_pg_*.dump" -type f | wc -l | 
 if [ "$BACKUP_COUNT" -gt "$MAX_BACKUPS" ]; then
   REMOVE_COUNT=$((BACKUP_COUNT - MAX_BACKUPS))
   echo "Cleaning up $REMOVE_COUNT old backup(s)..."
-  find "$BACKUP_DIR" -name "agentpane_pg_*.dump" -type f | sort | head -n "$REMOVE_COUNT" | xargs -I {} rm -f "{}"
+  find "$BACKUP_DIR" -name "agentpane_pg_*.dump" -type f -print0 | sort -z | head -z -n "$REMOVE_COUNT" | xargs -0 rm -f
 fi
 
 echo "Done."

--- a/scripts/backup-db-pg.sh
+++ b/scripts/backup-db-pg.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PostgreSQL backup script for AgentPane.
+#
+# Creates compressed backups using pg_dump with custom format.
+#
+# Usage:
+#   ./scripts/backup-db-pg.sh                    # backs up to data/backups/
+#   ./scripts/backup-db-pg.sh /path/to/backup    # custom backup directory
+#   DATABASE_URL=postgres://... ./scripts/backup-db-pg.sh
+
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:?DATABASE_URL environment variable is required}"
+BACKUP_DIR="${1:-./data/backups}"
+MAX_BACKUPS="${MAX_BACKUPS:-7}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_FILE="${BACKUP_DIR}/agentpane_pg_${TIMESTAMP}.dump"
+
+# Ensure backup directory exists
+mkdir -p "$BACKUP_DIR"
+
+# Create compressed backup using custom format
+echo "Creating PostgreSQL backup..."
+pg_dump "$DATABASE_URL" --format=custom --compress=6 --file="$BACKUP_FILE"
+
+# Verify backup
+SIZE=$(stat -f%z "$BACKUP_FILE" 2>/dev/null || stat --format=%s "$BACKUP_FILE" 2>/dev/null || echo "unknown")
+echo "Backup complete: $BACKUP_FILE ($SIZE bytes)"
+
+# Verify backup integrity
+echo "Verifying backup integrity..."
+pg_restore --list "$BACKUP_FILE" > /dev/null 2>&1
+echo "Backup verification passed."
+
+# Clean up old backups (keep last MAX_BACKUPS)
+BACKUP_COUNT=$(find "$BACKUP_DIR" -name "agentpane_pg_*.dump" -type f | wc -l | tr -d ' ')
+if [ "$BACKUP_COUNT" -gt "$MAX_BACKUPS" ]; then
+  REMOVE_COUNT=$((BACKUP_COUNT - MAX_BACKUPS))
+  echo "Cleaning up $REMOVE_COUNT old backup(s)..."
+  find "$BACKUP_DIR" -name "agentpane_pg_*.dump" -type f | sort | head -n "$REMOVE_COUNT" | xargs -I {} rm -f "{}"
+fi
+
+echo "Done."

--- a/scripts/check-schema-drift.ts
+++ b/scripts/check-schema-drift.ts
@@ -59,7 +59,7 @@ if (missingSqlite.length > 0) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 2: Column-level comparison for shared modules
+// Phase 2 & 3: Column-level and index-level comparison for shared modules
 // ---------------------------------------------------------------------------
 
 interface ColumnInfo {
@@ -73,44 +73,67 @@ interface TableInfo {
   columns: Map<string, ColumnInfo>;
 }
 
-/**
- * Extract table definitions from a schema file.
- *
- * Matches patterns like:
- *   export const tableName = sqliteTable('db_table_name', { ... })
- *   export const tableName = pgTable('db_table_name', { ... })
- *
- * Then extracts columns from the object body.
- */
-function extractTables(filePath: string): TableInfo[] {
-  const content = readFileSync(filePath, 'utf-8');
-  const tables: TableInfo[] = [];
+interface IndexInfo {
+  name: string;
+  columns: string;
+}
 
-  // Match table declarations — capture table variable name, db name, and body
-  // The body is everything in the first { ... } after the table name string
+/**
+ * Track delimiter depth to find the matching close character.
+ * Starts just past the opening delimiter and returns the index just past the close.
+ */
+function findMatchingClose(content: string, startIdx: number, open: string, close: string): number {
+  let depth = 1;
+  let i = startIdx;
+  while (i < content.length && depth > 0) {
+    if (content[i] === open) depth++;
+    else if (content[i] === close) depth--;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Parse a schema file and extract both table/column info and index info in a single pass.
+ * Avoids reading the same file twice (once for columns, once for indexes).
+ */
+function parseSchemaFile(filePath: string): {
+  tables: Map<string, TableInfo>;
+  indexes: Map<string, IndexInfo[]>;
+} {
+  const content = readFileSync(filePath, 'utf-8');
+  const tables = new Map<string, TableInfo>();
+  const indexes = new Map<string, IndexInfo[]>();
+
   const tableRe =
     /export\s+const\s+\w+\s*=\s*(?:sqliteTable|pgTable)\(\s*['"]([^'"]+)['"]\s*,\s*\{/g;
 
   for (const tableMatch of content.matchAll(tableRe)) {
     const tableName = tableMatch[1];
-    const startIdx = tableMatch.index + tableMatch[0].length;
+    const bodyStart = tableMatch.index + tableMatch[0].length;
 
-    // Find the matching closing brace by counting braces
-    let depth = 1;
-    let i = startIdx;
-    while (i < content.length && depth > 0) {
-      if (content[i] === '{') depth++;
-      else if (content[i] === '}') depth--;
-      i++;
+    // Extract column body (inside the first { ... })
+    const bodyEnd = findMatchingClose(content, bodyStart, '{', '}');
+    const body = content.slice(bodyStart, bodyEnd - 1);
+    tables.set(tableName, { tableName, columns: extractColumns(body) });
+
+    // Extract indexes from the full table call
+    const callStart = content.lastIndexOf('(', bodyStart);
+    const callEnd = findMatchingClose(content, callStart + 1, '(', ')');
+    const fullCall = content.slice(callStart, callEnd);
+
+    const indexRe = /(?:unique)?[Ii]ndex\(\s*['"]([^'"]+)['"]\s*\)\.on\(([^)]+)\)/g;
+    const tableIndexes: IndexInfo[] = [];
+    for (const idxMatch of fullCall.matchAll(indexRe)) {
+      const colRefs = [...idxMatch[2].matchAll(/(?:table|t)\.(\w+)/g)].map((m) => m[1]);
+      tableIndexes.push({ name: idxMatch[1], columns: colRefs.join(', ') });
     }
-
-    const body = content.slice(startIdx, i - 1);
-    const columns = extractColumns(body);
-
-    tables.push({ tableName, columns });
+    if (tableIndexes.length > 0) {
+      indexes.set(tableName, tableIndexes);
+    }
   }
 
-  return tables;
+  return { tables, indexes };
 }
 
 /**
@@ -193,7 +216,7 @@ function extractColumns(body: string): Map<string, ColumnInfo> {
   return columns;
 }
 
-// Compare tables across shared modules
+// Compare tables, columns, and indexes across shared modules (single pass per file pair)
 const sharedModules = [...sqliteModules].filter((m) => postgresModules.has(m));
 let columnDrift = false;
 const warnings: string[] = [];
@@ -206,36 +229,32 @@ for (const mod of sharedModules.sort()) {
     continue;
   }
 
-  const sqliteTables = extractTables(sqlitePath);
-  const postgresTables = extractTables(postgresPath);
+  // Parse both files once (extracts tables + indexes together)
+  const sqlite = parseSchemaFile(sqlitePath);
+  const postgres = parseSchemaFile(postgresPath);
 
-  // Build lookup by table name
-  const sqliteByName = new Map(sqliteTables.map((t) => [t.tableName, t]));
-  const postgresByName = new Map(postgresTables.map((t) => [t.tableName, t]));
-
-  // Check for tables present in one but not the other
-  for (const name of sqliteByName.keys()) {
-    if (!postgresByName.has(name)) {
+  // --- Table-level drift ---
+  for (const name of sqlite.tables.keys()) {
+    if (!postgres.tables.has(name)) {
       warnings.push(`[${mod}] Table '${name}' exists in SQLite but not in PostgreSQL`);
       columnDrift = true;
     }
   }
-  for (const name of postgresByName.keys()) {
-    if (!sqliteByName.has(name)) {
+  for (const name of postgres.tables.keys()) {
+    if (!sqlite.tables.has(name)) {
       warnings.push(`[${mod}] Table '${name}' exists in PostgreSQL but not in SQLite`);
       columnDrift = true;
     }
   }
 
-  // Compare columns for shared tables
-  for (const [tableName, sqliteTable] of sqliteByName) {
-    const pgTable = postgresByName.get(tableName);
+  // --- Column-level drift for shared tables ---
+  for (const [tableName, sqliteTable] of sqlite.tables) {
+    const pgTable = postgres.tables.get(tableName);
     if (!pgTable) continue;
 
     const sqliteCols = sqliteTable.columns;
     const pgCols = pgTable.columns;
 
-    // Columns in SQLite but missing from PostgreSQL
     for (const colName of sqliteCols.keys()) {
       if (!pgCols.has(colName)) {
         warnings.push(
@@ -245,7 +264,6 @@ for (const mod of sharedModules.sort()) {
       }
     }
 
-    // Columns in PostgreSQL but missing from SQLite
     for (const colName of pgCols.keys()) {
       if (!sqliteCols.has(colName)) {
         warnings.push(
@@ -255,120 +273,36 @@ for (const mod of sharedModules.sort()) {
       }
     }
 
-    // Compare onDelete behavior for shared columns with references
+    // Compare onDelete behavior for shared columns
     for (const [colName, sqliteCol] of sqliteCols) {
       const pgCol = pgCols.get(colName);
       if (!pgCol) continue;
 
-      // Compare onDelete — only flag if both have references but differ,
-      // or one has a reference and the other doesn't
-      if (sqliteCol.onDelete && pgCol.onDelete) {
-        if (sqliteCol.onDelete !== pgCol.onDelete) {
-          warnings.push(
-            `[${mod}] Table '${tableName}', column '${colName}': onDelete mismatch — SQLite='${sqliteCol.onDelete}', PostgreSQL='${pgCol.onDelete}'`
-          );
-          columnDrift = true;
-        }
-      } else if (sqliteCol.onDelete && !pgCol.onDelete) {
-        warnings.push(
-          `[${mod}] Table '${tableName}', column '${colName}': SQLite has onDelete='${sqliteCol.onDelete}' but PostgreSQL has no reference/onDelete`
-        );
-        columnDrift = true;
-      } else if (!sqliteCol.onDelete && pgCol.onDelete) {
-        warnings.push(
-          `[${mod}] Table '${tableName}', column '${colName}': PostgreSQL has onDelete='${pgCol.onDelete}' but SQLite has no reference/onDelete`
-        );
-        columnDrift = true;
-      }
-    }
-  }
-}
+      const sqlDel = sqliteCol.onDelete;
+      const pgDel = pgCol.onDelete;
+      if (sqlDel === pgDel) continue;
 
-// ---------------------------------------------------------------------------
-// Phase 3: Index comparison for shared modules
-// ---------------------------------------------------------------------------
-
-interface IndexInfo {
-  name: string;
-  columns: string;
-}
-
-/**
- * Extract index definitions from the table's second argument (the arrow function).
- *
- * Matches patterns like:
- *   index('idx_name').on(table.col1, table.col2)
- *   uniqueIndex('idx_name').on(table.col1)
- */
-function extractIndexes(filePath: string): Map<string, IndexInfo[]> {
-  const content = readFileSync(filePath, 'utf-8');
-  const result = new Map<string, IndexInfo[]>();
-
-  // Find table declarations with their index callbacks
-  // Pattern: sqliteTable/pgTable('name', { columns }, (table) => [ ... ])
-  const tableRe = /export\s+const\s+\w+\s*=\s*(?:sqliteTable|pgTable)\(\s*['"]([^'"]+)['"]/g;
-
-  for (const tableMatch of content.matchAll(tableRe)) {
-    const tableName = tableMatch[1];
-    const startIdx = tableMatch.index + tableMatch[0].length;
-
-    // Find the end of the entire table call by tracking parens from the opening paren
-    // We need to go back to find the opening paren of sqliteTable( / pgTable(
-    const callStart = content.lastIndexOf('(', startIdx);
-    let depth = 1;
-    let i = callStart + 1;
-    while (i < content.length && depth > 0) {
-      if (content[i] === '(') depth++;
-      else if (content[i] === ')') depth--;
-      i++;
-    }
-
-    const fullCall = content.slice(callStart, i);
-
-    // Extract indexes from the callback — match index('name').on(table.col, ...)
-    const indexRe = /(?:unique)?[Ii]ndex\(\s*['"]([^'"]+)['"]\s*\)\.on\(([^)]+)\)/g;
-    const indexes: IndexInfo[] = [];
-
-    for (const idxMatch of fullCall.matchAll(indexRe)) {
-      const name = idxMatch[1];
-      // Normalize columns: extract table.xxx references, sort for comparison
-      const colsRaw = idxMatch[2];
-      const colRefs = [...colsRaw.matchAll(/(?:table|t)\.(\w+)/g)].map((m) => m[1]);
-      indexes.push({ name, columns: colRefs.join(', ') });
-    }
-
-    if (indexes.length > 0) {
-      result.set(tableName, indexes);
+      const sqlLabel = sqlDel ? `'${sqlDel}'` : 'no reference/onDelete';
+      const pgLabel = pgDel ? `'${pgDel}'` : 'no reference/onDelete';
+      warnings.push(
+        `[${mod}] Table '${tableName}', column '${colName}': onDelete mismatch — SQLite=${sqlLabel}, PostgreSQL=${pgLabel}`
+      );
+      columnDrift = true;
     }
   }
 
-  return result;
-}
+  // --- Index-level drift ---
+  const allIndexedTables = new Set([...sqlite.indexes.keys(), ...postgres.indexes.keys()]);
 
-for (const mod of sharedModules.sort()) {
-  const sqlitePath = resolve(root, `sqlite/${mod}.ts`);
-  const postgresPath = resolve(root, `postgres/${mod}.ts`);
+  for (const tableName of allIndexedTables) {
+    const sqliteIdxs = sqlite.indexes.get(tableName) || [];
+    const postgresIdxs = postgres.indexes.get(tableName) || [];
 
-  if (!existsSync(sqlitePath) || !existsSync(postgresPath)) {
-    continue;
-  }
+    const sqliteIdxMap = new Map(sqliteIdxs.map((idx) => [idx.name, idx]));
+    const postgresIdxMap = new Map(postgresIdxs.map((idx) => [idx.name, idx]));
 
-  const sqliteIndexes = extractIndexes(sqlitePath);
-  const postgresIndexes = extractIndexes(postgresPath);
-
-  // Collect all table names that have indexes in either schema
-  const allTables = new Set([...sqliteIndexes.keys(), ...postgresIndexes.keys()]);
-
-  for (const tableName of allTables) {
-    const sqliteIdxs = sqliteIndexes.get(tableName) || [];
-    const postgresIdxs = postgresIndexes.get(tableName) || [];
-
-    const sqliteIdxNames = new Set(sqliteIdxs.map((idx) => idx.name));
-    const postgresIdxNames = new Set(postgresIdxs.map((idx) => idx.name));
-
-    // Indexes in SQLite but missing from PostgreSQL
     for (const idx of sqliteIdxs) {
-      if (!postgresIdxNames.has(idx.name)) {
+      if (!postgresIdxMap.has(idx.name)) {
         warnings.push(
           `[${mod}] Table '${tableName}': index '${idx.name}' (${idx.columns}) exists in SQLite but missing from PostgreSQL`
         );
@@ -376,9 +310,8 @@ for (const mod of sharedModules.sort()) {
       }
     }
 
-    // Indexes in PostgreSQL but missing from SQLite
     for (const idx of postgresIdxs) {
-      if (!sqliteIdxNames.has(idx.name)) {
+      if (!sqliteIdxMap.has(idx.name)) {
         warnings.push(
           `[${mod}] Table '${tableName}': index '${idx.name}' (${idx.columns}) exists in PostgreSQL but missing from SQLite`
         );
@@ -387,19 +320,14 @@ for (const mod of sharedModules.sort()) {
     }
 
     // Compare columns for shared indexes
-    const sqliteIdxMap = new Map(sqliteIdxs.map((idx) => [idx.name, idx]));
-    const postgresIdxMap = new Map(postgresIdxs.map((idx) => [idx.name, idx]));
-
     for (const [idxName, sqliteIdx] of sqliteIdxMap) {
       const pgIdx = postgresIdxMap.get(idxName);
-      if (!pgIdx) continue;
+      if (!pgIdx || sqliteIdx.columns === pgIdx.columns) continue;
 
-      if (sqliteIdx.columns !== pgIdx.columns) {
-        warnings.push(
-          `[${mod}] Table '${tableName}': index '${idxName}' column mismatch — SQLite=(${sqliteIdx.columns}), PostgreSQL=(${pgIdx.columns})`
-        );
-        columnDrift = true;
-      }
+      warnings.push(
+        `[${mod}] Table '${tableName}': index '${idxName}' column mismatch — SQLite=(${sqliteIdx.columns}), PostgreSQL=(${pgIdx.columns})`
+      );
+      columnDrift = true;
     }
   }
 }

--- a/scripts/check-schema-drift.ts
+++ b/scripts/check-schema-drift.ts
@@ -5,19 +5,25 @@
  * Compares the export lists in sqlite/index.ts and postgres/index.ts to ensure
  * every module re-exported by one is also re-exported by the other.
  *
+ * Then, for each shared module, compares column definitions, foreign key
+ * onDelete behavior, and index definitions between the two schemas.
+ *
  * Usage:  bun run scripts/check-schema-drift.ts
  * Exit 0 = schemas are in sync, Exit 1 = drift detected.
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dir, '../src/db/schema');
 
+// ---------------------------------------------------------------------------
+// Phase 1: Module-level check (existing logic)
+// ---------------------------------------------------------------------------
+
 function extractModules(indexPath: string): Set<string> {
   const content = readFileSync(indexPath, 'utf-8');
   const modules = new Set<string>();
-  // Match lines like: export * from './foo-bar';
   const re = /export\s+\*\s+from\s+['"]\.\/([^'"]+)['"]/g;
   for (const match of content.matchAll(re)) {
     modules.add(match[1]);
@@ -31,34 +37,396 @@ const postgresIndex = resolve(root, 'postgres/index.ts');
 const sqliteModules = extractModules(sqliteIndex);
 const postgresModules = extractModules(postgresIndex);
 
-// Filter out shared modules that are re-exported (e.g. ../shared/enums)
-// Those are handled separately and always shared.
-
 const missingSqlite = [...postgresModules].filter((m) => !sqliteModules.has(m));
 const missingPostgres = [...sqliteModules].filter((m) => !postgresModules.has(m));
 
-let driftDetected = false;
+let moduleDrift = false;
 
 if (missingPostgres.length > 0) {
-  console.error('Schema drift detected: modules in SQLite but MISSING from PostgreSQL:');
+  console.error('ERROR: Schema drift detected: modules in SQLite but MISSING from PostgreSQL:');
   for (const m of missingPostgres.sort()) {
     console.error(`  - ${m}`);
   }
-  driftDetected = true;
+  moduleDrift = true;
 }
 
 if (missingSqlite.length > 0) {
-  console.error('Schema drift detected: modules in PostgreSQL but MISSING from SQLite:');
+  console.error('ERROR: Schema drift detected: modules in PostgreSQL but MISSING from SQLite:');
   for (const m of missingSqlite.sort()) {
     console.error(`  - ${m}`);
   }
-  driftDetected = true;
+  moduleDrift = true;
 }
 
-if (driftDetected) {
-  console.error('\nSchema drift check FAILED. Fix the above discrepancies.');
-  process.exit(1);
-} else {
-  console.log('Schema drift check passed — SQLite and PostgreSQL index exports are in sync.');
-  process.exit(0);
+// ---------------------------------------------------------------------------
+// Phase 2: Column-level comparison for shared modules
+// ---------------------------------------------------------------------------
+
+interface ColumnInfo {
+  propertyName: string;
+  dbColumnName: string;
+  onDelete?: string;
 }
+
+interface TableInfo {
+  tableName: string;
+  columns: Map<string, ColumnInfo>;
+}
+
+/**
+ * Extract table definitions from a schema file.
+ *
+ * Matches patterns like:
+ *   export const tableName = sqliteTable('db_table_name', { ... })
+ *   export const tableName = pgTable('db_table_name', { ... })
+ *
+ * Then extracts columns from the object body.
+ */
+function extractTables(filePath: string): TableInfo[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const tables: TableInfo[] = [];
+
+  // Match table declarations — capture table variable name, db name, and body
+  // The body is everything in the first { ... } after the table name string
+  const tableRe =
+    /export\s+const\s+\w+\s*=\s*(?:sqliteTable|pgTable)\(\s*['"]([^'"]+)['"]\s*,\s*\{/g;
+
+  for (const tableMatch of content.matchAll(tableRe)) {
+    const tableName = tableMatch[1];
+    const startIdx = tableMatch.index + tableMatch[0].length;
+
+    // Find the matching closing brace by counting braces
+    let depth = 1;
+    let i = startIdx;
+    while (i < content.length && depth > 0) {
+      if (content[i] === '{') depth++;
+      else if (content[i] === '}') depth--;
+      i++;
+    }
+
+    const body = content.slice(startIdx, i - 1);
+    const columns = extractColumns(body);
+
+    tables.push({ tableName, columns });
+  }
+
+  return tables;
+}
+
+/**
+ * Extract column definitions from a table body string.
+ *
+ * Matches patterns like:
+ *   columnName: text('db_col_name')...
+ *   columnName: integer('db_col_name')...
+ *   columnName: jsonb('db_col_name')...
+ *   columnName: timestamp('db_col_name', ...)...
+ *
+ * Also extracts .references(() => ..., { onDelete: '...' }) if present.
+ */
+function extractColumns(body: string): Map<string, ColumnInfo> {
+  const columns = new Map<string, ColumnInfo>();
+
+  // Split body into top-level property definitions.
+  // Each column starts at the beginning of a line (after whitespace) with an identifier followed by ':'
+  // We need to handle multi-line column definitions, so we track brace/paren depth.
+  const lines = body.split('\n');
+  const columnChunks: string[] = [];
+  let currentChunk = '';
+  let depth = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (
+      !trimmed ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*')
+    ) {
+      // Comment or empty line — include in current chunk for continuity
+      if (currentChunk) currentChunk += `\n${line}`;
+      continue;
+    }
+
+    // Check if this line starts a new property (identifier: ...)
+    // But only at depth 0
+    const propStart = /^(\w+)\s*:/.test(trimmed);
+    if (propStart && depth === 0 && currentChunk) {
+      columnChunks.push(currentChunk);
+      currentChunk = '';
+    }
+
+    currentChunk += (currentChunk ? '\n' : '') + line;
+
+    // Track depth for parens and braces
+    for (const ch of trimmed) {
+      if (ch === '(' || ch === '{' || ch === '[') depth++;
+      else if (ch === ')' || ch === '}' || ch === ']') depth--;
+    }
+  }
+  if (currentChunk) columnChunks.push(currentChunk);
+
+  for (const chunk of columnChunks) {
+    const trimmed = chunk.trim();
+
+    // Extract property name
+    const propMatch = trimmed.match(/^(\w+)\s*:/);
+    if (!propMatch) continue;
+    const propertyName = propMatch[1];
+
+    // Extract DB column name from the type function call: text('col_name'), integer('col_name'), etc.
+    const dbColMatch = trimmed.match(
+      /:\s*(?:text|integer|real|blob|jsonb|timestamp|boolean|serial|varchar|numeric|uuid)\s*\(\s*['"]([^'"]+)['"]/
+    );
+    const dbColumnName = dbColMatch ? dbColMatch[1] : propertyName;
+
+    // Extract onDelete from .references(...)
+    let onDelete: string | undefined;
+    const refMatch = trimmed.match(/\.references\s*\([^)]*\{[^}]*onDelete\s*:\s*['"]([^'"]+)['"]/s);
+    if (refMatch) {
+      onDelete = refMatch[1];
+    }
+
+    columns.set(propertyName, { propertyName, dbColumnName, onDelete });
+  }
+
+  return columns;
+}
+
+// Compare tables across shared modules
+const sharedModules = [...sqliteModules].filter((m) => postgresModules.has(m));
+let columnDrift = false;
+const warnings: string[] = [];
+
+for (const mod of sharedModules.sort()) {
+  const sqlitePath = resolve(root, `sqlite/${mod}.ts`);
+  const postgresPath = resolve(root, `postgres/${mod}.ts`);
+
+  if (!existsSync(sqlitePath) || !existsSync(postgresPath)) {
+    continue;
+  }
+
+  const sqliteTables = extractTables(sqlitePath);
+  const postgresTables = extractTables(postgresPath);
+
+  // Build lookup by table name
+  const sqliteByName = new Map(sqliteTables.map((t) => [t.tableName, t]));
+  const postgresByName = new Map(postgresTables.map((t) => [t.tableName, t]));
+
+  // Check for tables present in one but not the other
+  for (const name of sqliteByName.keys()) {
+    if (!postgresByName.has(name)) {
+      warnings.push(`[${mod}] Table '${name}' exists in SQLite but not in PostgreSQL`);
+      columnDrift = true;
+    }
+  }
+  for (const name of postgresByName.keys()) {
+    if (!sqliteByName.has(name)) {
+      warnings.push(`[${mod}] Table '${name}' exists in PostgreSQL but not in SQLite`);
+      columnDrift = true;
+    }
+  }
+
+  // Compare columns for shared tables
+  for (const [tableName, sqliteTable] of sqliteByName) {
+    const pgTable = postgresByName.get(tableName);
+    if (!pgTable) continue;
+
+    const sqliteCols = sqliteTable.columns;
+    const pgCols = pgTable.columns;
+
+    // Columns in SQLite but missing from PostgreSQL
+    for (const colName of sqliteCols.keys()) {
+      if (!pgCols.has(colName)) {
+        warnings.push(
+          `[${mod}] Table '${tableName}': column '${colName}' exists in SQLite but missing from PostgreSQL`
+        );
+        columnDrift = true;
+      }
+    }
+
+    // Columns in PostgreSQL but missing from SQLite
+    for (const colName of pgCols.keys()) {
+      if (!sqliteCols.has(colName)) {
+        warnings.push(
+          `[${mod}] Table '${tableName}': column '${colName}' exists in PostgreSQL but missing from SQLite`
+        );
+        columnDrift = true;
+      }
+    }
+
+    // Compare onDelete behavior for shared columns with references
+    for (const [colName, sqliteCol] of sqliteCols) {
+      const pgCol = pgCols.get(colName);
+      if (!pgCol) continue;
+
+      // Compare onDelete — only flag if both have references but differ,
+      // or one has a reference and the other doesn't
+      if (sqliteCol.onDelete && pgCol.onDelete) {
+        if (sqliteCol.onDelete !== pgCol.onDelete) {
+          warnings.push(
+            `[${mod}] Table '${tableName}', column '${colName}': onDelete mismatch — SQLite='${sqliteCol.onDelete}', PostgreSQL='${pgCol.onDelete}'`
+          );
+          columnDrift = true;
+        }
+      } else if (sqliteCol.onDelete && !pgCol.onDelete) {
+        warnings.push(
+          `[${mod}] Table '${tableName}', column '${colName}': SQLite has onDelete='${sqliteCol.onDelete}' but PostgreSQL has no reference/onDelete`
+        );
+        columnDrift = true;
+      } else if (!sqliteCol.onDelete && pgCol.onDelete) {
+        warnings.push(
+          `[${mod}] Table '${tableName}', column '${colName}': PostgreSQL has onDelete='${pgCol.onDelete}' but SQLite has no reference/onDelete`
+        );
+        columnDrift = true;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Index comparison for shared modules
+// ---------------------------------------------------------------------------
+
+interface IndexInfo {
+  name: string;
+  columns: string;
+}
+
+/**
+ * Extract index definitions from the table's second argument (the arrow function).
+ *
+ * Matches patterns like:
+ *   index('idx_name').on(table.col1, table.col2)
+ *   uniqueIndex('idx_name').on(table.col1)
+ */
+function extractIndexes(filePath: string): Map<string, IndexInfo[]> {
+  const content = readFileSync(filePath, 'utf-8');
+  const result = new Map<string, IndexInfo[]>();
+
+  // Find table declarations with their index callbacks
+  // Pattern: sqliteTable/pgTable('name', { columns }, (table) => [ ... ])
+  const tableRe = /export\s+const\s+\w+\s*=\s*(?:sqliteTable|pgTable)\(\s*['"]([^'"]+)['"]/g;
+
+  for (const tableMatch of content.matchAll(tableRe)) {
+    const tableName = tableMatch[1];
+    const startIdx = tableMatch.index + tableMatch[0].length;
+
+    // Find the end of the entire table call by tracking parens from the opening paren
+    // We need to go back to find the opening paren of sqliteTable( / pgTable(
+    const callStart = content.lastIndexOf('(', startIdx);
+    let depth = 1;
+    let i = callStart + 1;
+    while (i < content.length && depth > 0) {
+      if (content[i] === '(') depth++;
+      else if (content[i] === ')') depth--;
+      i++;
+    }
+
+    const fullCall = content.slice(callStart, i);
+
+    // Extract indexes from the callback — match index('name').on(table.col, ...)
+    const indexRe = /(?:unique)?[Ii]ndex\(\s*['"]([^'"]+)['"]\s*\)\.on\(([^)]+)\)/g;
+    const indexes: IndexInfo[] = [];
+
+    for (const idxMatch of fullCall.matchAll(indexRe)) {
+      const name = idxMatch[1];
+      // Normalize columns: extract table.xxx references, sort for comparison
+      const colsRaw = idxMatch[2];
+      const colRefs = [...colsRaw.matchAll(/(?:table|t)\.(\w+)/g)].map((m) => m[1]);
+      indexes.push({ name, columns: colRefs.join(', ') });
+    }
+
+    if (indexes.length > 0) {
+      result.set(tableName, indexes);
+    }
+  }
+
+  return result;
+}
+
+for (const mod of sharedModules.sort()) {
+  const sqlitePath = resolve(root, `sqlite/${mod}.ts`);
+  const postgresPath = resolve(root, `postgres/${mod}.ts`);
+
+  if (!existsSync(sqlitePath) || !existsSync(postgresPath)) {
+    continue;
+  }
+
+  const sqliteIndexes = extractIndexes(sqlitePath);
+  const postgresIndexes = extractIndexes(postgresPath);
+
+  // Collect all table names that have indexes in either schema
+  const allTables = new Set([...sqliteIndexes.keys(), ...postgresIndexes.keys()]);
+
+  for (const tableName of allTables) {
+    const sqliteIdxs = sqliteIndexes.get(tableName) || [];
+    const postgresIdxs = postgresIndexes.get(tableName) || [];
+
+    const sqliteIdxNames = new Set(sqliteIdxs.map((idx) => idx.name));
+    const postgresIdxNames = new Set(postgresIdxs.map((idx) => idx.name));
+
+    // Indexes in SQLite but missing from PostgreSQL
+    for (const idx of sqliteIdxs) {
+      if (!postgresIdxNames.has(idx.name)) {
+        warnings.push(
+          `[${mod}] Table '${tableName}': index '${idx.name}' (${idx.columns}) exists in SQLite but missing from PostgreSQL`
+        );
+        columnDrift = true;
+      }
+    }
+
+    // Indexes in PostgreSQL but missing from SQLite
+    for (const idx of postgresIdxs) {
+      if (!sqliteIdxNames.has(idx.name)) {
+        warnings.push(
+          `[${mod}] Table '${tableName}': index '${idx.name}' (${idx.columns}) exists in PostgreSQL but missing from SQLite`
+        );
+        columnDrift = true;
+      }
+    }
+
+    // Compare columns for shared indexes
+    const sqliteIdxMap = new Map(sqliteIdxs.map((idx) => [idx.name, idx]));
+    const postgresIdxMap = new Map(postgresIdxs.map((idx) => [idx.name, idx]));
+
+    for (const [idxName, sqliteIdx] of sqliteIdxMap) {
+      const pgIdx = postgresIdxMap.get(idxName);
+      if (!pgIdx) continue;
+
+      if (sqliteIdx.columns !== pgIdx.columns) {
+        warnings.push(
+          `[${mod}] Table '${tableName}': index '${idxName}' column mismatch — SQLite=(${sqliteIdx.columns}), PostgreSQL=(${pgIdx.columns})`
+        );
+        columnDrift = true;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+
+if (warnings.length > 0) {
+  console.warn('\nColumn/Index drift warnings:');
+  for (const w of warnings) {
+    console.warn(`  WARNING: ${w}`);
+  }
+  console.warn(`\n${warnings.length} warning(s) found.`);
+}
+
+if (moduleDrift) {
+  console.error('\nSchema drift check FAILED — module-level mismatches detected.');
+  process.exit(1);
+}
+
+if (columnDrift) {
+  console.error('\nSchema drift check FAILED — column/index-level drift detected.');
+  process.exit(1);
+}
+
+console.log(
+  `\nSchema drift check passed — ${sharedModules.length} shared modules compared, SQLite and PostgreSQL schemas are in sync.`
+);
+process.exit(0);

--- a/src/db/migrations-pg/0004_schema_catchup.sql
+++ b/src/db/migrations-pg/0004_schema_catchup.sql
@@ -1,0 +1,518 @@
+-- 0004_schema_catchup.sql
+-- Comprehensive catch-up migration to bring PostgreSQL schema in line with
+-- the current Drizzle schema (equivalent to SQLite migrations v4 through v25).
+--
+-- Major changes:
+--   1. Rename projects -> codespaces (and all FK columns project_id -> codespace_id)
+--   2. Rename template_projects -> template_codespaces (and column renames)
+--   3. Create all missing tables (users, teams, folders, events, memory, skills, etc.)
+--   4. Add missing columns to existing tables
+--   5. Add missing indexes
+
+BEGIN;
+
+-- ============================================================================
+-- SECTION 1: Create prerequisite tables (needed before FK references)
+-- ============================================================================
+
+-- 1a. users
+CREATE TABLE IF NOT EXISTS "users" (
+    "id" text PRIMARY KEY NOT NULL,
+    "github_id" integer NOT NULL UNIQUE,
+    "github_login" text NOT NULL,
+    "name" text,
+    "email" text,
+    "github_email" text,
+    "avatar_url" text,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- 1b. teams
+CREATE TABLE IF NOT EXISTS "teams" (
+    "id" text PRIMARY KEY NOT NULL,
+    "name" text NOT NULL,
+    "slug" text NOT NULL UNIQUE,
+    "description" text,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- 1c. project_folders
+CREATE TABLE IF NOT EXISTS "project_folders" (
+    "id" text PRIMARY KEY NOT NULL,
+    "name" text NOT NULL,
+    "slug" text NOT NULL UNIQUE,
+    "description" text,
+    "icon" text NOT NULL DEFAULT 'Folder',
+    "color" text NOT NULL DEFAULT '#6B7280',
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- 1d. user_sessions
+CREATE TABLE IF NOT EXISTS "user_sessions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "token" text NOT NULL UNIQUE,
+    "expires_at" timestamp NOT NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- 1e. team_members
+CREATE TABLE IF NOT EXISTS "team_members" (
+    "team_id" text NOT NULL REFERENCES "teams"("id") ON DELETE CASCADE,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "role" text NOT NULL DEFAULT 'viewer',
+    "joined_at" timestamp DEFAULT now() NOT NULL,
+    PRIMARY KEY ("team_id", "user_id")
+);
+
+-- 1f. team_invitations
+CREATE TABLE IF NOT EXISTS "team_invitations" (
+    "id" text PRIMARY KEY NOT NULL,
+    "team_id" text NOT NULL REFERENCES "teams"("id") ON DELETE CASCADE,
+    "invited_by" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "email" text NOT NULL,
+    "role" text NOT NULL DEFAULT 'viewer',
+    "token" text NOT NULL UNIQUE,
+    "status" text NOT NULL DEFAULT 'pending',
+    "expires_at" timestamp NOT NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- 1g. team_project_folders
+CREATE TABLE IF NOT EXISTS "team_project_folders" (
+    "team_id" text NOT NULL REFERENCES "teams"("id") ON DELETE CASCADE,
+    "project_folder_id" text NOT NULL REFERENCES "project_folders"("id") ON DELETE CASCADE,
+    "assigned_at" timestamp DEFAULT now() NOT NULL,
+    PRIMARY KEY ("team_id", "project_folder_id")
+);
+
+-- 1h. folder_members
+CREATE TABLE IF NOT EXISTS "folder_members" (
+    "project_folder_id" text NOT NULL REFERENCES "project_folders"("id") ON DELETE CASCADE,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "role" text NOT NULL,
+    "granted_by_team_id" text REFERENCES "teams"("id") ON DELETE SET NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    PRIMARY KEY ("project_folder_id", "user_id")
+);
+
+-- ============================================================================
+-- SECTION 2: Rename projects -> codespaces
+-- ============================================================================
+
+-- 2a. Drop all foreign key constraints referencing "projects"
+ALTER TABLE "agent_runs" DROP CONSTRAINT IF EXISTS "agent_runs_project_id_projects_id_fk";
+ALTER TABLE "agents" DROP CONSTRAINT IF EXISTS "agents_project_id_projects_id_fk";
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_project_id_projects_id_fk";
+ALTER TABLE "plan_sessions" DROP CONSTRAINT IF EXISTS "plan_sessions_project_id_projects_id_fk";
+ALTER TABLE "projects" DROP CONSTRAINT IF EXISTS "projects_github_installation_id_github_installations_id_fk";
+ALTER TABLE "projects" DROP CONSTRAINT IF EXISTS "projects_sandbox_config_id_sandbox_configs_id_fk";
+ALTER TABLE "sandbox_instances" DROP CONSTRAINT IF EXISTS "sandbox_instances_project_id_projects_id_fk";
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_project_id_projects_id_fk";
+ALTER TABLE "tasks" DROP CONSTRAINT IF EXISTS "tasks_project_id_projects_id_fk";
+ALTER TABLE "template_projects" DROP CONSTRAINT IF EXISTS "template_projects_project_id_projects_id_fk";
+ALTER TABLE "template_projects" DROP CONSTRAINT IF EXISTS "template_projects_template_id_templates_id_fk";
+ALTER TABLE "templates" DROP CONSTRAINT IF EXISTS "templates_project_id_projects_id_fk";
+ALTER TABLE "worktrees" DROP CONSTRAINT IF EXISTS "worktrees_project_id_projects_id_fk";
+
+-- 2b. Drop unique constraint on projects.path before rename
+ALTER TABLE "projects" DROP CONSTRAINT IF EXISTS "projects_path_unique";
+
+-- 2c. Rename the table
+ALTER TABLE "projects" RENAME TO "codespaces";
+
+-- 2d. Add project_folder_id column to codespaces (required FK, default to placeholder)
+ALTER TABLE "codespaces" ADD COLUMN IF NOT EXISTS "project_folder_id" text;
+
+-- 2e. Re-add unique constraint on codespaces.path
+ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_path_unique" UNIQUE ("path");
+
+-- 2f. Rename project_id -> codespace_id in all referencing tables
+ALTER TABLE "agent_runs" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "agents" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "audit_logs" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "plan_sessions" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "sandbox_instances" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "sessions" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "tasks" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "worktrees" RENAME COLUMN "project_id" TO "codespace_id";
+
+-- Also rename unique constraint on sandbox_instances
+ALTER TABLE "sandbox_instances" DROP CONSTRAINT IF EXISTS "sandbox_instances_project_id_unique";
+ALTER TABLE "sandbox_instances" ADD CONSTRAINT "sandbox_instances_codespace_id_unique" UNIQUE ("codespace_id");
+
+-- 2g. Re-create all FK constraints pointing to "codespaces"
+ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_project_folder_id_project_folders_id_fk"
+    FOREIGN KEY ("project_folder_id") REFERENCES "project_folders"("id") ON DELETE CASCADE;
+ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_github_installation_id_github_installations_id_fk"
+    FOREIGN KEY ("github_installation_id") REFERENCES "github_installations"("id") ON DELETE SET NULL;
+ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_sandbox_config_id_sandbox_configs_id_fk"
+    FOREIGN KEY ("sandbox_config_id") REFERENCES "sandbox_configs"("id") ON DELETE SET NULL;
+
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "agents" ADD CONSTRAINT "agents_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "plan_sessions" ADD CONSTRAINT "plan_sessions_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "sandbox_instances" ADD CONSTRAINT "sandbox_instances_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "worktrees" ADD CONSTRAINT "worktrees_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+
+-- Re-add non-project FK constraints that were dropped
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_id_agents_id_fk"
+    FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE CASCADE;
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_task_id_tasks_id_fk"
+    FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE CASCADE;
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_session_id_sessions_id_fk"
+    FOREIGN KEY ("session_id") REFERENCES "sessions"("id") ON DELETE SET NULL;
+
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_agent_id_agents_id_fk"
+    FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_agent_run_id_agent_runs_id_fk"
+    FOREIGN KEY ("agent_run_id") REFERENCES "agent_runs"("id") ON DELETE SET NULL;
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_task_id_tasks_id_fk"
+    FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE SET NULL;
+
+ALTER TABLE "plan_sessions" ADD CONSTRAINT "plan_sessions_task_id_tasks_id_fk"
+    FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE CASCADE;
+
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_task_id_tasks_id_fk"
+    FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE SET NULL;
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_agent_id_agents_id_fk"
+    FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_agent_id_agents_id_fk"
+    FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_session_id_sessions_id_fk"
+    FOREIGN KEY ("session_id") REFERENCES "sessions"("id") ON DELETE SET NULL;
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_worktree_id_worktrees_id_fk"
+    FOREIGN KEY ("worktree_id") REFERENCES "worktrees"("id") ON DELETE SET NULL;
+
+ALTER TABLE "worktrees" ADD CONSTRAINT "worktrees_agent_id_agents_id_fk"
+    FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+ALTER TABLE "worktrees" ADD CONSTRAINT "worktrees_task_id_tasks_id_fk"
+    FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE SET NULL;
+
+-- ============================================================================
+-- SECTION 3: Rename template_projects -> template_codespaces
+-- ============================================================================
+
+-- 3a. Drop template_projects and recreate as template_codespaces
+-- (Rename table + rename column)
+ALTER TABLE "template_projects" RENAME TO "template_codespaces";
+ALTER TABLE "template_codespaces" RENAME COLUMN "project_id" TO "codespace_id";
+
+-- Drop old PK constraint and add new one
+ALTER TABLE "template_codespaces" DROP CONSTRAINT IF EXISTS "template_projects_template_id_project_id_pk";
+ALTER TABLE "template_codespaces" ADD PRIMARY KEY ("template_id", "codespace_id");
+
+-- Re-add FK constraints
+ALTER TABLE "template_codespaces" ADD CONSTRAINT "template_codespaces_template_id_templates_id_fk"
+    FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+ALTER TABLE "template_codespaces" ADD CONSTRAINT "template_codespaces_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+
+-- ============================================================================
+-- SECTION 3b: Update templates table - rename project_id -> codespace_id
+-- ============================================================================
+
+ALTER TABLE "templates" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "templates" ADD CONSTRAINT "templates_codespace_id_codespaces_id_fk"
+    FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+
+-- ============================================================================
+-- SECTION 4: Add missing columns to existing tables
+-- ============================================================================
+
+-- 4a. github_installations: add team_id
+ALTER TABLE "github_installations" ADD COLUMN IF NOT EXISTS "team_id" text
+    REFERENCES "teams"("id") ON DELETE SET NULL;
+
+-- 4b. sessions: add sandbox_provider and sandbox_container_id
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "sandbox_provider" text;
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "sandbox_container_id" text;
+
+-- 4c. agents: add parent_agent_id
+ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "parent_agent_id" text;
+
+-- 4d. tasks: add skill_id and skill_name
+ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "skill_id" text;
+ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "skill_name" text;
+
+-- 4e. session_summaries: add cost_usd, duration_api_ms, cache_read_tokens, cache_creation_tokens, stop_reason
+ALTER TABLE "session_summaries" ADD COLUMN IF NOT EXISTS "cost_usd" double precision;
+ALTER TABLE "session_summaries" ADD COLUMN IF NOT EXISTS "duration_api_ms" integer;
+ALTER TABLE "session_summaries" ADD COLUMN IF NOT EXISTS "cache_read_tokens" integer;
+ALTER TABLE "session_summaries" ADD COLUMN IF NOT EXISTS "cache_creation_tokens" integer;
+ALTER TABLE "session_summaries" ADD COLUMN IF NOT EXISTS "stop_reason" text;
+
+-- ============================================================================
+-- SECTION 5: Create codespace_members (formerly project_members concept)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS "codespace_members" (
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "role" text NOT NULL,
+    "granted_by_team_id" text REFERENCES "teams"("id") ON DELETE SET NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    PRIMARY KEY ("codespace_id", "user_id")
+);
+
+-- ============================================================================
+-- SECTION 6: Create api_tokens
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS "api_tokens" (
+    "id" text PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "team_id" text NOT NULL REFERENCES "teams"("id") ON DELETE CASCADE,
+    "name" text NOT NULL,
+    "token_hash" text NOT NULL UNIQUE,
+    "token_prefix" text NOT NULL,
+    "role" text NOT NULL,
+    "scope_tags" jsonb,
+    "scope_codespace_id" text REFERENCES "codespaces"("id") ON DELETE SET NULL,
+    "status" text NOT NULL DEFAULT 'active',
+    "expires_at" timestamp,
+    "use_count" integer DEFAULT 0,
+    "last_used_at" timestamp,
+    "revoked_at" timestamp,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- ============================================================================
+-- SECTION 7: Create tags, codespace_tags, task_tags
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS "tags" (
+    "id" text PRIMARY KEY NOT NULL,
+    "project_folder_id" text NOT NULL REFERENCES "project_folders"("id") ON DELETE CASCADE,
+    "name" text NOT NULL,
+    "color" text NOT NULL DEFAULT '#6B7280',
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "tags_folder_name_unique" ON "tags" ("project_folder_id", "name");
+
+CREATE TABLE IF NOT EXISTS "codespace_tags" (
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "tag_id" text NOT NULL REFERENCES "tags"("id") ON DELETE CASCADE,
+    "assigned_at" timestamp DEFAULT now() NOT NULL,
+    PRIMARY KEY ("codespace_id", "tag_id")
+);
+
+CREATE TABLE IF NOT EXISTS "task_tags" (
+    "task_id" text NOT NULL REFERENCES "tasks"("id") ON DELETE CASCADE,
+    "tag_id" text NOT NULL REFERENCES "tags"("id") ON DELETE CASCADE,
+    "assigned_at" timestamp DEFAULT now() NOT NULL,
+    PRIMARY KEY ("task_id", "tag_id")
+);
+
+-- ============================================================================
+-- SECTION 8: Create event_sources, event_subscriptions, event_log, schedule_executions
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS "event_sources" (
+    "id" text PRIMARY KEY NOT NULL,
+    "team_id" text NOT NULL REFERENCES "teams"("id") ON DELETE CASCADE,
+    "name" text NOT NULL,
+    "type" text NOT NULL,
+    "slug" text NOT NULL UNIQUE,
+    "webhook_secret" text,
+    "is_enabled" boolean NOT NULL DEFAULT true,
+    "config" jsonb DEFAULT '{}',
+    "event_count" integer NOT NULL DEFAULT 0,
+    "last_event_at" timestamp,
+    "github_installation_id" text REFERENCES "github_installations"("id") ON DELETE SET NULL,
+    "status" text NOT NULL DEFAULT 'active',
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "event_sources_team_idx" ON "event_sources" ("team_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "event_sources_slug_idx" ON "event_sources" ("slug");
+
+CREATE TABLE IF NOT EXISTS "event_subscriptions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "name" text NOT NULL,
+    "event_source_id" text NOT NULL REFERENCES "event_sources"("id") ON DELETE CASCADE,
+    "target_codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "is_enabled" boolean NOT NULL DEFAULT true,
+    "event_types" jsonb DEFAULT '[]',
+    "filters" jsonb DEFAULT '[]',
+    "prompt_template" text NOT NULL,
+    "auto_start_agent" boolean NOT NULL DEFAULT false,
+    "task_column" text NOT NULL DEFAULT 'backlog',
+    "task_priority" text NOT NULL DEFAULT 'medium',
+    "task_labels" jsonb DEFAULT '[]',
+    "matched_count" integer NOT NULL DEFAULT 0,
+    "last_matched_at" timestamp,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "event_subscriptions_source_idx" ON "event_subscriptions" ("event_source_id");
+CREATE INDEX IF NOT EXISTS "event_subscriptions_codespace_idx" ON "event_subscriptions" ("target_codespace_id");
+CREATE INDEX IF NOT EXISTS "event_subscriptions_source_enabled_idx" ON "event_subscriptions" ("event_source_id", "is_enabled");
+
+CREATE TABLE IF NOT EXISTS "event_log" (
+    "id" text PRIMARY KEY NOT NULL,
+    "event_source_id" text REFERENCES "event_sources"("id") ON DELETE SET NULL,
+    "event_type" text NOT NULL,
+    "action" text,
+    "status" text NOT NULL DEFAULT 'received',
+    "payload" jsonb DEFAULT '{}',
+    "matched_subscriptions" jsonb DEFAULT '[]',
+    "error" text,
+    "delivery_id" text NOT NULL,
+    "received_at" timestamp DEFAULT now() NOT NULL,
+    "processed_at" timestamp
+);
+
+CREATE INDEX IF NOT EXISTS "event_log_source_idx" ON "event_log" ("event_source_id");
+CREATE INDEX IF NOT EXISTS "event_log_received_at_idx" ON "event_log" ("received_at");
+CREATE INDEX IF NOT EXISTS "event_log_source_status_idx" ON "event_log" ("event_source_id", "status");
+CREATE UNIQUE INDEX IF NOT EXISTS "event_log_delivery_idx" ON "event_log" ("event_source_id", "delivery_id");
+
+CREATE TABLE IF NOT EXISTS "schedule_executions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "event_source_id" text NOT NULL REFERENCES "event_sources"("id") ON DELETE CASCADE,
+    "status" text NOT NULL,
+    "scheduled_at" timestamp NOT NULL,
+    "executed_at" timestamp NOT NULL,
+    "task_id" text REFERENCES "tasks"("id") ON DELETE SET NULL,
+    "subscription_id" text REFERENCES "event_subscriptions"("id") ON DELETE SET NULL,
+    "budget_window" text,
+    "window_execution_count" integer NOT NULL DEFAULT 0,
+    "error" text,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "schedule_executions_event_source_idx" ON "schedule_executions" ("event_source_id");
+CREATE INDEX IF NOT EXISTS "schedule_executions_source_status_idx" ON "schedule_executions" ("event_source_id", "status");
+CREATE INDEX IF NOT EXISTS "schedule_executions_source_executed_at_idx" ON "schedule_executions" ("event_source_id", "executed_at");
+CREATE INDEX IF NOT EXISTS "schedule_executions_source_scheduled_at_idx" ON "schedule_executions" ("event_source_id", "scheduled_at");
+
+-- ============================================================================
+-- SECTION 9: Create memory tables (memory_insights, memory_messages)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS "memory_insights" (
+    "id" text PRIMARY KEY NOT NULL,
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "content" text NOT NULL,
+    "source" text NOT NULL,
+    "source_session_id" text REFERENCES "sessions"("id") ON DELETE SET NULL,
+    "skill_id" text,
+    "tags" jsonb DEFAULT '[]',
+    "metadata" jsonb,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "memory_messages" (
+    "id" text PRIMARY KEY NOT NULL,
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "memory_session_id" text NOT NULL,
+    "agent_id" text NOT NULL,
+    "task_id" text REFERENCES "tasks"("id") ON DELETE SET NULL,
+    "role" text NOT NULL,
+    "content" text NOT NULL,
+    "turn_number" integer NOT NULL,
+    "metadata" jsonb,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- ============================================================================
+-- SECTION 10: Create skill tables (skill_executions, skill_metrics, dream_sessions, skill_suggestions)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS "skill_executions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "skill_id" text NOT NULL,
+    "skill_name" text,
+    "task_id" text REFERENCES "tasks"("id") ON DELETE SET NULL,
+    "agent_run_id" text REFERENCES "agent_runs"("id") ON DELETE SET NULL,
+    "session_id" text REFERENCES "sessions"("id") ON DELETE SET NULL,
+    "status" text NOT NULL,
+    "turns_used" integer,
+    "tokens_used" integer,
+    "duration_ms" integer,
+    "files_modified" integer,
+    "lines_added" integer,
+    "lines_removed" integer,
+    "cost_usd" double precision,
+    "error_message" text,
+    "started_at" timestamp,
+    "completed_at" timestamp,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "skill_metrics" (
+    "id" text PRIMARY KEY NOT NULL,
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "skill_id" text NOT NULL,
+    "skill_name" text NOT NULL,
+    "total_runs" integer NOT NULL DEFAULT 0,
+    "success_count" integer NOT NULL DEFAULT 0,
+    "error_count" integer NOT NULL DEFAULT 0,
+    "avg_tokens_used" double precision,
+    "avg_turns_used" double precision,
+    "avg_duration_ms" double precision,
+    "avg_cost_usd" double precision,
+    "success_rate" double precision,
+    "last_run_at" timestamp,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "skill_metrics_codespace_skill_unique"
+    ON "skill_metrics" ("codespace_id", "skill_id");
+
+CREATE TABLE IF NOT EXISTS "dream_sessions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "codespace_id" text REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "type" text NOT NULL,
+    "status" text NOT NULL,
+    "skills_analyzed" integer NOT NULL DEFAULT 0,
+    "suggestions_generated" integer NOT NULL DEFAULT 0,
+    "tokens_used" integer NOT NULL DEFAULT 0,
+    "cost_usd" double precision,
+    "started_at" timestamp DEFAULT now() NOT NULL,
+    "completed_at" timestamp,
+    "error_message" text,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "skill_suggestions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "dream_session_id" text NOT NULL REFERENCES "dream_sessions"("id") ON DELETE CASCADE,
+    "codespace_id" text NOT NULL REFERENCES "codespaces"("id") ON DELETE CASCADE,
+    "skill_id" text NOT NULL,
+    "skill_name" text NOT NULL,
+    "suggestion_type" text NOT NULL,
+    "title" text NOT NULL,
+    "reasoning" text NOT NULL,
+    "current_content" text,
+    "suggested_content" text NOT NULL,
+    "diff" text,
+    "status" text NOT NULL DEFAULT 'pending',
+    "user_notes" text,
+    "applied_at" timestamp,
+    "applied_by" text,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+COMMIT;

--- a/src/db/migrations-pg/0004_schema_catchup.sql
+++ b/src/db/migrations-pg/0004_schema_catchup.sql
@@ -526,7 +526,34 @@ CREATE TABLE IF NOT EXISTS "skill_suggestions" (
     "created_at" timestamp DEFAULT now() NOT NULL
 );
 
--- SECTION 11: Add missing indexes from Drizzle schema
+-- SECTION 11: Add github_tokens.team_id (matches SQLite migration v11-v12)
+ALTER TABLE "github_tokens" ADD COLUMN IF NOT EXISTS "team_id" text
+    REFERENCES "teams"("id") ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS "idx_github_tokens_team" ON "github_tokens" ("team_id");
+
+-- SECTION 12: Add missing indexes from Drizzle schema
 CREATE INDEX IF NOT EXISTS "session_events_created_at_idx" ON "session_events" ("created_at");
+
+-- Memory indexes
+CREATE INDEX IF NOT EXISTS "idx_memory_insights_codespace_id" ON "memory_insights" ("codespace_id");
+CREATE INDEX IF NOT EXISTS "idx_memory_insights_skill_id" ON "memory_insights" ("skill_id");
+CREATE INDEX IF NOT EXISTS "idx_memory_insights_source_session_id" ON "memory_insights" ("source_session_id");
+CREATE INDEX IF NOT EXISTS "idx_memory_messages_codespace_id" ON "memory_messages" ("codespace_id");
+CREATE INDEX IF NOT EXISTS "idx_memory_messages_memory_session_id" ON "memory_messages" ("memory_session_id");
+CREATE INDEX IF NOT EXISTS "idx_memory_messages_task_id" ON "memory_messages" ("task_id");
+
+-- Skill indexes
+CREATE INDEX IF NOT EXISTS "idx_skill_executions_codespace_id" ON "skill_executions" ("codespace_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_executions_skill_id" ON "skill_executions" ("skill_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_executions_task_id" ON "skill_executions" ("task_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_executions_agent_run_id" ON "skill_executions" ("agent_run_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_suggestions_dream_session_id" ON "skill_suggestions" ("dream_session_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_suggestions_codespace_id" ON "skill_suggestions" ("codespace_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_suggestions_skill_id" ON "skill_suggestions" ("skill_id");
+CREATE INDEX IF NOT EXISTS "idx_skill_suggestions_status" ON "skill_suggestions" ("status");
+
+-- Dream indexes
+CREATE INDEX IF NOT EXISTS "idx_dream_sessions_codespace_id" ON "dream_sessions" ("codespace_id");
+CREATE INDEX IF NOT EXISTS "idx_dream_sessions_status" ON "dream_sessions" ("status");
 
 COMMIT;

--- a/src/db/migrations-pg/0004_schema_catchup.sql
+++ b/src/db/migrations-pg/0004_schema_catchup.sql
@@ -139,6 +139,7 @@ UPDATE "codespaces" SET "project_folder_id" = 'default_folder' WHERE "project_fo
 ALTER TABLE "codespaces" ALTER COLUMN "project_folder_id" SET NOT NULL;
 
 -- 2e. Re-add unique constraint on codespaces.path
+ALTER TABLE "codespaces" DROP CONSTRAINT IF EXISTS "codespaces_path_unique";
 ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_path_unique" UNIQUE ("path");
 
 -- 2f. Rename project_id -> codespace_id in all referencing tables
@@ -153,65 +154,92 @@ ALTER TABLE "worktrees" RENAME COLUMN "project_id" TO "codespace_id";
 
 -- Also rename unique constraint on sandbox_instances
 ALTER TABLE "sandbox_instances" DROP CONSTRAINT IF EXISTS "sandbox_instances_project_id_unique";
+ALTER TABLE "sandbox_instances" DROP CONSTRAINT IF EXISTS "sandbox_instances_codespace_id_unique";
 ALTER TABLE "sandbox_instances" ADD CONSTRAINT "sandbox_instances_codespace_id_unique" UNIQUE ("codespace_id");
 
 -- 2g. Re-create all FK constraints pointing to "codespaces"
+-- Drop before add for idempotency (safe to run multiple times)
+ALTER TABLE "codespaces" DROP CONSTRAINT IF EXISTS "codespaces_project_folder_id_project_folders_id_fk";
 ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_project_folder_id_project_folders_id_fk"
     FOREIGN KEY ("project_folder_id") REFERENCES "project_folders"("id") ON DELETE CASCADE;
+ALTER TABLE "codespaces" DROP CONSTRAINT IF EXISTS "codespaces_github_installation_id_github_installations_id_fk";
 ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_github_installation_id_github_installations_id_fk"
     FOREIGN KEY ("github_installation_id") REFERENCES "github_installations"("id") ON DELETE SET NULL;
+ALTER TABLE "codespaces" DROP CONSTRAINT IF EXISTS "codespaces_sandbox_config_id_sandbox_configs_id_fk";
 ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_sandbox_config_id_sandbox_configs_id_fk"
     FOREIGN KEY ("sandbox_config_id") REFERENCES "sandbox_configs"("id") ON DELETE SET NULL;
 
+ALTER TABLE "agent_runs" DROP CONSTRAINT IF EXISTS "agent_runs_codespace_id_codespaces_id_fk";
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "agents" DROP CONSTRAINT IF EXISTS "agents_codespace_id_codespaces_id_fk";
 ALTER TABLE "agents" ADD CONSTRAINT "agents_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_codespace_id_codespaces_id_fk";
 ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "plan_sessions" DROP CONSTRAINT IF EXISTS "plan_sessions_codespace_id_codespaces_id_fk";
 ALTER TABLE "plan_sessions" ADD CONSTRAINT "plan_sessions_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "sandbox_instances" DROP CONSTRAINT IF EXISTS "sandbox_instances_codespace_id_codespaces_id_fk";
 ALTER TABLE "sandbox_instances" ADD CONSTRAINT "sandbox_instances_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_codespace_id_codespaces_id_fk";
 ALTER TABLE "sessions" ADD CONSTRAINT "sessions_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "tasks" DROP CONSTRAINT IF EXISTS "tasks_codespace_id_codespaces_id_fk";
 ALTER TABLE "tasks" ADD CONSTRAINT "tasks_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
+ALTER TABLE "worktrees" DROP CONSTRAINT IF EXISTS "worktrees_codespace_id_codespaces_id_fk";
 ALTER TABLE "worktrees" ADD CONSTRAINT "worktrees_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
 
 -- Re-add non-project FK constraints that were dropped
+ALTER TABLE "agent_runs" DROP CONSTRAINT IF EXISTS "agent_runs_agent_id_agents_id_fk";
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_id_agents_id_fk"
     FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE CASCADE;
+ALTER TABLE "agent_runs" DROP CONSTRAINT IF EXISTS "agent_runs_task_id_tasks_id_fk";
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_task_id_tasks_id_fk"
     FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE CASCADE;
+ALTER TABLE "agent_runs" DROP CONSTRAINT IF EXISTS "agent_runs_session_id_sessions_id_fk";
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_session_id_sessions_id_fk"
     FOREIGN KEY ("session_id") REFERENCES "sessions"("id") ON DELETE SET NULL;
 
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_agent_id_agents_id_fk";
 ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_agent_id_agents_id_fk"
     FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_agent_run_id_agent_runs_id_fk";
 ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_agent_run_id_agent_runs_id_fk"
     FOREIGN KEY ("agent_run_id") REFERENCES "agent_runs"("id") ON DELETE SET NULL;
+ALTER TABLE "audit_logs" DROP CONSTRAINT IF EXISTS "audit_logs_task_id_tasks_id_fk";
 ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_task_id_tasks_id_fk"
     FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE SET NULL;
 
+ALTER TABLE "plan_sessions" DROP CONSTRAINT IF EXISTS "plan_sessions_task_id_tasks_id_fk";
 ALTER TABLE "plan_sessions" ADD CONSTRAINT "plan_sessions_task_id_tasks_id_fk"
     FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE CASCADE;
 
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_task_id_tasks_id_fk";
 ALTER TABLE "sessions" ADD CONSTRAINT "sessions_task_id_tasks_id_fk"
     FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE SET NULL;
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_agent_id_agents_id_fk";
 ALTER TABLE "sessions" ADD CONSTRAINT "sessions_agent_id_agents_id_fk"
     FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
 
+ALTER TABLE "tasks" DROP CONSTRAINT IF EXISTS "tasks_agent_id_agents_id_fk";
 ALTER TABLE "tasks" ADD CONSTRAINT "tasks_agent_id_agents_id_fk"
     FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+ALTER TABLE "tasks" DROP CONSTRAINT IF EXISTS "tasks_session_id_sessions_id_fk";
 ALTER TABLE "tasks" ADD CONSTRAINT "tasks_session_id_sessions_id_fk"
     FOREIGN KEY ("session_id") REFERENCES "sessions"("id") ON DELETE SET NULL;
+ALTER TABLE "tasks" DROP CONSTRAINT IF EXISTS "tasks_worktree_id_worktrees_id_fk";
 ALTER TABLE "tasks" ADD CONSTRAINT "tasks_worktree_id_worktrees_id_fk"
     FOREIGN KEY ("worktree_id") REFERENCES "worktrees"("id") ON DELETE SET NULL;
 
+ALTER TABLE "worktrees" DROP CONSTRAINT IF EXISTS "worktrees_agent_id_agents_id_fk";
 ALTER TABLE "worktrees" ADD CONSTRAINT "worktrees_agent_id_agents_id_fk"
     FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE SET NULL;
+ALTER TABLE "worktrees" DROP CONSTRAINT IF EXISTS "worktrees_task_id_tasks_id_fk";
 ALTER TABLE "worktrees" ADD CONSTRAINT "worktrees_task_id_tasks_id_fk"
     FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE SET NULL;
 
@@ -228,9 +256,11 @@ ALTER TABLE "template_codespaces" RENAME COLUMN "project_id" TO "codespace_id";
 ALTER TABLE "template_codespaces" DROP CONSTRAINT IF EXISTS "template_projects_template_id_project_id_pk";
 ALTER TABLE "template_codespaces" ADD PRIMARY KEY ("template_id", "codespace_id");
 
--- Re-add FK constraints
+-- Re-add FK constraints (drop first for idempotency)
+ALTER TABLE "template_codespaces" DROP CONSTRAINT IF EXISTS "template_codespaces_template_id_templates_id_fk";
 ALTER TABLE "template_codespaces" ADD CONSTRAINT "template_codespaces_template_id_templates_id_fk"
     FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+ALTER TABLE "template_codespaces" DROP CONSTRAINT IF EXISTS "template_codespaces_codespace_id_codespaces_id_fk";
 ALTER TABLE "template_codespaces" ADD CONSTRAINT "template_codespaces_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
 
@@ -239,6 +269,7 @@ ALTER TABLE "template_codespaces" ADD CONSTRAINT "template_codespaces_codespace_
 -- ============================================================================
 
 ALTER TABLE "templates" RENAME COLUMN "project_id" TO "codespace_id";
+ALTER TABLE "templates" DROP CONSTRAINT IF EXISTS "templates_codespace_id_codespaces_id_fk";
 ALTER TABLE "templates" ADD CONSTRAINT "templates_codespace_id_codespaces_id_fk"
     FOREIGN KEY ("codespace_id") REFERENCES "codespaces"("id") ON DELETE CASCADE;
 

--- a/src/db/migrations-pg/0004_schema_catchup.sql
+++ b/src/db/migrations-pg/0004_schema_catchup.sql
@@ -124,8 +124,19 @@ ALTER TABLE "projects" DROP CONSTRAINT IF EXISTS "projects_path_unique";
 -- 2c. Rename the table
 ALTER TABLE "projects" RENAME TO "codespaces";
 
--- 2d. Add project_folder_id column to codespaces (required FK, default to placeholder)
+-- 2d. Add project_folder_id column to codespaces (nullable first for backfill)
 ALTER TABLE "codespaces" ADD COLUMN IF NOT EXISTS "project_folder_id" text;
+
+-- 2d-i. Create a default project folder for existing codespaces
+INSERT INTO "project_folders" ("id", "name", "slug", "description")
+SELECT 'default_folder', 'Default', 'default', 'Auto-created for existing codespaces'
+WHERE NOT EXISTS (SELECT 1 FROM "project_folders" WHERE "id" = 'default_folder');
+
+-- 2d-ii. Backfill project_folder_id for existing codespaces
+UPDATE "codespaces" SET "project_folder_id" = 'default_folder' WHERE "project_folder_id" IS NULL;
+
+-- 2d-iii. Set NOT NULL constraint to match Drizzle schema
+ALTER TABLE "codespaces" ALTER COLUMN "project_folder_id" SET NOT NULL;
 
 -- 2e. Re-add unique constraint on codespaces.path
 ALTER TABLE "codespaces" ADD CONSTRAINT "codespaces_path_unique" UNIQUE ("path");
@@ -514,5 +525,8 @@ CREATE TABLE IF NOT EXISTS "skill_suggestions" (
     "applied_by" text,
     "created_at" timestamp DEFAULT now() NOT NULL
 );
+
+-- SECTION 11: Add missing indexes from Drizzle schema
+CREATE INDEX IF NOT EXISTS "session_events_created_at_idx" ON "session_events" ("created_at");
 
 COMMIT;

--- a/src/db/migrations-pg/meta/_journal.json
+++ b/src/db/migrations-pg/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770245300000,
       "tag": "0003_nomad_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1774992000000,
+      "tag": "0004_schema_catchup",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/postgres/agent-runs.ts
+++ b/src/db/schema/postgres/agent-runs.ts
@@ -1,32 +1,40 @@
 import { createId } from '@paralleldrive/cuid2';
-import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import type { AgentStatus } from '../shared/enums';
 import { agents } from './agents';
 import { codespaces } from './codespaces';
 import { sessions } from './sessions';
 import { tasks } from './tasks';
 
-export const agentRuns = pgTable('agent_runs', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  agentId: text('agent_id')
-    .notNull()
-    .references(() => agents.id, { onDelete: 'cascade' }),
-  taskId: text('task_id')
-    .notNull()
-    .references(() => tasks.id, { onDelete: 'cascade' }),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  sessionId: text('session_id').references(() => sessions.id, { onDelete: 'set null' }),
-  status: text('status').$type<AgentStatus>().notNull(),
-  startedAt: timestamp('started_at', { mode: 'string' }).defaultNow().notNull(),
-  completedAt: timestamp('completed_at', { mode: 'string' }),
-  turnsUsed: integer('turns_used').default(0),
-  tokensUsed: integer('tokens_used').default(0),
-  errorMessage: text('error_message'),
-});
+export const agentRuns = pgTable(
+  'agent_runs',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    agentId: text('agent_id')
+      .notNull()
+      .references(() => agents.id, { onDelete: 'cascade' }),
+    taskId: text('task_id')
+      .notNull()
+      .references(() => tasks.id, { onDelete: 'cascade' }),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    sessionId: text('session_id').references(() => sessions.id, { onDelete: 'set null' }),
+    status: text('status').$type<AgentStatus>().notNull(),
+    startedAt: timestamp('started_at', { mode: 'string' }).defaultNow().notNull(),
+    completedAt: timestamp('completed_at', { mode: 'string' }),
+    turnsUsed: integer('turns_used').default(0),
+    tokensUsed: integer('tokens_used').default(0),
+    errorMessage: text('error_message'),
+  },
+  (table) => [
+    index('idx_agent_runs_agent_id').on(table.agentId),
+    index('idx_agent_runs_codespace_id').on(table.codespaceId),
+    index('idx_agent_runs_task_id').on(table.taskId),
+  ]
+);
 
 export type AgentRun = typeof agentRuns.$inferSelect;
 export type NewAgentRun = typeof agentRuns.$inferInsert;

--- a/src/db/schema/postgres/agents.ts
+++ b/src/db/schema/postgres/agents.ts
@@ -1,32 +1,36 @@
 import { createId } from '@paralleldrive/cuid2';
-import { integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import type { AgentStatus, AgentType } from '../shared/enums';
 import type { AgentConfig } from '../shared/types';
 import { codespaces } from './codespaces';
 
 export type { AgentConfig };
 
-export const agents = pgTable('agents', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  type: text('type').$type<AgentType>().default('task').notNull(),
-  status: text('status').$type<AgentStatus>().default('idle').notNull(),
-  config: jsonb('config').$type<AgentConfig>(),
-  currentTaskId: text('current_task_id'),
-  currentSessionId: text('current_session_id'),
-  currentTurn: integer('current_turn').default(0),
-  parentAgentId: text('parent_agent_id'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'string' })
-    .defaultNow()
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-});
+export const agents = pgTable(
+  'agents',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    type: text('type').$type<AgentType>().default('task').notNull(),
+    status: text('status').$type<AgentStatus>().default('idle').notNull(),
+    config: jsonb('config').$type<AgentConfig>(),
+    currentTaskId: text('current_task_id'),
+    currentSessionId: text('current_session_id'),
+    currentTurn: integer('current_turn').default(0),
+    parentAgentId: text('parent_agent_id'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+  },
+  (table) => [index('idx_agents_codespace_id').on(table.codespaceId)]
+);
 
 export type Agent = typeof agents.$inferSelect;
 export type NewAgent = typeof agents.$inferInsert;

--- a/src/db/schema/postgres/audit-logs.ts
+++ b/src/db/schema/postgres/audit-logs.ts
@@ -1,28 +1,37 @@
 import { createId } from '@paralleldrive/cuid2';
-import { integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import type { ToolStatus } from '../shared/enums';
 import { agentRuns } from './agent-runs';
 import { agents } from './agents';
 import { codespaces } from './codespaces';
 import { tasks } from './tasks';
 
-export const auditLogs = pgTable('audit_logs', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
-  agentRunId: text('agent_run_id').references(() => agentRuns.id, { onDelete: 'set null' }),
-  taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
-  codespaceId: text('codespace_id').references(() => codespaces.id, { onDelete: 'cascade' }),
-  tool: text('tool').notNull(),
-  status: text('status').$type<ToolStatus>().notNull(),
-  input: jsonb('input'),
-  output: jsonb('output'),
-  errorMessage: text('error_message'),
-  durationMs: integer('duration_ms'),
-  turnNumber: integer('turn_number'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-});
+export const auditLogs = pgTable(
+  'audit_logs',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
+    agentRunId: text('agent_run_id').references(() => agentRuns.id, { onDelete: 'set null' }),
+    taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    codespaceId: text('codespace_id').references(() => codespaces.id, { onDelete: 'cascade' }),
+    tool: text('tool').notNull(),
+    status: text('status').$type<ToolStatus>().notNull(),
+    input: jsonb('input'),
+    output: jsonb('output'),
+    errorMessage: text('error_message'),
+    durationMs: integer('duration_ms'),
+    turnNumber: integer('turn_number'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_audit_logs_agent_id').on(table.agentId),
+    index('idx_audit_logs_codespace_id').on(table.codespaceId),
+    index('idx_audit_logs_task_id').on(table.taskId),
+    index('idx_audit_logs_created_at').on(table.createdAt),
+  ]
+);
 
 export type AuditLog = typeof auditLogs.$inferSelect;
 export type NewAuditLog = typeof auditLogs.$inferInsert;

--- a/src/db/schema/postgres/cli-sessions.ts
+++ b/src/db/schema/postgres/cli-sessions.ts
@@ -27,6 +27,12 @@ export const cliSessions = pgTable(
     lastActivityAt: bigint('last_activity_at', { mode: 'number' }).notNull(),
     isSubagent: boolean('is_subagent').notNull().default(false),
     parentSessionId: text('parent_session_id'),
+    slug: text('slug'),
+    cliVersion: text('cli_version'),
+    permissionMode: text('permission_mode'),
+    topology: text('topology'), // JSON
+    queueOperations: text('queue_operations'), // JSON
+    toolInvocations: text('tool_invocations'), // JSON
     createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { mode: 'string' })
       .defaultNow()

--- a/src/db/schema/postgres/codespaces.ts
+++ b/src/db/schema/postgres/codespaces.ts
@@ -25,7 +25,9 @@ export const codespaces = pgTable('codespaces', {
     onDelete: 'set null',
   }),
   configPath: text('config_path').default('.claude'),
-  sandboxConfigId: text('sandbox_config_id').references(() => sandboxConfigs.id),
+  sandboxConfigId: text('sandbox_config_id').references(() => sandboxConfigs.id, {
+    onDelete: 'set null',
+  }),
   createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { mode: 'string' })
     .defaultNow()

--- a/src/db/schema/postgres/dream-sessions.ts
+++ b/src/db/schema/postgres/dream-sessions.ts
@@ -1,25 +1,32 @@
 import { createId } from '@paralleldrive/cuid2';
-import { doublePrecision, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { doublePrecision, index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { codespaces } from './codespaces';
 
-export const dreamSessions = pgTable('dream_sessions', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id').references(() => codespaces.id, { onDelete: 'cascade' }),
-  type: text('type')
-    .$type<'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup'>()
-    .notNull(),
-  status: text('status').$type<'running' | 'completed' | 'error'>().notNull(),
-  skillsAnalyzed: integer('skills_analyzed').default(0).notNull(),
-  suggestionsGenerated: integer('suggestions_generated').default(0).notNull(),
-  tokensUsed: integer('tokens_used').default(0).notNull(),
-  costUsd: doublePrecision('cost_usd'),
-  startedAt: timestamp('started_at', { mode: 'string' }).defaultNow().notNull(),
-  completedAt: timestamp('completed_at', { mode: 'string' }),
-  errorMessage: text('error_message'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-});
+export const dreamSessions = pgTable(
+  'dream_sessions',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id').references(() => codespaces.id, { onDelete: 'cascade' }),
+    type: text('type')
+      .$type<'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup'>()
+      .notNull(),
+    status: text('status').$type<'running' | 'completed' | 'error'>().notNull(),
+    skillsAnalyzed: integer('skills_analyzed').default(0).notNull(),
+    suggestionsGenerated: integer('suggestions_generated').default(0).notNull(),
+    tokensUsed: integer('tokens_used').default(0).notNull(),
+    costUsd: doublePrecision('cost_usd'),
+    startedAt: timestamp('started_at', { mode: 'string' }).defaultNow().notNull(),
+    completedAt: timestamp('completed_at', { mode: 'string' }),
+    errorMessage: text('error_message'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_dream_sessions_codespace_id').on(table.codespaceId),
+    index('idx_dream_sessions_status').on(table.status),
+  ]
+);
 
 export type DreamSession = typeof dreamSessions.$inferSelect;
 export type NewDreamSession = typeof dreamSessions.$inferInsert;

--- a/src/db/schema/postgres/github.ts
+++ b/src/db/schema/postgres/github.ts
@@ -11,6 +11,7 @@ export const githubTokens = pgTable('github_tokens', {
   scopes: text('scopes'),
   githubLogin: text('github_login'),
   githubId: text('github_id'),
+  teamId: text('team_id').references(() => teams.id, { onDelete: 'set null' }),
   isValid: boolean('is_valid').default(true),
   lastValidatedAt: timestamp('last_validated_at', { mode: 'string' }),
   createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),

--- a/src/db/schema/postgres/memory-insights.ts
+++ b/src/db/schema/postgres/memory-insights.ts
@@ -1,25 +1,33 @@
 import { createId } from '@paralleldrive/cuid2';
-import { jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { codespaces } from './codespaces';
 import { sessions } from './sessions';
 
-export const memoryInsights = pgTable('memory_insights', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  content: text('content').notNull(),
-  source: text('source').$type<'agent_derived' | 'manual' | 'dream'>().notNull(),
-  sourceSessionId: text('source_session_id').references(() => sessions.id, {
-    onDelete: 'set null',
-  }),
-  skillId: text('skill_id'),
-  tags: jsonb('tags').$type<string[]>().default([]),
-  metadata: jsonb('metadata').$type<Record<string, unknown>>(),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-});
+export const memoryInsights = pgTable(
+  'memory_insights',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    content: text('content').notNull(),
+    source: text('source').$type<'agent_derived' | 'manual' | 'dream'>().notNull(),
+    sourceSessionId: text('source_session_id').references(() => sessions.id, {
+      onDelete: 'set null',
+    }),
+    skillId: text('skill_id'),
+    tags: jsonb('tags').$type<string[]>().default([]),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_memory_insights_codespace_id').on(table.codespaceId),
+    index('idx_memory_insights_skill_id').on(table.skillId),
+    index('idx_memory_insights_source_session_id').on(table.sourceSessionId),
+  ]
+);
 
 export type MemoryInsight = typeof memoryInsights.$inferSelect;
 export type NewMemoryInsight = typeof memoryInsights.$inferInsert;

--- a/src/db/schema/postgres/memory-messages.ts
+++ b/src/db/schema/postgres/memory-messages.ts
@@ -1,24 +1,32 @@
 import { createId } from '@paralleldrive/cuid2';
-import { integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { codespaces } from './codespaces';
 import { tasks } from './tasks';
 
-export const memoryMessages = pgTable('memory_messages', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  memorySessionId: text('memory_session_id').notNull(),
-  agentId: text('agent_id').notNull(),
-  taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
-  role: text('role').$type<'user' | 'assistant'>().notNull(),
-  content: text('content').notNull(),
-  turnNumber: integer('turn_number').notNull(),
-  metadata: jsonb('metadata').$type<Record<string, unknown>>(),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-});
+export const memoryMessages = pgTable(
+  'memory_messages',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    memorySessionId: text('memory_session_id').notNull(),
+    agentId: text('agent_id').notNull(),
+    taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    role: text('role').$type<'user' | 'assistant'>().notNull(),
+    content: text('content').notNull(),
+    turnNumber: integer('turn_number').notNull(),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_memory_messages_codespace_id').on(table.codespaceId),
+    index('idx_memory_messages_memory_session_id').on(table.memorySessionId),
+    index('idx_memory_messages_task_id').on(table.taskId),
+  ]
+);
 
 export type MemoryMessage = typeof memoryMessages.$inferSelect;
 export type NewMemoryMessage = typeof memoryMessages.$inferInsert;

--- a/src/db/schema/postgres/session-events.ts
+++ b/src/db/schema/postgres/session-events.ts
@@ -30,7 +30,7 @@ export const sessionEvents = pgTable(
   },
   (table) => [
     index('session_events_session_idx').on(table.sessionId),
-    index('session_events_offset_idx').on(table.sessionId, table.offset),
+    // DB-008: Removed redundant session_events_offset_idx — covered by unique_offset below
     uniqueIndex('session_events_unique_offset').on(table.sessionId, table.offset),
     index('session_events_created_at_idx').on(table.createdAt),
   ]

--- a/src/db/schema/postgres/sessions.ts
+++ b/src/db/schema/postgres/sessions.ts
@@ -1,32 +1,36 @@
 import { createId } from '@paralleldrive/cuid2';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import type { SessionStatus } from '../shared/enums';
 import { agents } from './agents';
 import { codespaces } from './codespaces';
 import { tasks } from './tasks';
 
-export const sessions = pgTable('sessions', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  taskId: text('task_id').references((): AnyPgColumn => tasks.id, { onDelete: 'set null' }),
-  agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
-  status: text('status').$type<SessionStatus>().default('idle').notNull(),
-  title: text('title'),
-  url: text('url').notNull(),
-  sandboxProvider: text('sandbox_provider'),
-  sandboxContainerId: text('sandbox_container_id'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'string' })
-    .defaultNow()
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-  closedAt: timestamp('closed_at', { mode: 'string' }),
-});
+export const sessions = pgTable(
+  'sessions',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    taskId: text('task_id').references((): AnyPgColumn => tasks.id, { onDelete: 'set null' }),
+    agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
+    status: text('status').$type<SessionStatus>().default('idle').notNull(),
+    title: text('title'),
+    url: text('url').notNull(),
+    sandboxProvider: text('sandbox_provider'),
+    sandboxContainerId: text('sandbox_container_id'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+    closedAt: timestamp('closed_at', { mode: 'string' }),
+  },
+  (table) => [index('idx_sessions_codespace_id').on(table.codespaceId)]
+);
 
 export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;

--- a/src/db/schema/postgres/skill-executions.ts
+++ b/src/db/schema/postgres/skill-executions.ts
@@ -1,35 +1,44 @@
 import { createId } from '@paralleldrive/cuid2';
-import { doublePrecision, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { doublePrecision, index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { agentRuns } from './agent-runs';
 import { codespaces } from './codespaces';
 import { sessions } from './sessions';
 import { tasks } from './tasks';
 
-export const skillExecutions = pgTable('skill_executions', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  skillId: text('skill_id').notNull(),
-  skillName: text('skill_name'),
-  taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
-  agentRunId: text('agent_run_id').references(() => agentRuns.id, { onDelete: 'set null' }),
-  sessionId: text('session_id').references(() => sessions.id, { onDelete: 'set null' }),
-  status: text('status').$type<'success' | 'failed' | 'cancelled' | 'turn_limit'>().notNull(),
-  turnsUsed: integer('turns_used'),
-  tokensUsed: integer('tokens_used'),
-  durationMs: integer('duration_ms'),
-  filesModified: integer('files_modified'),
-  linesAdded: integer('lines_added'),
-  linesRemoved: integer('lines_removed'),
-  costUsd: doublePrecision('cost_usd'),
-  errorMessage: text('error_message'),
-  startedAt: timestamp('started_at', { mode: 'string' }),
-  completedAt: timestamp('completed_at', { mode: 'string' }),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-});
+export const skillExecutions = pgTable(
+  'skill_executions',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    skillId: text('skill_id').notNull(),
+    skillName: text('skill_name'),
+    taskId: text('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+    agentRunId: text('agent_run_id').references(() => agentRuns.id, { onDelete: 'set null' }),
+    sessionId: text('session_id').references(() => sessions.id, { onDelete: 'set null' }),
+    status: text('status').$type<'success' | 'failed' | 'cancelled' | 'turn_limit'>().notNull(),
+    turnsUsed: integer('turns_used'),
+    tokensUsed: integer('tokens_used'),
+    durationMs: integer('duration_ms'),
+    filesModified: integer('files_modified'),
+    linesAdded: integer('lines_added'),
+    linesRemoved: integer('lines_removed'),
+    costUsd: doublePrecision('cost_usd'),
+    errorMessage: text('error_message'),
+    startedAt: timestamp('started_at', { mode: 'string' }),
+    completedAt: timestamp('completed_at', { mode: 'string' }),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_skill_executions_codespace_id').on(table.codespaceId),
+    index('idx_skill_executions_skill_id').on(table.skillId),
+    index('idx_skill_executions_task_id').on(table.taskId),
+    index('idx_skill_executions_agent_run_id').on(table.agentRunId),
+  ]
+);
 
 export type SkillExecution = typeof skillExecutions.$inferSelect;
 export type NewSkillExecution = typeof skillExecutions.$inferInsert;

--- a/src/db/schema/postgres/skill-suggestions.ts
+++ b/src/db/schema/postgres/skill-suggestions.ts
@@ -1,37 +1,46 @@
 import { createId } from '@paralleldrive/cuid2';
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { codespaces } from './codespaces';
 import { dreamSessions } from './dream-sessions';
 
-export const skillSuggestions = pgTable('skill_suggestions', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  dreamSessionId: text('dream_session_id')
-    .notNull()
-    .references(() => dreamSessions.id, { onDelete: 'cascade' }),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  skillId: text('skill_id').notNull(),
-  skillName: text('skill_name').notNull(),
-  suggestionType: text('suggestion_type')
-    .$type<'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill'>()
-    .notNull(),
-  title: text('title').notNull(),
-  reasoning: text('reasoning').notNull(),
-  currentContent: text('current_content'),
-  suggestedContent: text('suggested_content').notNull(),
-  diff: text('diff'),
-  status: text('status')
-    .$type<'pending' | 'accepted' | 'rejected' | 'modified'>()
-    .default('pending')
-    .notNull(),
-  userNotes: text('user_notes'),
-  appliedAt: timestamp('applied_at', { mode: 'string' }),
-  appliedBy: text('applied_by'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-});
+export const skillSuggestions = pgTable(
+  'skill_suggestions',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    dreamSessionId: text('dream_session_id')
+      .notNull()
+      .references(() => dreamSessions.id, { onDelete: 'cascade' }),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    skillId: text('skill_id').notNull(),
+    skillName: text('skill_name').notNull(),
+    suggestionType: text('suggestion_type')
+      .$type<'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill'>()
+      .notNull(),
+    title: text('title').notNull(),
+    reasoning: text('reasoning').notNull(),
+    currentContent: text('current_content'),
+    suggestedContent: text('suggested_content').notNull(),
+    diff: text('diff'),
+    status: text('status')
+      .$type<'pending' | 'accepted' | 'rejected' | 'modified'>()
+      .default('pending')
+      .notNull(),
+    userNotes: text('user_notes'),
+    appliedAt: timestamp('applied_at', { mode: 'string' }),
+    appliedBy: text('applied_by'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_skill_suggestions_dream_session_id').on(table.dreamSessionId),
+    index('idx_skill_suggestions_codespace_id').on(table.codespaceId),
+    index('idx_skill_suggestions_skill_id').on(table.skillId),
+    index('idx_skill_suggestions_status').on(table.status),
+  ]
+);
 
 export type SkillSuggestion = typeof skillSuggestions.$inferSelect;
 export type NewSkillSuggestion = typeof skillSuggestions.$inferInsert;

--- a/src/db/schema/postgres/tasks.ts
+++ b/src/db/schema/postgres/tasks.ts
@@ -1,6 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
-import { integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import type { ExitPlanModeOptions } from '../../../lib/agents/stream-handler';
 import type { DiffSummary } from '../../../lib/types/diff';
 
@@ -18,50 +18,57 @@ import { codespaces } from './codespaces';
 import { sessions } from './sessions';
 import { worktrees } from './worktrees';
 
-export const tasks = pgTable('tasks', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
-  sessionId: text('session_id').references((): AnyPgColumn => sessions.id, {
-    onDelete: 'set null',
-  }),
-  worktreeId: text('worktree_id').references((): AnyPgColumn => worktrees.id, {
-    onDelete: 'set null',
-  }),
-  title: text('title').notNull(),
-  description: text('description'),
-  column: text('column').$type<TaskColumn>().default('backlog').notNull(),
-  position: integer('position').default(0).notNull(),
-  labels: jsonb('labels').$type<string[]>().default([]),
-  priority: text('priority').$type<TaskPriority>().default('medium'),
-  branch: text('branch'),
-  diffSummary: jsonb('diff_summary').$type<DiffSummary>(),
-  approvedAt: timestamp('approved_at', { mode: 'string' }),
-  approvedBy: text('approved_by'),
-  rejectionCount: integer('rejection_count').default(0),
-  rejectionReason: text('rejection_reason'),
-  modelOverride: text('model_override'),
-  /** Skill directory name (e.g., 'terraform-stacks') — maps to .claude/skills/{skillId}/SKILL.md */
-  skillId: text('skill_id'),
-  /** Denormalized skill display name for UI rendering */
-  skillName: text('skill_name'),
-  planOptions: jsonb('plan_options').$type<StoredPlanOptions>(),
-  plan: text('plan'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'string' })
-    .defaultNow()
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-  startedAt: timestamp('started_at', { mode: 'string' }),
-  completedAt: timestamp('completed_at', { mode: 'string' }),
-  lastAgentStatus: text('last_agent_status').$type<
-    'completed' | 'cancelled' | 'error' | 'turn_limit' | 'planning'
-  >(),
-});
+export const tasks = pgTable(
+  'tasks',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
+    sessionId: text('session_id').references((): AnyPgColumn => sessions.id, {
+      onDelete: 'set null',
+    }),
+    worktreeId: text('worktree_id').references((): AnyPgColumn => worktrees.id, {
+      onDelete: 'set null',
+    }),
+    title: text('title').notNull(),
+    description: text('description'),
+    column: text('column').$type<TaskColumn>().default('backlog').notNull(),
+    position: integer('position').default(0).notNull(),
+    labels: jsonb('labels').$type<string[]>().default([]),
+    priority: text('priority').$type<TaskPriority>().default('medium'),
+    branch: text('branch'),
+    diffSummary: jsonb('diff_summary').$type<DiffSummary>(),
+    approvedAt: timestamp('approved_at', { mode: 'string' }),
+    approvedBy: text('approved_by'),
+    rejectionCount: integer('rejection_count').default(0),
+    rejectionReason: text('rejection_reason'),
+    modelOverride: text('model_override'),
+    /** Skill directory name (e.g., 'terraform-stacks') — maps to .claude/skills/{skillId}/SKILL.md */
+    skillId: text('skill_id'),
+    /** Denormalized skill display name for UI rendering */
+    skillName: text('skill_name'),
+    planOptions: jsonb('plan_options').$type<StoredPlanOptions>(),
+    plan: text('plan'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+    startedAt: timestamp('started_at', { mode: 'string' }),
+    completedAt: timestamp('completed_at', { mode: 'string' }),
+    lastAgentStatus: text('last_agent_status').$type<
+      'completed' | 'cancelled' | 'error' | 'turn_limit' | 'planning'
+    >(),
+  },
+  (table) => [
+    index('idx_tasks_agent_id').on(table.agentId),
+    index('idx_tasks_kanban').on(table.codespaceId, table.column, table.position),
+  ]
+);
 
 export type Task = typeof tasks.$inferSelect;
 export type NewTask = typeof tasks.$inferInsert;

--- a/src/db/schema/postgres/worktrees.ts
+++ b/src/db/schema/postgres/worktrees.ts
@@ -1,6 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import type { WorktreeStatus } from '../shared/enums';
 
 export type { WorktreeStatus } from '../shared/enums';
@@ -9,27 +9,31 @@ import { agents } from './agents';
 import { codespaces } from './codespaces';
 import { tasks } from './tasks';
 
-export const worktrees = pgTable('worktrees', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  agentId: text('agent_id').references((): AnyPgColumn => agents.id, { onDelete: 'set null' }),
-  taskId: text('task_id').references((): AnyPgColumn => tasks.id, { onDelete: 'set null' }),
-  branch: text('branch').notNull(),
-  path: text('path').notNull(),
-  baseBranch: text('base_branch').default('main').notNull(),
-  status: text('status').$type<WorktreeStatus>().default('creating').notNull(),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'string' })
-    .defaultNow()
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-  mergedAt: timestamp('merged_at', { mode: 'string' }),
-  removedAt: timestamp('removed_at', { mode: 'string' }),
-});
+export const worktrees = pgTable(
+  'worktrees',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    agentId: text('agent_id').references((): AnyPgColumn => agents.id, { onDelete: 'set null' }),
+    taskId: text('task_id').references((): AnyPgColumn => tasks.id, { onDelete: 'set null' }),
+    branch: text('branch').notNull(),
+    path: text('path').notNull(),
+    baseBranch: text('base_branch').default('main').notNull(),
+    status: text('status').$type<WorktreeStatus>().default('creating').notNull(),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+    mergedAt: timestamp('merged_at', { mode: 'string' }),
+    removedAt: timestamp('removed_at', { mode: 'string' }),
+  },
+  (table) => [index('idx_worktrees_codespace_id').on(table.codespaceId)]
+);
 
 export type Worktree = typeof worktrees.$inferSelect;
 export type NewWorktree = typeof worktrees.$inferInsert;

--- a/src/db/schema/sqlite/codespaces.ts
+++ b/src/db/schema/sqlite/codespaces.ts
@@ -27,7 +27,9 @@ export const codespaces = sqliteTable('codespaces', {
     onDelete: 'set null',
   }),
   configPath: text('config_path').default('.claude'),
-  sandboxConfigId: text('sandbox_config_id').references(() => sandboxConfigs.id),
+  sandboxConfigId: text('sandbox_config_id').references(() => sandboxConfigs.id, {
+    onDelete: 'set null',
+  }),
   createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
   updatedAt: text('updated_at')
     .default(sql`(datetime('now'))`)

--- a/src/db/schema/sqlite/terraform.ts
+++ b/src/db/schema/sqlite/terraform.ts
@@ -1,6 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import { sql } from 'drizzle-orm';
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 export const TERRAFORM_REGISTRY_STATUSES = ['active', 'syncing', 'error'] as const;
 export type TerraformRegistryStatus = (typeof TERRAFORM_REGISTRY_STATUSES)[number];
@@ -39,30 +39,38 @@ export const terraformRegistries = sqliteTable('terraform_registries', {
     .$onUpdate(() => new Date().toISOString()),
 });
 
-export const terraformModules = sqliteTable('terraform_modules', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  registryId: text('registry_id')
-    .notNull()
-    .references(() => terraformRegistries.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  namespace: text('namespace').notNull(),
-  provider: text('provider').notNull(),
-  version: text('version').notNull(),
-  source: text('source').notNull(),
-  description: text('description'),
-  readme: text('readme'),
-  inputs: text('inputs', { mode: 'json' }).$type<TerraformVariable[]>(),
-  outputs: text('outputs', { mode: 'json' }).$type<TerraformOutput[]>(),
-  dependencies: text('dependencies', { mode: 'json' }).$type<string[]>(),
-  publishedAt: text('published_at'),
-  createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
-  updatedAt: text('updated_at')
-    .default(sql`(datetime('now'))`)
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-});
+export const terraformModules = sqliteTable(
+  'terraform_modules',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    registryId: text('registry_id')
+      .notNull()
+      .references(() => terraformRegistries.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    namespace: text('namespace').notNull(),
+    provider: text('provider').notNull(),
+    version: text('version').notNull(),
+    source: text('source').notNull(),
+    description: text('description'),
+    readme: text('readme'),
+    inputs: text('inputs', { mode: 'json' }).$type<TerraformVariable[]>(),
+    outputs: text('outputs', { mode: 'json' }).$type<TerraformOutput[]>(),
+    dependencies: text('dependencies', { mode: 'json' }).$type<string[]>(),
+    publishedAt: text('published_at'),
+    createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
+    updatedAt: text('updated_at')
+      .default(sql`(datetime('now'))`)
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+  },
+  (table) => [
+    index('idx_tf_modules_registry').on(table.registryId),
+    index('idx_tf_modules_provider').on(table.provider),
+    index('idx_tf_modules_name').on(table.name),
+  ]
+);
 
 export type TerraformRegistry = typeof terraformRegistries.$inferSelect;
 export type NewTerraformRegistry = typeof terraformRegistries.$inferInsert;

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -157,4 +157,105 @@ export const MIGRATIONS: Migration[] = [
       `ALTER TABLE event_sources ADD COLUMN github_installation_id TEXT REFERENCES github_installations(id) ON DELETE SET NULL`,
     ],
   },
+
+  // 24. Fix missing onDelete on codespaces.sandboxConfigId — recreate FK with SET NULL
+  // SQLite does not support ALTER TABLE ... ALTER CONSTRAINT, so this is a schema-level fix
+  // that takes effect on new databases. Existing databases will continue to work (the FK
+  // constraint just defaults to NO ACTION). The Drizzle schema now specifies onDelete: 'set null'.
+  {
+    version: 24,
+    name: 'sandbox-config-fk-on-delete',
+    sql: `-- Schema-level fix: onDelete 'set null' is now defined in Drizzle schema.
+-- For existing databases, the FK behavior defaults to NO ACTION which is safe.
+-- A full table rebuild would be needed to change FK behavior in SQLite,
+-- which is not worth the risk for an existing production database.
+SELECT 1;`,
+  },
+
+  // 25. Add CHECK constraints for critical enum columns on new databases.
+  // Uses CREATE TABLE IF NOT EXISTS with CHECK constraints for validation tables,
+  // then creates triggers to validate enum values on INSERT/UPDATE.
+  {
+    version: 25,
+    name: 'enum-check-triggers',
+    sql: `
+-- Trigger-based enum validation for critical columns.
+-- SQLite does not support ALTER TABLE ADD CONSTRAINT, so we use BEFORE triggers.
+
+-- tasks.column validation
+CREATE TRIGGER IF NOT EXISTS trg_tasks_column_insert
+BEFORE INSERT ON tasks
+WHEN NEW."column" NOT IN ('backlog', 'queued', 'in_progress', 'waiting_approval', 'verified')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid task column value');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_tasks_column_update
+BEFORE UPDATE OF "column" ON tasks
+WHEN NEW."column" NOT IN ('backlog', 'queued', 'in_progress', 'waiting_approval', 'verified')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid task column value');
+END;
+
+-- agents.status validation
+CREATE TRIGGER IF NOT EXISTS trg_agents_status_insert
+BEFORE INSERT ON agents
+WHEN NEW.status NOT IN ('idle', 'starting', 'planning', 'running', 'paused', 'error', 'completed')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid agent status value');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_agents_status_update
+BEFORE UPDATE OF status ON agents
+WHEN NEW.status NOT IN ('idle', 'starting', 'planning', 'running', 'paused', 'error', 'completed')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid agent status value');
+END;
+
+-- worktrees.status validation
+CREATE TRIGGER IF NOT EXISTS trg_worktrees_status_insert
+BEFORE INSERT ON worktrees
+WHEN NEW.status NOT IN ('creating', 'active', 'merging', 'removing', 'removed', 'error')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid worktree status value');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_worktrees_status_update
+BEFORE UPDATE OF status ON worktrees
+WHEN NEW.status NOT IN ('creating', 'active', 'merging', 'removing', 'removed', 'error')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid worktree status value');
+END;
+
+-- agents.type validation
+CREATE TRIGGER IF NOT EXISTS trg_agents_type_insert
+BEFORE INSERT ON agents
+WHEN NEW.type NOT IN ('task', 'conversational', 'background')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid agent type value');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_agents_type_update
+BEFORE UPDATE OF type ON agents
+WHEN NEW.type NOT IN ('task', 'conversational', 'background')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid agent type value');
+END;
+
+-- tasks.priority validation (nullable, so allow NULL)
+CREATE TRIGGER IF NOT EXISTS trg_tasks_priority_insert
+BEFORE INSERT ON tasks
+WHEN NEW.priority IS NOT NULL AND NEW.priority NOT IN ('high', 'medium', 'low')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid task priority value');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_tasks_priority_update
+BEFORE UPDATE OF priority ON tasks
+WHEN NEW.priority IS NOT NULL AND NEW.priority NOT IN ('high', 'medium', 'low')
+BEGIN
+  SELECT RAISE(ABORT, 'Invalid task priority value');
+END;
+`,
+  },
 ];

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -23,18 +23,19 @@ import {
 /**
  * A single migration step in the ordered migration sequence.
  *
- * - `sql`: SQL string to execute via db.exec()
+ * Exactly one of `sql` or `statements` must be provided:
+ * - `sql`: SQL string to execute via db.exec() (multi-statement blocks)
  * - `statements`: Array of individual SQL strings, each executed separately
  *                 with try/catch for ALTER TABLE idempotency
- *
- * Exactly one of `sql` or `statements` must be provided.
  */
-export interface Migration {
+interface MigrationBase {
   version: number;
   name: string;
-  sql?: string;
-  statements?: string[];
 }
+
+export type Migration =
+  | (MigrationBase & { sql: string; statements?: never })
+  | (MigrationBase & { statements: string[]; sql?: never });
 
 /**
  * Ordered list of all SQLite migrations.

--- a/src/lib/bootstrap/migrations/runner.ts
+++ b/src/lib/bootstrap/migrations/runner.ts
@@ -86,8 +86,18 @@ export function runMigrations(db: RawSQLiteDatabase, migrations: Migration[]): v
   const recordMigration = db.prepare('INSERT INTO schema_migrations (version, name) VALUES (?, ?)');
 
   for (const migration of pending) {
-    applyMigration(db, migration);
-    recordMigration.run(migration.version, migration.name);
-    log.info(`Applied migration v${migration.version}: ${migration.name}`);
+    db.prepare('BEGIN').run();
+    try {
+      applyMigration(db, migration);
+      recordMigration.run(migration.version, migration.name);
+      db.prepare('COMMIT').run();
+      log.info(`Applied migration v${migration.version}: ${migration.name}`);
+    } catch (e) {
+      db.prepare('ROLLBACK').run();
+      log.error(`Migration v${migration.version} (${migration.name}) failed, rolled back`, {
+        data: { error: e instanceof Error ? e.message : String(e) },
+      });
+      throw e;
+    }
   }
 }

--- a/src/lib/bootstrap/migrations/runner.ts
+++ b/src/lib/bootstrap/migrations/runner.ts
@@ -40,8 +40,9 @@ function applyMigration(db: RawSQLiteDatabase, migration: Migration): void {
         db.prepare(stmt).run();
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
+        // Duplicate column errors are expected on re-runs (idempotency)
         if (!msg.includes('duplicate column')) {
-          log.warn(`Migration v${migration.version} (${migration.name}) statement note: ${msg}`);
+          throw e;
         }
       }
     }

--- a/src/lib/bootstrap/migrations/runner.ts
+++ b/src/lib/bootstrap/migrations/runner.ts
@@ -49,7 +49,7 @@ function applyMigration(db: RawSQLiteDatabase, migration: Migration): void {
   } else if (migration.sql) {
     try {
       // Use exec for multi-statement SQL blocks (CREATE TABLE, CREATE INDEX, etc.)
-      (db as RawSQLiteDatabase & { exec: (sql: string) => void }).exec(migration.sql);
+      db.exec(migration.sql);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       // ALTER TABLE migrations may fail with "duplicate column" on re-runs

--- a/src/lib/bootstrap/phases/schema.ts
+++ b/src/lib/bootstrap/phases/schema.ts
@@ -836,6 +836,7 @@ export interface RawSQLiteDatabase {
     all(...params: unknown[]): unknown[];
     run(...params: unknown[]): unknown;
   };
+  exec(sql: string): void;
 }
 
 /**

--- a/src/services/__tests__/event-cleanup.service.test.ts
+++ b/src/services/__tests__/event-cleanup.service.test.ts
@@ -88,10 +88,11 @@ describe('EventCleanupService', () => {
     const service = new EventCleanupService(db as never, settings as never);
 
     // Should not throw
-    await expect(service.runCleanup()).resolves.toEqual({
-      sessionEventsDeleted: 0,
-      eventLogDeleted: 0,
-    });
+    const result = await service.runCleanup();
+    expect(result.sessionEventsDeleted).toBe(0);
+    expect(result.eventLogDeleted).toBe(0);
+    expect(result.backup).toBeDefined();
+    expect(result.backup.skipped).toBe(true);
   });
 
   it('batch-processes when more than BATCH_SIZE rows exist', async () => {

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -412,6 +412,12 @@ export class AgentExecutionService {
             data: { worktreeId: worktree.value.id, agentId },
           });
         });
+      await this.sessionService.delete(session.value.id).catch((cleanupErr) => {
+        log.error('Failed to clean up orphaned session after transaction failure', {
+          error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          data: { sessionId: session.value.id, agentId },
+        });
+      });
       return err(AgentErrors.EXECUTION_ERROR('Failed to start agent: transaction error'));
     }
 

--- a/src/services/agent/types.ts
+++ b/src/services/agent/types.ts
@@ -73,6 +73,7 @@ export type SessionServiceInterface = {
     agentId?: string;
     title?: string;
   }) => Promise<Result<SessionWithPresence, unknown>>;
+  delete: (id: string) => Promise<Result<{ deleted: boolean }, unknown>>;
   publish: (sessionId: string, event: SessionEvent) => Promise<Result<{ offset: number }, unknown>>;
 };
 

--- a/src/services/event-cleanup.service.ts
+++ b/src/services/event-cleanup.service.ts
@@ -5,7 +5,13 @@
  * and event_log tables to bound storage growth. Retention periods are
  * configurable via admin settings (retention.sessionEventsDays,
  * retention.eventLogDays) and take effect without restart.
+ *
+ * Also performs automated SQLite database backups alongside cleanup cycles.
+ * Backup behavior is configurable via admin settings (backup.enabled,
+ * backup.intervalHours, backup.maxBackups).
  */
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
 import { sql } from 'drizzle-orm';
 import { createLogger } from '../lib/logging/logger.js';
 import type { Database } from '../types/database.js';
@@ -28,11 +34,36 @@ const INITIAL_DELAY_MS = 60 * 1000;
 /** Number of rows to delete per batch to avoid long-held locks */
 const BATCH_SIZE = 1000;
 
+/** Default: backups are enabled */
+const DEFAULT_BACKUP_ENABLED = true;
+
+/** Default: backup every 24 hours (runs every cleanup cycle) */
+const DEFAULT_BACKUP_INTERVAL_HOURS = 24;
+
+/** Default: keep 7 most recent backups */
+const DEFAULT_BACKUP_MAX_BACKUPS = 7;
+
+/** Default database path */
+const DEFAULT_DB_PATH = './data/agentpane.db';
+
+/** Default backup directory */
+const DEFAULT_BACKUP_DIR = './data/backups';
+
+export interface BackupResult {
+  performed: boolean;
+  skipped: boolean;
+  reason?: string;
+  backupPath?: string;
+  integrityOk?: boolean;
+  oldBackupsRemoved?: number;
+}
+
 export class EventCleanupService {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private initialTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private isRunning = false;
   private lastRunAt: string | null = null;
+  private lastBackupAt: string | null = null;
 
   constructor(
     private db: Database,
@@ -90,11 +121,174 @@ export class EventCleanupService {
   }
 
   /**
+   * Read a boolean or numeric backup setting, falling back to the provided default.
+   */
+  private async getBackupSetting<T extends boolean | number>(
+    key: string,
+    defaultValue: T
+  ): Promise<T> {
+    try {
+      const result = await this.settingsService.get(key);
+      if (result.ok && result.value) {
+        const parsed = JSON.parse(result.value.value);
+        if (typeof parsed === typeof defaultValue) {
+          return parsed as T;
+        }
+      }
+    } catch (err) {
+      log.warn('Failed to read backup setting, using default', {
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+    return defaultValue;
+  }
+
+  /**
+   * Run an automated SQLite database backup.
+   *
+   * Steps:
+   * 1. Check if backup is enabled via settings
+   * 2. Check if enough time has elapsed since last backup
+   * 3. Run PRAGMA integrity_check
+   * 4. Run PRAGMA wal_checkpoint(TRUNCATE)
+   * 5. Copy the DB file with a timestamp suffix
+   * 6. Clean up old backups beyond maxBackups
+   */
+  async runBackup(): Promise<BackupResult> {
+    const enabled = await this.getBackupSetting('backup.enabled', DEFAULT_BACKUP_ENABLED);
+    if (!enabled) {
+      return { performed: false, skipped: true, reason: 'Backup disabled via settings' };
+    }
+
+    const intervalHours = await this.getBackupSetting(
+      'backup.intervalHours',
+      DEFAULT_BACKUP_INTERVAL_HOURS
+    );
+    const maxBackups = await this.getBackupSetting('backup.maxBackups', DEFAULT_BACKUP_MAX_BACKUPS);
+
+    // Check if enough time has elapsed since the last backup
+    if (this.lastBackupAt) {
+      const elapsedMs = Date.now() - new Date(this.lastBackupAt).getTime();
+      const intervalMs = intervalHours * 60 * 60 * 1000;
+      if (elapsedMs < intervalMs) {
+        return {
+          performed: false,
+          skipped: true,
+          reason: `Only ${Math.round(elapsedMs / 60000)}m since last backup (interval: ${intervalHours}h)`,
+        };
+      }
+    }
+
+    const dbPath = resolve(process.env.DB_PATH || DEFAULT_DB_PATH);
+    const backupDir = resolve(
+      dirname(dbPath),
+      basename(DEFAULT_BACKUP_DIR) === 'backups' ? 'backups' : DEFAULT_BACKUP_DIR
+    );
+
+    if (!existsSync(dbPath)) {
+      return { performed: false, skipped: true, reason: `DB file not found: ${dbPath}` };
+    }
+
+    // Ensure backup directory exists
+    if (!existsSync(backupDir)) {
+      mkdirSync(backupDir, { recursive: true });
+    }
+
+    // Run integrity check
+    let integrityOk = false;
+    try {
+      this.db.run(sql`PRAGMA integrity_check`);
+      // integrity_check returns 'ok' on success; if it doesn't throw, the check passed
+      integrityOk = true;
+      log.info('Database integrity check passed');
+    } catch (err) {
+      log.error('Database integrity check failed', {
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+      return {
+        performed: false,
+        skipped: false,
+        reason: 'Integrity check failed',
+        integrityOk: false,
+      };
+    }
+
+    // WAL checkpoint to flush pending writes
+    try {
+      this.db.run(sql`PRAGMA wal_checkpoint(TRUNCATE)`);
+      log.info('WAL checkpoint completed');
+    } catch (err) {
+      log.warn('WAL checkpoint failed, proceeding with backup anyway', {
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+
+    // Copy DB file with timestamp
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupFileName = `agentpane_${timestamp}.db`;
+    const backupPath = join(backupDir, backupFileName);
+
+    try {
+      copyFileSync(dbPath, backupPath);
+      log.info('Database backup created', { data: { backupPath } });
+    } catch (err) {
+      log.error('Failed to copy database file', {
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { dbPath, backupPath },
+      });
+      return {
+        performed: false,
+        skipped: false,
+        reason: 'File copy failed',
+        integrityOk,
+      };
+    }
+
+    // Clean up old backups
+    let oldBackupsRemoved = 0;
+    try {
+      const backupFiles = readdirSync(backupDir)
+        .filter((f) => f.startsWith('agentpane_') && f.endsWith('.db'))
+        .map((f) => ({
+          name: f,
+          path: join(backupDir, f),
+          mtime: statSync(join(backupDir, f)).mtimeMs,
+        }))
+        .sort((a, b) => b.mtime - a.mtime); // newest first
+
+      if (backupFiles.length > maxBackups) {
+        const toRemove = backupFiles.slice(maxBackups);
+        for (const file of toRemove) {
+          unlinkSync(file.path);
+          oldBackupsRemoved++;
+        }
+        log.info(`Removed ${oldBackupsRemoved} old backup(s)`);
+      }
+    } catch (err) {
+      log.warn('Failed to clean up old backups', {
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+
+    this.lastBackupAt = new Date().toISOString();
+
+    return {
+      performed: true,
+      skipped: false,
+      backupPath,
+      integrityOk,
+      oldBackupsRemoved,
+    };
+  }
+
+  /**
    * Run a single cleanup cycle: read config, compute cutoffs, batch-delete.
+   * Also runs a database backup at the end of each cycle.
    */
   async runCleanup(): Promise<{
     sessionEventsDeleted: number;
     eventLogDeleted: number;
+    backup: BackupResult;
   }> {
     const sessionEventsDays = await this.getRetentionDays(
       'retention.sessionEventsDays',
@@ -141,7 +335,17 @@ export class EventCleanupService {
       log.info('Event cleanup completed — no rows to delete');
     }
 
-    return { sessionEventsDeleted, eventLogDeleted };
+    // Run database backup after cleanup
+    const backup = await this.runBackup();
+    if (backup.performed) {
+      log.info('Database backup completed after cleanup', {
+        data: { backupPath: backup.backupPath, oldBackupsRemoved: backup.oldBackupsRemoved },
+      });
+    } else if (backup.skipped) {
+      log.info('Database backup skipped', { data: { reason: backup.reason } });
+    }
+
+    return { sessionEventsDeleted, eventLogDeleted, backup };
   }
 
   /**
@@ -199,10 +403,15 @@ export class EventCleanupService {
   /**
    * Get the current service state (for debugging/monitoring).
    */
-  getState(): Readonly<{ isRunning: boolean; lastRunAt: string | null }> {
+  getState(): Readonly<{
+    isRunning: boolean;
+    lastRunAt: string | null;
+    lastBackupAt: string | null;
+  }> {
     return {
       isRunning: this.isRunning,
       lastRunAt: this.lastRunAt,
+      lastBackupAt: this.lastBackupAt,
     };
   }
 }

--- a/src/services/event-cleanup.service.ts
+++ b/src/services/event-cleanup.service.ts
@@ -194,13 +194,25 @@ export class EventCleanupService {
       mkdirSync(backupDir, { recursive: true });
     }
 
-    // Run integrity check
+    // Run integrity check — query the result and verify it returns 'ok'
     let integrityOk = false;
     try {
-      this.db.run(sql`PRAGMA integrity_check`);
-      // integrity_check returns 'ok' on success; if it doesn't throw, the check passed
-      integrityOk = true;
-      log.info('Database integrity check passed');
+      const rows = this.db.all<{ integrity_check: string }>(sql`PRAGMA integrity_check`);
+      const firstRow = rows[0];
+      if (firstRow && firstRow.integrity_check === 'ok') {
+        integrityOk = true;
+        log.info('Database integrity check passed');
+      } else {
+        const details = rows.map((r) => r.integrity_check).join('; ');
+        log.error('Database integrity check found issues', {
+          data: { details },
+        });
+        return {
+          performed: false,
+          skipped: false,
+          reason: `Integrity check failed: ${details}`,
+        };
+      }
     } catch (err) {
       log.error('Database integrity check failed', {
         error: err instanceof Error ? err : new Error(String(err)),

--- a/src/services/event-cleanup.service.ts
+++ b/src/services/event-cleanup.service.ts
@@ -10,8 +10,16 @@
  * Backup behavior is configurable via admin settings (backup.enabled,
  * backup.intervalHours, backup.maxBackups).
  */
-import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'node:fs';
-import { basename, dirname, join, resolve } from 'node:path';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { sql } from 'drizzle-orm';
 import { createLogger } from '../lib/logging/logger.js';
 import type { Database } from '../types/database.js';
@@ -45,9 +53,6 @@ const DEFAULT_BACKUP_MAX_BACKUPS = 7;
 
 /** Default database path */
 const DEFAULT_DB_PATH = './data/agentpane.db';
-
-/** Default backup directory */
-const DEFAULT_BACKUP_DIR = './data/backups';
 
 export interface BackupResult {
   performed: boolean;
@@ -180,13 +185,11 @@ export class EventCleanupService {
     }
 
     const dbPath = resolve(process.env.DB_PATH || DEFAULT_DB_PATH);
-    const backupDir = resolve(
-      dirname(dbPath),
-      basename(DEFAULT_BACKUP_DIR) === 'backups' ? 'backups' : DEFAULT_BACKUP_DIR
-    );
+    const backupDir = resolve(dirname(dbPath), 'backups');
 
     if (!existsSync(dbPath)) {
-      return { performed: false, skipped: true, reason: `DB file not found: ${dbPath}` };
+      log.warn('Database file not found for backup', { data: { dbPath } });
+      return { performed: false, skipped: true, reason: 'Database file not found' };
     }
 
     // Ensure backup directory exists
@@ -210,7 +213,7 @@ export class EventCleanupService {
         return {
           performed: false,
           skipped: false,
-          reason: `Integrity check failed: ${details}`,
+          reason: 'Integrity check failed',
         };
       }
     } catch (err) {
@@ -242,6 +245,8 @@ export class EventCleanupService {
 
     try {
       copyFileSync(dbPath, backupPath);
+      // Restrict backup file to owner-only read/write
+      chmodSync(backupPath, 0o600);
       log.info('Database backup created', { data: { backupPath } });
     } catch (err) {
       log.error('Failed to copy database file', {

--- a/tests/integration/pg-schema.test.ts
+++ b/tests/integration/pg-schema.test.ts
@@ -1,0 +1,803 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Static analysis test for PostgreSQL migration integrity.
+ *
+ * This test reads the raw SQL migration files and the Drizzle journal
+ * without spinning up a PostgreSQL instance.  It verifies that:
+ *   - All migration files referenced in the journal exist on disk
+ *   - CREATE TABLE statements cover the expected set of tables
+ *   - Critical columns are present in each table
+ *   - Foreign-key constraints reference valid tables
+ *   - The journal metadata is internally consistent
+ */
+
+const MIGRATIONS_DIR = resolve(process.cwd(), 'src/db/migrations-pg');
+const META_DIR = resolve(MIGRATIONS_DIR, 'meta');
+const JOURNAL_PATH = resolve(META_DIR, '_journal.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readAllMigrationSql(): string {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  return files.map((f) => readFileSync(resolve(MIGRATIONS_DIR, f), 'utf8')).join('\n');
+}
+
+function readMigrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+}
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+function readJournal(): Journal {
+  return JSON.parse(readFileSync(JOURNAL_PATH, 'utf8'));
+}
+
+/**
+ * Extract all table names from CREATE TABLE statements across all migrations.
+ * Handles both quoted and unquoted identifiers, and IF NOT EXISTS.
+ */
+function extractCreateTables(sql: string): string[] {
+  const regex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z_][a-z0-9_]*)"?\s*\(/gi;
+  const tables: string[] = [];
+  for (const match of sql.matchAll(regex)) {
+    tables.push(match[1].toLowerCase());
+  }
+  return [...new Set(tables)].sort();
+}
+
+/**
+ * Extract table renames from ALTER TABLE ... RENAME TO statements.
+ * Returns array of { from, to } pairs.
+ */
+function extractTableRenames(sql: string): Array<{ from: string; to: string }> {
+  const regex = /ALTER\s+TABLE\s+"([^"]+)"\s+RENAME\s+TO\s+"([^"]+)"/gi;
+  const renames: Array<{ from: string; to: string }> = [];
+  for (const m of sql.matchAll(regex)) {
+    renames.push({ from: m[1].toLowerCase(), to: m[2].toLowerCase() });
+  }
+  return renames;
+}
+
+/**
+ * Compute the effective set of tables after applying all CREATE TABLE and
+ * RENAME TO operations across the full migration chain.
+ */
+function computeEffectiveTables(sql: string): string[] {
+  const created = new Set(extractCreateTables(sql));
+  const renames = extractTableRenames(sql);
+  for (const { from, to } of renames) {
+    // The original name was created, now renamed
+    created.delete(from);
+    created.add(to);
+  }
+  return [...created].sort();
+}
+
+/**
+ * Extract columns for a given table from the CREATE TABLE block.
+ * Returns lowercased column names.
+ */
+function extractColumnsForTable(sql: string, tableName: string): string[] {
+  // Match the CREATE TABLE block — greedy up to the closing ");".
+  const tableRegex = new RegExp(
+    `CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?"?${tableName}"?\\s*\\(([\\s\\S]*?)\\);`,
+    'i'
+  );
+  const tableMatch = tableRegex.exec(sql);
+  if (!tableMatch) return [];
+
+  const body = tableMatch[1];
+  // Each column definition starts with "column_name" at the beginning of a
+  // line (after optional whitespace).  We extract quoted names.
+  const colRegex = /^\s+"([a-z_][a-z0-9_]*)"/gm;
+  const cols: string[] = [];
+  for (const m of body.matchAll(colRegex)) {
+    cols.push(m[1].toLowerCase());
+  }
+  return cols;
+}
+
+/**
+ * Extract all foreign key constraints from ALTER TABLE ... ADD CONSTRAINT ...
+ * FOREIGN KEY statements.
+ */
+interface ForeignKey {
+  constraintName: string;
+  sourceTable: string;
+  sourceColumn: string;
+  targetTable: string;
+  targetColumn: string;
+}
+
+function extractAlterTableForeignKeys(sql: string): ForeignKey[] {
+  // Handle both "public"."table"("col") and "table"("col") reference formats
+  const fkRegex =
+    /ALTER\s+TABLE\s+"([^"]+)"\s+ADD\s+CONSTRAINT\s+"([^"]+)"\s+FOREIGN\s+KEY\s+\("([^"]+)"\)\s+REFERENCES\s+(?:"public"\s*\.\s*)?"([^"]+)"\("([^"]+)"\)/gi;
+  const keys: ForeignKey[] = [];
+  for (const m of sql.matchAll(fkRegex)) {
+    keys.push({
+      sourceTable: m[1].toLowerCase(),
+      constraintName: m[2],
+      sourceColumn: m[3].toLowerCase(),
+      targetTable: m[4].toLowerCase(),
+      targetColumn: m[5].toLowerCase(),
+    });
+  }
+  return keys;
+}
+
+/**
+ * Extract inline REFERENCES from CREATE TABLE column definitions.
+ * e.g.: "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE
+ */
+interface InlineFK {
+  sourceTable: string;
+  sourceColumn: string;
+  targetTable: string;
+  targetColumn: string;
+}
+
+function extractInlineForeignKeys(sql: string): InlineFK[] {
+  const keys: InlineFK[] = [];
+  // Find each CREATE TABLE block
+  const tableRegex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"([^"]+)"\s*\(([\s\S]*?)\);/gi;
+  for (const tableMatch of sql.matchAll(tableRegex)) {
+    const tableName = tableMatch[1].toLowerCase();
+    const body = tableMatch[2];
+    // Look for inline REFERENCES in column definitions
+    const colRefRegex = /"([a-z_][a-z0-9_]*)"\s+[^,]*?REFERENCES\s+"([^"]+)"\("([^"]+)"\)/gi;
+    for (const colMatch of body.matchAll(colRefRegex)) {
+      keys.push({
+        sourceTable: tableName,
+        sourceColumn: colMatch[1].toLowerCase(),
+        targetTable: colMatch[2].toLowerCase(),
+        targetColumn: colMatch[3].toLowerCase(),
+      });
+    }
+  }
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// Tables present in the Drizzle PG schema definitions (source of truth).
+// Derived from src/db/schema/postgres/*.ts pgTable() calls — 48 tables.
+// ---------------------------------------------------------------------------
+
+const DRIZZLE_PG_TABLES = [
+  'agent_runs',
+  'agents',
+  'api_keys',
+  'api_tokens',
+  'audit_logs',
+  'cli_sessions',
+  'codespace_members',
+  'codespace_tags',
+  'codespaces',
+  'dream_sessions',
+  'event_log',
+  'event_sources',
+  'event_subscriptions',
+  'folder_members',
+  'github_installations',
+  'github_tokens',
+  'marketplaces',
+  'memory_insights',
+  'memory_messages',
+  'plan_sessions',
+  'project_folders',
+  'repository_configs',
+  'sandbox_configs',
+  'sandbox_instances',
+  'sandbox_tmux_sessions',
+  'schedule_executions',
+  'session_events',
+  'session_summaries',
+  'sessions',
+  'settings',
+  'skill_executions',
+  'skill_metrics',
+  'skill_suggestions',
+  'tags',
+  'task_tags',
+  'tasks',
+  'team_invitations',
+  'team_members',
+  'team_project_folders',
+  'teams',
+  'template_codespaces',
+  'templates',
+  'terraform_modules',
+  'terraform_registries',
+  'user_sessions',
+  'users',
+  'workflows',
+  'worktrees',
+].sort();
+
+/**
+ * All tables that should exist after applying every migration.
+ * This includes:
+ * - Tables from 0000 (initial creation)
+ * - Tables added in 0004 (schema catch-up)
+ * - Renames applied: projects->codespaces, template_projects->template_codespaces
+ *
+ * The effective table set should match the Drizzle schema exactly.
+ */
+const EXPECTED_EFFECTIVE_TABLES = [...DRIZZLE_PG_TABLES].sort();
+
+/**
+ * Tables created via CREATE TABLE across all migrations (before renames).
+ * Includes both original names and new names from 0004.
+ */
+const ALL_CREATED_TABLES = [
+  // From 0000 (initial)
+  'agent_runs',
+  'agents',
+  'api_keys',
+  'audit_logs',
+  'cli_sessions',
+  'github_installations',
+  'github_tokens',
+  'marketplaces',
+  'plan_sessions',
+  'projects', // renamed to codespaces in 0004
+  'repository_configs',
+  'sandbox_configs',
+  'sandbox_instances',
+  'sandbox_tmux_sessions',
+  'session_events',
+  'session_summaries',
+  'sessions',
+  'settings',
+  'tasks',
+  'template_projects', // renamed to template_codespaces in 0004
+  'templates',
+  'terraform_modules',
+  'terraform_registries',
+  'workflows',
+  'worktrees',
+  // From 0004 (schema catch-up)
+  'api_tokens',
+  'codespace_members',
+  'codespace_tags',
+  'dream_sessions',
+  'event_log',
+  'event_sources',
+  'event_subscriptions',
+  'folder_members',
+  'memory_insights',
+  'memory_messages',
+  'project_folders',
+  'schedule_executions',
+  'skill_executions',
+  'skill_metrics',
+  'skill_suggestions',
+  'tags',
+  'task_tags',
+  'team_invitations',
+  'team_members',
+  'team_project_folders',
+  'teams',
+  'user_sessions',
+  'users',
+].sort();
+
+// Critical columns that every table must have (at minimum: a primary key).
+// We check columns from the CREATE TABLE block (original column names).
+const CRITICAL_COLUMNS: Record<string, string[]> = {
+  // From 0000 — these use original column names (project_id, not codespace_id)
+  agents: ['id', 'project_id', 'name', 'status', 'type', 'created_at'],
+  tasks: ['id', 'project_id', 'title', 'column', 'position', 'priority', 'created_at'],
+  sessions: ['id', 'project_id', 'status', 'url', 'created_at'],
+  worktrees: ['id', 'project_id', 'branch', 'path', 'status', 'created_at'],
+  agent_runs: ['id', 'agent_id', 'task_id', 'project_id', 'status', 'started_at'],
+  audit_logs: ['id', 'tool', 'status', 'created_at'],
+  session_events: ['id', 'session_id', 'offset', 'type', 'channel', 'data', 'timestamp'],
+  settings: ['key', 'value', 'updated_at'],
+  sandbox_configs: ['id', 'name', 'type', 'created_at'],
+  sandbox_instances: ['id', 'project_id', 'container_id', 'status', 'created_at'],
+  templates: ['id', 'name', 'scope', 'github_owner', 'github_repo', 'created_at'],
+  workflows: ['id', 'name', 'nodes', 'edges', 'status', 'created_at'],
+  cli_sessions: ['id', 'session_id', 'file_path', 'cwd', 'status', 'created_at'],
+  plan_sessions: ['id', 'task_id', 'project_id', 'status', 'created_at'],
+  terraform_registries: ['id', 'name', 'org_name', 'status', 'created_at'],
+  terraform_modules: ['id', 'registry_id', 'name', 'namespace', 'provider', 'version'],
+  github_installations: ['id', 'installation_id', 'account_login', 'created_at'],
+  github_tokens: ['id', 'encrypted_token', 'token_type', 'created_at'],
+  marketplaces: ['id', 'name', 'github_owner', 'github_repo', 'created_at'],
+  projects: ['id', 'name', 'path', 'created_at'],
+  // From 0004 — new tables
+  users: ['id', 'github_id', 'github_login', 'created_at'],
+  teams: ['id', 'name', 'slug', 'created_at'],
+  project_folders: ['id', 'name', 'slug', 'created_at'],
+  user_sessions: ['id', 'user_id', 'token', 'expires_at', 'created_at'],
+  team_members: ['team_id', 'user_id', 'role'],
+  team_invitations: ['id', 'team_id', 'email', 'role', 'token', 'status', 'created_at'],
+  codespace_members: ['codespace_id', 'user_id', 'role', 'created_at'],
+  api_tokens: ['id', 'user_id', 'team_id', 'name', 'token_hash', 'status', 'created_at'],
+  tags: ['id', 'project_folder_id', 'name', 'color', 'created_at'],
+  codespace_tags: ['codespace_id', 'tag_id'],
+  task_tags: ['task_id', 'tag_id'],
+  event_sources: ['id', 'team_id', 'name', 'type', 'slug', 'status', 'created_at'],
+  event_subscriptions: ['id', 'name', 'event_source_id', 'target_codespace_id', 'created_at'],
+  event_log: ['id', 'event_type', 'status', 'delivery_id'],
+  schedule_executions: ['id', 'event_source_id', 'status', 'scheduled_at', 'created_at'],
+  memory_insights: ['id', 'codespace_id', 'content', 'source', 'created_at'],
+  memory_messages: ['id', 'codespace_id', 'memory_session_id', 'role', 'content', 'created_at'],
+  skill_executions: ['id', 'codespace_id', 'skill_id', 'status', 'created_at'],
+  skill_metrics: ['id', 'codespace_id', 'skill_id', 'skill_name'],
+  dream_sessions: ['id', 'type', 'status', 'created_at'],
+  skill_suggestions: ['id', 'dream_session_id', 'codespace_id', 'skill_id', 'status', 'created_at'],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PostgreSQL Schema Static Analysis', () => {
+  const allSql = readAllMigrationSql();
+  const migrationFiles = readMigrationFiles();
+  const journal = readJournal();
+  const createdTables = extractCreateTables(allSql);
+  const effectiveTables = computeEffectiveTables(allSql);
+  const alterForeignKeys = extractAlterTableForeignKeys(allSql);
+  const inlineForeignKeys = extractInlineForeignKeys(allSql);
+
+  // -----------------------------------------------------------------------
+  // 1. Migration files can be read and parsed
+  // -----------------------------------------------------------------------
+  describe('Migration files are readable', () => {
+    it('should have at least one migration SQL file', () => {
+      expect(migrationFiles.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should have non-empty SQL content', () => {
+      expect(allSql.length).toBeGreaterThan(0);
+    });
+
+    it('each migration file should be valid UTF-8 and non-empty', () => {
+      for (const file of migrationFiles) {
+        const content = readFileSync(resolve(MIGRATIONS_DIR, file), 'utf8');
+        expect(content.trim().length, `${file} should not be empty`).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. All expected tables exist in the migration chain
+  // -----------------------------------------------------------------------
+  describe('CREATE TABLE completeness', () => {
+    it('should contain all expected CREATE TABLE statements', () => {
+      for (const table of ALL_CREATED_TABLES) {
+        expect(createdTables, `Missing CREATE TABLE for "${table}"`).toContain(table);
+      }
+    });
+
+    it('should match the expected count of CREATE TABLE statements', () => {
+      expect(createdTables.length).toBe(ALL_CREATED_TABLES.length);
+    });
+
+    it('should not have unexpected tables outside the known set', () => {
+      for (const table of createdTables) {
+        expect(
+          ALL_CREATED_TABLES,
+          `Unexpected table "${table}" found in migrations but not in expected list`
+        ).toContain(table);
+      }
+    });
+
+    it('effective tables (after renames) should match the Drizzle PG schema', () => {
+      expect(effectiveTables).toEqual(EXPECTED_EFFECTIVE_TABLES);
+    });
+
+    it('should apply expected table renames', () => {
+      const renames = extractTableRenames(allSql);
+      const renameMap = new Map(renames.map((r) => [r.from, r.to]));
+      expect(renameMap.get('projects')).toBe('codespaces');
+      expect(renameMap.get('template_projects')).toBe('template_codespaces');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Critical columns exist in migration SQL
+  // -----------------------------------------------------------------------
+  describe('Critical columns', () => {
+    for (const [table, expectedCols] of Object.entries(CRITICAL_COLUMNS)) {
+      it(`"${table}" should have columns: ${expectedCols.join(', ')}`, () => {
+        const actualCols = extractColumnsForTable(allSql, table);
+        expect(
+          actualCols.length,
+          `Could not find CREATE TABLE block for "${table}"`
+        ).toBeGreaterThan(0);
+        for (const col of expectedCols) {
+          expect(actualCols, `"${table}" is missing column "${col}"`).toContain(col);
+        }
+      });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Foreign key constraints reference valid tables
+  // -----------------------------------------------------------------------
+  describe('Foreign key constraints (ALTER TABLE)', () => {
+    it('should have ALTER TABLE foreign key constraints defined', () => {
+      expect(alterForeignKeys.length).toBeGreaterThan(0);
+    });
+
+    it('every ALTER TABLE FK source table should exist as created or renamed table', () => {
+      for (const fk of alterForeignKeys) {
+        expect(
+          effectiveTables.includes(fk.sourceTable) || createdTables.includes(fk.sourceTable),
+          `FK "${fk.constraintName}" references source table "${fk.sourceTable}" which does not exist`
+        ).toBe(true);
+      }
+    });
+
+    it('every ALTER TABLE FK target table should exist as created or renamed table', () => {
+      for (const fk of alterForeignKeys) {
+        expect(
+          effectiveTables.includes(fk.targetTable) || createdTables.includes(fk.targetTable),
+          `FK "${fk.constraintName}" references target table "${fk.targetTable}" which does not exist`
+        ).toBe(true);
+      }
+    });
+
+    it('FK target columns should be "id" or a known primary key', () => {
+      for (const fk of alterForeignKeys) {
+        expect(
+          ['id', 'key'],
+          `FK "${fk.constraintName}" targets column "${fk.targetColumn}" which is not a standard PK`
+        ).toContain(fk.targetColumn);
+      }
+    });
+
+    it('should have expected core FK relationships', () => {
+      const fkPairs = alterForeignKeys.map(
+        (fk) => `${fk.sourceTable}.${fk.sourceColumn}->${fk.targetTable}`
+      );
+
+      // Core entity relationships (re-created in 0004 with codespace_id)
+      expect(fkPairs).toContain('agent_runs.agent_id->agents');
+      expect(fkPairs).toContain('agent_runs.task_id->tasks');
+      expect(fkPairs).toContain('session_events.session_id->sessions');
+      expect(fkPairs).toContain('tasks.agent_id->agents');
+      expect(fkPairs).toContain('tasks.session_id->sessions');
+      expect(fkPairs).toContain('tasks.worktree_id->worktrees');
+      expect(fkPairs).toContain('worktrees.agent_id->agents');
+      expect(fkPairs).toContain('worktrees.task_id->tasks');
+      expect(fkPairs).toContain('audit_logs.agent_id->agents');
+      expect(fkPairs).toContain('plan_sessions.task_id->tasks');
+    });
+
+    it('should have codespace FK relationships from catch-up migration', () => {
+      const fkPairs = alterForeignKeys.map(
+        (fk) => `${fk.sourceTable}.${fk.sourceColumn}->${fk.targetTable}`
+      );
+
+      // From 0004: codespace_id -> codespaces relationships (after rename)
+      expect(fkPairs).toContain('agents.codespace_id->codespaces');
+      expect(fkPairs).toContain('tasks.codespace_id->codespaces');
+      expect(fkPairs).toContain('sessions.codespace_id->codespaces');
+      expect(fkPairs).toContain('worktrees.codespace_id->codespaces');
+      expect(fkPairs).toContain('codespaces.project_folder_id->project_folders');
+    });
+
+    it('should define ON DELETE behavior for all ALTER TABLE FK statements', () => {
+      const fkStatements = allSql.match(/ALTER\s+TABLE[^;]*FOREIGN\s+KEY[^;]*REFERENCES[^;]*/gi);
+      expect(fkStatements).not.toBeNull();
+      for (const stmt of fkStatements!) {
+        expect(
+          stmt.toLowerCase(),
+          `FK statement missing ON DELETE clause:\n${stmt.slice(0, 120)}...`
+        ).toMatch(/on delete (cascade|set null|no action|restrict|set default)/i);
+      }
+    });
+  });
+
+  describe('Foreign key constraints (inline REFERENCES)', () => {
+    it('should have inline REFERENCES in CREATE TABLE definitions', () => {
+      expect(inlineForeignKeys.length).toBeGreaterThan(0);
+    });
+
+    it('inline FK target tables should exist', () => {
+      for (const fk of inlineForeignKeys) {
+        expect(
+          effectiveTables.includes(fk.targetTable) || createdTables.includes(fk.targetTable),
+          `Inline FK in "${fk.sourceTable}.${fk.sourceColumn}" references non-existent table "${fk.targetTable}"`
+        ).toBe(true);
+      }
+    });
+
+    it('inline FK target columns should be "id" (standard PK)', () => {
+      for (const fk of inlineForeignKeys) {
+        expect(
+          fk.targetColumn,
+          `Inline FK "${fk.sourceTable}.${fk.sourceColumn}" targets non-PK column "${fk.targetColumn}"`
+        ).toBe('id');
+      }
+    });
+
+    it('should have inline FKs for new tables created in 0004', () => {
+      const inlinePairs = inlineForeignKeys.map(
+        (fk) => `${fk.sourceTable}.${fk.sourceColumn}->${fk.targetTable}`
+      );
+
+      // user_sessions references users
+      expect(inlinePairs).toContain('user_sessions.user_id->users');
+      // team_members references teams and users
+      expect(inlinePairs).toContain('team_members.team_id->teams');
+      expect(inlinePairs).toContain('team_members.user_id->users');
+      // team_invitations references teams
+      expect(inlinePairs).toContain('team_invitations.team_id->teams');
+      // codespace_members references users
+      expect(inlinePairs).toContain('codespace_members.user_id->users');
+      // tags references project_folders
+      expect(inlinePairs).toContain('tags.project_folder_id->project_folders');
+      // event_sources references teams
+      expect(inlinePairs).toContain('event_sources.team_id->teams');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Migration journal consistency
+  // -----------------------------------------------------------------------
+  describe('Migration journal', () => {
+    it('journal file should exist and be valid JSON', () => {
+      expect(journal).toBeDefined();
+      expect(journal.version).toBeDefined();
+      expect(journal.dialect).toBe('postgresql');
+    });
+
+    it('journal should have entries for all migration SQL files', () => {
+      const journalTags = journal.entries.map((e) => e.tag);
+      for (const file of migrationFiles) {
+        const tag = file.replace('.sql', '');
+        expect(
+          journalTags,
+          `Migration file "${file}" has no corresponding journal entry`
+        ).toContain(tag);
+      }
+    });
+
+    it('all journal entries should have corresponding SQL files', () => {
+      const fileNames = new Set(migrationFiles.map((f) => f.replace('.sql', '')));
+      for (const entry of journal.entries) {
+        expect(
+          fileNames.has(entry.tag),
+          `Journal entry "${entry.tag}" has no corresponding SQL file`
+        ).toBe(true);
+      }
+    });
+
+    it('journal entries should have sequential indices', () => {
+      for (let i = 0; i < journal.entries.length; i++) {
+        expect(journal.entries[i].idx, `Entry at position ${i} has wrong idx`).toBe(i);
+      }
+    });
+
+    it('journal entries should have monotonically increasing timestamps', () => {
+      for (let i = 1; i < journal.entries.length; i++) {
+        expect(
+          journal.entries[i].when,
+          `Entry ${i} timestamp should be after entry ${i - 1}`
+        ).toBeGreaterThan(journal.entries[i - 1].when);
+      }
+    });
+
+    it('journal entry count should match migration file count', () => {
+      expect(journal.entries.length).toBe(migrationFiles.length);
+    });
+
+    it('all journal entries should use breakpoints', () => {
+      for (const entry of journal.entries) {
+        expect(entry.breakpoints, `Entry "${entry.tag}" should use breakpoints`).toBe(true);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. ALTER TABLE mutations in subsequent migrations
+  // -----------------------------------------------------------------------
+  describe('Subsequent migration mutations', () => {
+    it('migration 0001 should alter cli_sessions columns to bigint', () => {
+      const sql0001 = readFileSync(resolve(MIGRATIONS_DIR, '0001_overconfident_raza.sql'), 'utf8');
+      expect(sql0001).toMatch(/ALTER\s+TABLE\s+"cli_sessions"/i);
+      expect(sql0001).toMatch(/started_at.*bigint/i);
+      expect(sql0001).toMatch(/last_activity_at.*bigint/i);
+    });
+
+    it('migration 0002 should alter session_events timestamp to bigint', () => {
+      const sql0002 = readFileSync(resolve(MIGRATIONS_DIR, '0002_amused_talon.sql'), 'utf8');
+      expect(sql0002).toMatch(/ALTER\s+TABLE\s+"session_events"/i);
+      expect(sql0002).toMatch(/timestamp.*bigint/i);
+    });
+
+    it('migration 0003 should add nomad columns to sandbox_configs', () => {
+      const sql0003 = readFileSync(resolve(MIGRATIONS_DIR, '0003_nomad_columns.sql'), 'utf8');
+      expect(sql0003).toMatch(/ALTER\s+TABLE\s+"sandbox_configs"/i);
+      const expectedCols = [
+        'nomad_address',
+        'nomad_token',
+        'nomad_namespace',
+        'nomad_datacenter',
+        'nomad_region',
+      ];
+      for (const col of expectedCols) {
+        expect(sql0003, `Missing nomad column "${col}"`).toContain(col);
+      }
+    });
+
+    it('migration 0004 should rename projects to codespaces', () => {
+      const sql0004 = readFileSync(resolve(MIGRATIONS_DIR, '0004_schema_catchup.sql'), 'utf8');
+      expect(sql0004).toMatch(/ALTER\s+TABLE\s+"projects"\s+RENAME\s+TO\s+"codespaces"/i);
+    });
+
+    it('migration 0004 should rename template_projects to template_codespaces', () => {
+      const sql0004 = readFileSync(resolve(MIGRATIONS_DIR, '0004_schema_catchup.sql'), 'utf8');
+      expect(sql0004).toMatch(
+        /ALTER\s+TABLE\s+"template_projects"\s+RENAME\s+TO\s+"template_codespaces"/i
+      );
+    });
+
+    it('migration 0004 should rename project_id columns to codespace_id', () => {
+      const sql0004 = readFileSync(resolve(MIGRATIONS_DIR, '0004_schema_catchup.sql'), 'utf8');
+      // These tables had project_id renamed to codespace_id
+      const tablesWithRenamedColumn = [
+        'agent_runs',
+        'agents',
+        'audit_logs',
+        'plan_sessions',
+        'sandbox_instances',
+        'sessions',
+        'tasks',
+        'worktrees',
+      ];
+      for (const table of tablesWithRenamedColumn) {
+        expect(sql0004, `Missing column rename for "${table}.project_id"`).toMatch(
+          new RegExp(
+            `ALTER\\s+TABLE\\s+"${table}"\\s+RENAME\\s+COLUMN\\s+"project_id"\\s+TO\\s+"codespace_id"`,
+            'i'
+          )
+        );
+      }
+    });
+
+    it('migration 0004 should create all new tables', () => {
+      const sql0004 = readFileSync(resolve(MIGRATIONS_DIR, '0004_schema_catchup.sql'), 'utf8');
+      const newTables = [
+        'users',
+        'teams',
+        'project_folders',
+        'user_sessions',
+        'team_members',
+        'team_invitations',
+        'team_project_folders',
+        'folder_members',
+        'codespace_members',
+        'api_tokens',
+        'tags',
+        'codespace_tags',
+        'task_tags',
+        'event_sources',
+        'event_subscriptions',
+        'event_log',
+        'schedule_executions',
+        'memory_insights',
+        'memory_messages',
+        'skill_executions',
+        'skill_metrics',
+        'dream_sessions',
+        'skill_suggestions',
+      ];
+      for (const table of newTables) {
+        expect(sql0004, `Migration 0004 should create table "${table}"`).toMatch(
+          new RegExp(`CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?"${table}"`, 'i')
+        );
+      }
+    });
+
+    it('migration 0004 should add new columns to existing tables', () => {
+      const sql0004 = readFileSync(resolve(MIGRATIONS_DIR, '0004_schema_catchup.sql'), 'utf8');
+      // Spot-check new columns added to existing tables
+      expect(sql0004).toContain('skill_id');
+      expect(sql0004).toContain('skill_name');
+      expect(sql0004).toContain('parent_agent_id');
+      expect(sql0004).toContain('sandbox_provider');
+      expect(sql0004).toContain('sandbox_container_id');
+      expect(sql0004).toContain('cost_usd');
+      expect(sql0004).toContain('stop_reason');
+    });
+
+    it('migration 0004 should be wrapped in a transaction', () => {
+      const sql0004 = readFileSync(resolve(MIGRATIONS_DIR, '0004_schema_catchup.sql'), 'utf8');
+      // The file starts with comment lines, then BEGIN
+      expect(sql0004).toMatch(/\bBEGIN\b/);
+      expect(sql0004.trim()).toMatch(/COMMIT;\s*$/);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Snapshot files exist for completed migrations
+  // -----------------------------------------------------------------------
+  describe('Snapshot files', () => {
+    it('meta directory should contain snapshot files', () => {
+      const metaFiles = readdirSync(META_DIR).filter((f) => f.endsWith('_snapshot.json'));
+      expect(metaFiles.length).toBeGreaterThan(0);
+    });
+
+    it('snapshot files should be valid JSON', () => {
+      const metaFiles = readdirSync(META_DIR).filter((f) => f.endsWith('_snapshot.json'));
+      for (const file of metaFiles) {
+        const content = readFileSync(resolve(META_DIR, file), 'utf8');
+        expect(() => JSON.parse(content), `Snapshot ${file} is not valid JSON`).not.toThrow();
+      }
+    });
+
+    it('latest snapshot should contain tables from the initial migration', () => {
+      const metaFiles = readdirSync(META_DIR)
+        .filter((f) => f.endsWith('_snapshot.json'))
+        .sort();
+      const latestSnapshot = JSON.parse(
+        readFileSync(resolve(META_DIR, metaFiles[metaFiles.length - 1]), 'utf8')
+      );
+      const snapshotTables = Object.keys(latestSnapshot.tables || {}).map((t) =>
+        t.replace('public.', '')
+      );
+
+      // The latest snapshot (0002) captures state after 0000-0002.
+      // Tables from 0000 should all be present.
+      const initialTables = [
+        'agent_runs',
+        'agents',
+        'api_keys',
+        'audit_logs',
+        'cli_sessions',
+        'github_installations',
+        'github_tokens',
+        'marketplaces',
+        'plan_sessions',
+        'projects',
+        'repository_configs',
+        'sandbox_configs',
+        'sandbox_instances',
+        'sandbox_tmux_sessions',
+        'session_events',
+        'session_summaries',
+        'sessions',
+        'settings',
+        'tasks',
+        'template_projects',
+        'templates',
+        'terraform_modules',
+        'terraform_registries',
+        'workflows',
+        'worktrees',
+      ];
+
+      for (const table of initialTables) {
+        expect(snapshotTables, `Latest snapshot missing table "${table}"`).toContain(table);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive PostgreSQL migration support and automated backup infrastructure to bring the PostgreSQL schema in line with the current Drizzle schema definitions. It includes a major schema catch-up migration (0004), static analysis tests for migration integrity, and automated backup capabilities for both SQLite and PostgreSQL databases.

## Key Changes

### PostgreSQL Migrations
- **New migration 0004_schema_catchup.sql**: Comprehensive catch-up migration that:
  - Renames `projects` → `codespaces` and all `project_id` → `codespace_id` foreign key columns
  - Renames `template_projects` → `template_codespaces`
  - Creates 23 missing tables (users, teams, project_folders, event sources, memory tables, skill tables, etc.)
  - Adds missing columns and foreign key constraints
  - Adds missing indexes
  - Properly handles constraint drops/recreations during renames to maintain referential integrity

- **Updated Drizzle journal**: Added entry for migration 0004 with proper versioning

### Schema Validation & Testing
- **New test file pg-schema.test.ts**: Comprehensive static analysis test suite that:
  - Reads raw SQL migration files without spinning up a PostgreSQL instance
  - Verifies all migration files referenced in the journal exist on disk
  - Validates CREATE TABLE statements cover the expected 48 tables
  - Checks critical columns are present in each table
  - Validates foreign key constraints reference valid tables
  - Verifies journal metadata consistency
  - Includes 40+ test cases covering migration integrity

### Backup Infrastructure
- **EventCleanupService enhancements**:
  - Added `runBackup()` method for automated SQLite database backups
  - Configurable via admin settings: `backup.enabled`, `backup.intervalHours`, `backup.maxBackups`
  - Runs PRAGMA integrity_check before backup
  - Runs PRAGMA wal_checkpoint(TRUNCATE) for WAL cleanup
  - Automatically removes old backups beyond the configured limit
  - Returns detailed BackupResult with status and diagnostics

- **New PostgreSQL backup script (backup-db-pg.sh)**:
  - Creates compressed backups using pg_dump with custom format
  - Configurable backup directory and retention count
  - Proper error handling and cleanup on failure
  - Secure file permissions (owner-only read/write)

### Schema Drift Detection
- **Enhanced check-schema-drift.ts script**:
  - Phase 1: Module-level validation (existing logic)
  - Phase 2: Column-level comparison between SQLite and PostgreSQL schemas
  - Phase 3: Index-level comparison
  - Extracts and compares column definitions, foreign key onDelete behavior, and index definitions
  - Single-pass file parsing to avoid redundant reads

### Schema Updates
- **codespaces.ts (both SQLite and PostgreSQL)**: Added explicit `onDelete: 'set null'` to `sandboxConfigId` foreign key
- **github.ts (PostgreSQL)**: Added `teamId` foreign key to `githubTokens` table

### Migration Infrastructure
- **Updated MIGRATIONS array**: Added migrations 24-25 for SQLite:
  - Migration 24: Schema-level fix for sandbox config FK onDelete behavior
  - Migration 25: Enum check triggers for critical columns (tasks.column validation)

- **Migration runner improvements**: Better handling of duplicate column errors during idempotent re-runs

## Notable Implementation Details

- The 0004 migration uses a multi-section approach: prerequisite table creation, table renames with FK management, and new table creation
- Foreign key constraints are carefully dropped before renames and re-created with updated column names to maintain referential integrity
- The static analysis test extracts table names, columns, and foreign keys using regex patterns that handle both quoted and unquoted identifiers
- Backup functionality is non-blocking and includes integrity checks before backup to prevent backing up corrupted databases
- The schema drift checker now performs deep structural comparison beyond just module exports

https://claude.ai/code/session_01T5UGxKSpsZitLoLQ7u3f5e