### PR TITLE
fix: resolve flaky agent-execution test from in-flight DB writes

### DIFF
--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -1229,6 +1229,16 @@ export class AgentExecutionService {
   }
 
   /**
+   * Stop all running agents. Used for graceful shutdown and test cleanup.
+   */
+  stopAll(): void {
+    for (const [, controller] of this.runningAgents) {
+      controller.abort();
+    }
+    this.runningAgents.clear();
+  }
+
+  /**
    * Try to dequeue the next queued task and auto-start the agent on it.
    * Called after an agent completes a task. Failures are logged but not propagated.
    */

--- a/tests/services/agent-execution.service.test.ts
+++ b/tests/services/agent-execution.service.test.ts
@@ -101,6 +101,9 @@ describe('AgentExecutionService', () => {
   });
 
   afterEach(async () => {
+    service.stopAll();
+    // Allow pending async operations to settle after abort
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await clearTestDatabase();
   });
 


### PR DESCRIPTION
## Summary
- Added `stopAll()` method to `AgentExecutionService` that aborts all running agent AbortControllers and clears the `runningAgents` map
- Updated test `afterEach` to call `service.stopAll()` with a 50ms settle delay before `clearTestDatabase()`, preventing fire-and-forget `executeAgentAsync()` operations from hitting FK constraint violations on truncated tables

## Root Cause
`AgentExecutionService.start()` fires `executeAgentAsync()` as fire-and-forget. This async function does multiple DB writes (update agents, tasks, agentRuns, tryDequeueAndStart). When the test's `afterEach` calls `clearTestDatabase()`, these in-flight DB operations hit FK violations because tables are being truncated while the async operations are still running. This caused CI shard 3/3 to fail with 2 unhandled `SqliteError: FOREIGN KEY constraint failed` rejections.

## Test plan
- [x] `npx vitest run tests/services/agent-execution.service.test.ts` passes all 27 tests with no unhandled rejections
- [x] `npx tsc --noEmit` passes
- [x] Biome lint/format passes
- [ ] CI shard 3/3 no longer fails with FK constraint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)