### PR TITLE
fix: sandbox stream ID mismatch, ephemeral stream errors, and orphan cleanup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -395,6 +395,22 @@ The stream handler publishes these events during execution:
 - **Frontend**: `DurableStreamsClient` connects via EventSource
 - Events are published through `sessionService.publish()`
 
+### Durable Stream ID Patterns
+
+The `session_events` table stores events for ALL stream types, not just sessions. The `sessionId` column has **no FK constraint** — cleanup is explicit.
+
+| Stream Type | Stream ID Format | Persistence | Cleanup |
+|-------------|-----------------|-------------|---------|
+| Agent sessions | `{sessionId}` (bare CUID) | Durable (DB + Caddy) | `session-crud.service.ts` deletes explicitly |
+| Plan sessions | `plan:{planSessionId}` | Durable (DB + Caddy) | `codespace.service.ts` deletes on codespace removal |
+| Sandbox lifecycle | `sandbox:{sandboxId}` | Durable (DB + Caddy) | `codespace.service.ts` deletes on codespace removal |
+| Terraform compose | `terraform:{jobId}` | **Ephemeral** (Caddy only, no DB) | Stream deleted after each turn |
+| CLI monitor | `cli-monitor` | Durable | N/A (singleton) |
+
+**Critical: Sandbox ID consistency** — The service generates the sandbox ID via `createId()` and passes it to the provider via `config.id`. The provider MUST use `config.id ?? createId()` so the same ID flows through the stream (`sandbox:{id}`), the DB (`sandboxInstances.id`), and the provider's in-memory map (`provider.getById(id)`). This prevents orphaned events from ID mismatches.
+
+**Critical: Plan stream ID prefix** — Plan sessions use `plan:{id}` prefix because bare CUIDs would be treated as session IDs. The `plan-mode.service.ts` prefixes all stream operations with `plan:`.
+
 ## Terraform Compose Architecture
 
 The Terraform No-Code Composer uses the Claude Agent SDK to generate HCL configurations from natural language.

--- a/src/db/schema/postgres/session-events.ts
+++ b/src/db/schema/postgres/session-events.ts
@@ -9,7 +9,6 @@ import {
   timestamp,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { sessions } from './sessions';
 
 export const sessionEvents = pgTable(
   'session_events',
@@ -17,9 +16,10 @@ export const sessionEvents = pgTable(
     id: text('id')
       .primaryKey()
       .$defaultFn(() => createId()),
-    sessionId: text('session_id')
-      .notNull()
-      .references(() => sessions.id, { onDelete: 'cascade' }),
+    // Stream ID — stores events for sessions, plans, sandboxes, and other stream types.
+    // No FK constraint: plan/sandbox/task-creation stream IDs don't exist in the sessions table.
+    // Session cleanup is handled explicitly in session-crud.service.ts and codespace.service.ts.
+    sessionId: text('session_id').notNull(),
     offset: integer('offset').notNull(),
     type: text('type').notNull(),
     channel: text('channel').notNull(),

--- a/src/lib/sandbox/providers/agent-sandbox-provider.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-provider.ts
@@ -136,7 +136,7 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
     }
     this.creatingCodespaces.add(config.codespaceId);
 
-    const sandboxId = createId();
+    const sandboxId = config.id ?? createId();
     // CRD sandbox names must be DNS-1123 compliant
     const sandboxName = `agentpane-${config.codespaceId.slice(0, 20)}-${sandboxId.slice(0, 8)}`
       .toLowerCase()

--- a/src/lib/sandbox/providers/docker-provider.ts
+++ b/src/lib/sandbox/providers/docker-provider.ts
@@ -536,7 +536,7 @@ export class DockerProvider implements EventEmittingSandboxProvider {
       }
     }
 
-    const sandboxId = createId();
+    const sandboxId = config.id ?? createId();
 
     this.emit({
       type: 'sandbox:creating',

--- a/src/lib/sandbox/providers/nomad-sandbox-provider.ts
+++ b/src/lib/sandbox/providers/nomad-sandbox-provider.ts
@@ -141,7 +141,7 @@ export class NomadSandboxProvider implements EventEmittingSandboxProvider {
     }
 
     this.creatingCodespaces.add(config.codespaceId);
-    const sandboxId = createId();
+    const sandboxId = config.id ?? createId();
     // Job names must be DNS-compatible: lowercase alphanumeric and hyphens
     const jobName = `agentpane-${config.codespaceId.slice(0, 20)}-${sandboxId.slice(0, 8)}`
       .toLowerCase()

--- a/src/lib/sandbox/types.ts
+++ b/src/lib/sandbox/types.ts
@@ -10,6 +10,8 @@ export interface VolumeMountConfig {
 }
 
 export interface SandboxConfig {
+  /** Pre-assigned sandbox ID. Providers use this instead of generating their own. */
+  id?: string;
   codespaceId: string;
   codespacePath: string;
   image: string;
@@ -100,6 +102,7 @@ export const volumeMountConfigSchema = z.object({
 });
 
 export const sandboxConfigSchema = z.object({
+  id: z.string().optional(),
   codespaceId: z.string(),
   codespacePath: z.string(),
   image: z.string().default(SANDBOX_DEFAULTS.image),

--- a/src/services/codespace.service.ts
+++ b/src/services/codespace.service.ts
@@ -404,16 +404,16 @@ export class CodespaceService {
 
     // Explicitly delete session_events for this codespace's sessions, plans, and sandboxes
     // (no FK cascade — session_events stores events for multiple stream types)
-    const codspaceSessions = await this.db
+    const codespaceSessionIds = await this.db
       .select({ id: sessions.id })
       .from(sessions)
       .where(eq(sessions.codespaceId, id));
 
     // Plan and sandbox tables may not exist in all environments (pre-migration DBs)
-    let codspacePlans: { id: string }[] = [];
-    let codspaceSandboxes: { id: string }[] = [];
+    let codspacePlanIds: { id: string }[] = [];
+    let codspaceSandboxIds: { id: string }[] = [];
     try {
-      codspacePlans = await this.db
+      codspacePlanIds = await this.db
         .select({ id: planSessions.id })
         .from(planSessions)
         .where(eq(planSessions.codespaceId, id));
@@ -421,7 +421,7 @@ export class CodespaceService {
       // plan_sessions table may not exist yet
     }
     try {
-      codspaceSandboxes = await this.db
+      codspaceSandboxIds = await this.db
         .select({ id: sandboxInstances.id })
         .from(sandboxInstances)
         .where(eq(sandboxInstances.codespaceId, id));
@@ -430,9 +430,9 @@ export class CodespaceService {
     }
 
     const eventSessionIds = [
-      ...codspaceSessions.map((s) => s.id),
-      ...codspacePlans.map((p) => `plan:${p.id}`),
-      ...codspaceSandboxes.map((s) => `sandbox:${s.id}`),
+      ...codespaceSessionIds.map((s) => s.id),
+      ...codspacePlanIds.map((p) => `plan:${p.id}`),
+      ...codspaceSandboxIds.map((s) => `sandbox:${s.id}`),
     ];
     if (eventSessionIds.length > 0) {
       await this.db.delete(sessionEvents).where(inArray(sessionEvents.sessionId, eventSessionIds));

--- a/src/services/durable-streams.service.ts
+++ b/src/services/durable-streams.service.ts
@@ -698,7 +698,18 @@ export class DurableStreamsService {
       try {
         memoryOffset = await this.server.publish(streamId, type, payload);
       } catch (caddyErr) {
-        log.debug('Caddy publish failed', {
+        if (isEphemeral) {
+          // Ephemeral streams have no DB fallback — surface the error so callers
+          // can decide how to handle it (e.g., throw for terminal events, swallow for status).
+          return err(
+            createError(
+              'STREAM_PUBLISH_FAILED',
+              caddyErr instanceof Error ? caddyErr.message : String(caddyErr),
+              500
+            )
+          );
+        }
+        log.debug('Caddy publish failed (durable — DB persisted)', {
           error: caddyErr instanceof Error ? caddyErr.message : String(caddyErr),
         });
       }

--- a/src/services/sandbox.service.ts
+++ b/src/services/sandbox.service.ts
@@ -160,22 +160,23 @@ export class SandboxService {
         await this.provider.pullImage(config.image);
       }
 
-      // Create container
-      const sandbox = await this.provider.create(config);
+      // Create container — pass our sandboxId so provider uses it as its ID.
+      // This ensures one consistent ID across stream, DB, and provider lookups.
+      const sandbox = await this.provider.create({ ...config, id: sandboxId });
 
       // Inject credentials - emit warning event if this fails so user is informed
       const credResult = await this.credentialsInjector.inject(sandbox);
       if (!credResult.ok) {
         // Emit warning event so user is aware credentials are missing
-        await this.streams.publish(`sandbox:${sandbox.id}`, 'sandbox:error', {
-          sandboxId: sandbox.id,
+        await this.streams.publish(streamId, 'sandbox:error', {
+          sandboxId,
           codespaceId: config.codespaceId,
           error: `Sandbox created but credentials injection failed: ${credResult.error.message}. Claude API/CLI access inside the sandbox may not work.`,
           code: 'CREDENTIALS_INJECTION_WARNING',
         });
       }
 
-      // Store in database
+      // Store in database — sandbox.id === sandboxId (provider used our ID)
       const dbSandbox: NewSandboxInstance = {
         id: sandbox.id,
         codespaceId: config.codespaceId,
@@ -194,8 +195,8 @@ export class SandboxService {
       const info = this.sandboxToInfo(sandbox, config);
 
       // Publish ready event
-      await this.streams.publish(`sandbox:${sandbox.id}`, 'sandbox:ready', {
-        sandboxId: sandbox.id,
+      await this.streams.publish(streamId, 'sandbox:ready', {
+        sandboxId,
         codespaceId: config.codespaceId,
         containerId: sandbox.containerId,
       });

--- a/src/services/terraform-compose.service.ts
+++ b/src/services/terraform-compose.service.ts
@@ -193,22 +193,27 @@ export class TerraformComposeService {
       throw ServiceErrors.STREAMS_REQUIRED;
     }
     const streamId = `terraform:${jobId}`;
+    const isTerminal = type === 'terraform:error' || type === 'terraform:done';
+    let result: Awaited<ReturnType<DurableStreamsService['publish']>>;
     try {
-      const result = await this.durableStreamsService.publish(streamId, type, data);
-      if (!result.ok) {
-        log.error('Failed to publish terraform event (Result error)', {
-          data: { type, jobId, error: result.error.message },
-        });
-        if (type === 'terraform:error' || type === 'terraform:done') {
-          throw new Error(result.error.message);
-        }
-      }
+      result = await this.durableStreamsService.publish(streamId, type, data);
     } catch (err) {
       log.error('Failed to publish terraform event', { data: { type, jobId }, error: err });
       // Rethrow for terminal events -- clients MUST receive done/error events
-      if (type === 'terraform:error' || type === 'terraform:done') {
+      if (isTerminal) {
         throw err;
       }
+      return;
+    }
+    // Check result outside try/catch to avoid double-logging when the throw
+    // for terminal events is caught by the same catch block
+    if (!result.ok) {
+      if (isTerminal) {
+        throw new Error(result.error.message);
+      }
+      log.error('Failed to publish terraform event (Result error)', {
+        data: { type, jobId, error: result.error.message },
+      });
     }
   }
 

--- a/tests/helpers/database.ts
+++ b/tests/helpers/database.ts
@@ -260,6 +260,7 @@ export async function clearTestDatabase(): Promise<void> {
   await testDb.delete(schema.eventSubscriptions);
   await testDb.delete(schema.eventSources);
   await testDb.delete(schema.agentRuns);
+  await testDb.delete(schema.sessionEvents);
   await testDb.delete(schema.sessions);
   await testDb.delete(schema.worktrees);
   await testDb.delete(schema.tasks);

--- a/tests/integration/durable-streams-terraform-publish.test.ts
+++ b/tests/integration/durable-streams-terraform-publish.test.ts
@@ -300,7 +300,7 @@ describe('DurableStreams: non-session stream publish (terraform, plan, task-crea
     expect(publishSpy).toHaveBeenCalledTimes(4);
   });
 
-  it('surfaces Caddy publish errors for terminal events', async () => {
+  it('surfaces Caddy publish errors for ephemeral streams (Caddy is only delivery path)', async () => {
     const jobId = createId();
     const streamId = `terraform:${jobId}`;
     publishSpy.mockRejectedValueOnce(new Error('Caddy unavailable'));
@@ -311,7 +311,23 @@ describe('DurableStreams: non-session stream publish (terraform, plan, task-crea
       stage: 'loading_catalog',
     });
 
-    // Non-terminal events should succeed even if Caddy fails (best-effort)
+    // Ephemeral streams (terraform:*) rely solely on Caddy — errors must propagate
+    expect(result.ok).toBe(false);
+  });
+
+  it('tolerates Caddy publish errors for durable (non-ephemeral) streams', async () => {
+    const sessionId = createId();
+    const streamId = `plan:${sessionId}`;
+    publishSpy.mockRejectedValueOnce(new Error('Caddy unavailable'));
+
+    await service.createStream(streamId, null);
+    const result = await service.publish(streamId, 'plan:started', {
+      sessionId,
+      taskId: createId(),
+      codespaceId: createId(),
+    });
+
+    // Durable streams persist to DB first — Caddy failure is best-effort
     expect(result.ok).toBe(true);
   });
 });

--- a/tests/services/sandbox.service.test.ts
+++ b/tests/services/sandbox.service.test.ts
@@ -85,7 +85,11 @@ const createMockSandbox = (overrides: Partial<Sandbox> = {}): Sandbox => ({
 
 const createMockProvider = (): SandboxProvider => ({
   name: 'mock',
-  create: vi.fn(),
+  create: vi
+    .fn()
+    .mockImplementation(async (cfg: SandboxConfig) =>
+      createMockSandbox({ id: cfg.id ?? 'sandbox-123', codespaceId: cfg.codespaceId })
+    ),
   get: vi.fn(),
   getById: vi.fn(),
   list: vi.fn().mockResolvedValue([]),
@@ -132,9 +136,6 @@ describe('SandboxService', () => {
 
   describe('Sandbox Creation', () => {
     it('creates a sandbox with valid configuration', async () => {
-      const mockSandbox = createMockSandbox();
-      (mockProvider.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockSandbox);
-
       const config: SandboxConfig = {
         codespaceId: 'project-123',
         codespacePath: '/path/to/project',
@@ -165,9 +166,7 @@ describe('SandboxService', () => {
     });
 
     it('pulls image if not available locally', async () => {
-      const mockSandbox = createMockSandbox();
       (mockProvider.isImageAvailable as ReturnType<typeof vi.fn>).mockResolvedValue(false);
-      (mockProvider.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockSandbox);
 
       const config: SandboxConfig = {
         codespaceId: 'project-123',
@@ -186,10 +185,17 @@ describe('SandboxService', () => {
     });
 
     it('emits warning when credentials injection fails', async () => {
-      const mockSandbox = createMockSandbox({
-        exec: vi.fn().mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'Permission denied' }),
-      });
-      (mockProvider.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockSandbox);
+      // Override create to return a sandbox whose exec fails (triggers credential injection warning)
+      (mockProvider.create as ReturnType<typeof vi.fn>).mockImplementation(
+        async (cfg: SandboxConfig) =>
+          createMockSandbox({
+            id: cfg.id ?? 'sandbox-123',
+            codespaceId: cfg.codespaceId,
+            exec: vi
+              .fn()
+              .mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'Permission denied' }),
+          })
+      );
 
       const config: SandboxConfig = {
         codespaceId: 'project-123',

--- a/tests/services/services-remaining.test.ts
+++ b/tests/services/services-remaining.test.ts
@@ -171,12 +171,16 @@ function createMockSandbox(overrides: Partial<Sandbox> = {}): Sandbox {
 }
 
 function createMockSandboxProvider(overrides: Partial<SandboxProvider> = {}): SandboxProvider {
-  const mockSandbox = createMockSandbox();
+  const defaultSandbox = createMockSandbox();
   return {
     name: 'mock-provider',
-    create: vi.fn().mockResolvedValue(mockSandbox),
-    get: vi.fn().mockResolvedValue(mockSandbox),
-    getById: vi.fn().mockResolvedValue(mockSandbox),
+    create: vi
+      .fn()
+      .mockImplementation(async (cfg: SandboxConfig) =>
+        createMockSandbox({ id: cfg.id ?? 'sandbox-123', codespaceId: cfg.codespaceId })
+      ),
+    get: vi.fn().mockResolvedValue(defaultSandbox),
+    getById: vi.fn().mockResolvedValue(defaultSandbox),
     list: vi.fn().mockResolvedValue([]),
     pullImage: vi.fn().mockResolvedValue(undefined),
     isImageAvailable: vi.fn().mockResolvedValue(true),
@@ -254,9 +258,7 @@ describe('SandboxService', () => {
         },
       });
 
-      // Create mock sandbox with matching project ID
-      const mockSandbox = createMockSandbox({ codespaceId: project.id });
-      vi.mocked(mockProvider.create).mockResolvedValueOnce(mockSandbox);
+      // Provider mock already echoes config.id and codespaceId from createMockSandboxProvider
 
       const config: SandboxConfig = {
         codespaceId: project.id,
@@ -276,7 +278,7 @@ describe('SandboxService', () => {
         expect(result.value.status).toBe('running');
         expect(result.value.image).toBe('node:22-slim');
       }
-      expect(mockProvider.create).toHaveBeenCalledWith(config);
+      expect(mockProvider.create).toHaveBeenCalledWith(expect.objectContaining(config));
     });
 
     it('returns existing sandbox if already running for project', async () => {

--- a/tests/services/terraform-compose.service.test.ts
+++ b/tests/services/terraform-compose.service.test.ts
@@ -102,7 +102,7 @@ function createMockDurableStreamsService(overrides: Record<string, unknown> = {}
     if (eventType === 'terraform:done' || eventType === 'terraform:error') {
       _resolvePipelineDone?.();
     }
-    return Promise.resolve({ ok: true, data: 0 });
+    return Promise.resolve({ ok: true, value: 0 });
   });
 
   return {

--- a/tests/services/terraform-compose.service.test.ts
+++ b/tests/services/terraform-compose.service.test.ts
@@ -102,7 +102,7 @@ function createMockDurableStreamsService(overrides: Record<string, unknown> = {}
     if (eventType === 'terraform:done' || eventType === 'terraform:error') {
       _resolvePipelineDone?.();
     }
-    return Promise.resolve(undefined);
+    return Promise.resolve({ ok: true, data: 0 });
   });
 
   return {


### PR DESCRIPTION
## Summary
- **Sandbox stream ID consistency**: Pre-assign sandbox ID via `SandboxConfig.id` so one ID flows through stream, DB, and provider. Eliminates orphaned `sandbox:creating` events from ID mismatches between service and provider.
- **Ephemeral stream error propagation**: `DurableStreamsService` returns `err()` for Caddy failures on ephemeral (terraform) streams. `publishEvent()` throws only for terminal events, logs for status.
- **Postgres FK removal**: Remove `session_events.session_id` FK constraint in postgres schema to match SQLite (supports plan/sandbox/terraform stream IDs).
- **Orphan cleanup**: `codespace.service.ts` wraps plan/sandbox queries in try-catch for pre-migration DBs. ORM fallback in `clearTestDatabase` deletes `session_events` before `sessions`.
- **CLAUDE.md**: Document durable stream ID patterns with persistence/cleanup reference table.

## Test plan
- [x] 7428 tests passing (334 files, full suite)
- [x] Sandbox service tests: create, pull image, credential injection warning
- [x] Terraform compose pipeline tests: status, text, code, done events
- [x] Durable streams tests: ephemeral vs durable publish, Caddy error handling
- [x] Codespace lifecycle tests: cascade deletion with session_events cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
