### PR TITLE
Add context optimization and insight effectiveness scoring

### DIFF
--- a/src/app/components/features/memory-view/dream-session-card.tsx
+++ b/src/app/components/features/memory-view/dream-session-card.tsx
@@ -14,12 +14,14 @@ const TYPE_LABELS: Record<string, string> = {
   conclusion_derivation: 'Conclusions',
   skill_improvement: 'Skills',
   metrics_rollup: 'Metrics',
+  context_optimization: 'Context Optimization',
 };
 
 const TYPE_BADGE_STYLES: Record<string, string> = {
   conclusion_derivation: 'bg-accent-subtle text-accent',
   skill_improvement: 'bg-done-subtle text-done',
   metrics_rollup: 'bg-success-subtle text-success',
+  context_optimization: 'bg-secondary-subtle text-secondary',
 };
 
 const STATUS_DOT_STYLES: Record<string, string> = {

--- a/src/app/components/features/memory-view/dream-session-card.tsx
+++ b/src/app/components/features/memory-view/dream-session-card.tsx
@@ -10,21 +10,21 @@ interface DreamSessionCardProps {
   isLast?: boolean;
 }
 
-const TYPE_LABELS: Record<string, string> = {
+const TYPE_LABELS: Record<DreamSession['type'], string> = {
   conclusion_derivation: 'Conclusions',
   skill_improvement: 'Skills',
   metrics_rollup: 'Metrics',
   context_optimization: 'Context Optimization',
 };
 
-const TYPE_BADGE_STYLES: Record<string, string> = {
+const TYPE_BADGE_STYLES: Record<DreamSession['type'], string> = {
   conclusion_derivation: 'bg-accent-subtle text-accent',
   skill_improvement: 'bg-done-subtle text-done',
   metrics_rollup: 'bg-success-subtle text-success',
   context_optimization: 'bg-secondary-subtle text-secondary',
 };
 
-const STATUS_DOT_STYLES: Record<string, string> = {
+const STATUS_DOT_STYLES: Record<DreamSession['status'], string> = {
   running: 'border-accent bg-accent animate-pulse',
   completed: 'border-success bg-success',
   error: 'border-danger bg-danger',

--- a/src/app/components/features/memory-view/insight-card.tsx
+++ b/src/app/components/features/memory-view/insight-card.tsx
@@ -1,7 +1,23 @@
-import { ArrowsClockwise, CaretRight, Check, Clock, Tag, Trash, X } from '@phosphor-icons/react';
+import {
+  ArrowsClockwise,
+  CaretRight,
+  Check,
+  Clock,
+  Tag,
+  Trash,
+  TrendDown,
+  TrendUp,
+  X,
+} from '@phosphor-icons/react';
 import type React from 'react';
 import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/app/components/ui/tooltip';
 import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import { formatRelativeDate } from './formatters';
@@ -73,12 +89,60 @@ interface InsightCardProps {
     status?: 'active' | 'pending_review' | 'rejected';
     category?: string | null;
     updatedAt?: string | null;
+    effectivenessScore?: number | null;
   };
   injections: Array<InsightInjection> | undefined;
   onDelete: (id: string) => undefined | Promise<boolean>;
   onExpand: (insightId: string) => void;
   onApprove?: (id: string) => undefined | Promise<unknown>;
   onReject?: (id: string) => undefined | Promise<unknown>;
+}
+
+function EffectivenessScoreBadge({
+  score,
+}: {
+  score: number | null | undefined;
+}): React.JSX.Element | null {
+  if (score == null) return null;
+
+  const pct = Math.round(score * 100);
+  const isPositive = score > 0;
+  const isNeutral = score === 0;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
+              isPositive && 'bg-success-subtle text-success',
+              isNeutral && 'bg-surface-muted text-fg-muted',
+              !isPositive && !isNeutral && 'bg-danger-subtle text-danger'
+            )}
+          >
+            {isPositive ? (
+              <TrendUp size={10} weight="bold" />
+            ) : isNeutral ? null : (
+              <TrendDown size={10} weight="bold" />
+            )}
+            {isPositive ? '+' : ''}
+            {pct}%
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[220px]">
+          <p className="font-medium">Effectiveness Score</p>
+          <p className="mt-0.5 text-fg-muted">
+            {isPositive
+              ? 'This insight correlates with successful task outcomes.'
+              : isNeutral
+                ? 'Neutral impact on task outcomes.'
+                : 'This insight correlates with task failures.'}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
 }
 
 function InjectionBadge({ count }: { count: number | undefined }): React.JSX.Element | null {
@@ -280,6 +344,7 @@ export function InsightCard({
               : formatRelativeDate(insight.createdAt)}
           </span>
           <InjectionBadge count={injectionCount} />
+          <EffectivenessScoreBadge score={insight.effectivenessScore} />
         </div>
         <div className="flex items-center gap-1">
           <Button

--- a/src/app/components/features/memory-view/insight-card.tsx
+++ b/src/app/components/features/memory-view/insight-card.tsx
@@ -12,21 +12,18 @@ import {
 import type React from 'react';
 import { useState } from 'react';
 import { Button } from '@/app/components/ui/button';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/app/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/app/components/ui/tooltip';
 import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import { cn } from '@/lib/utils/cn';
 import { formatRelativeDate } from './formatters';
 import { InsightSourceBadge } from './insight-source-badge';
-import type { InsightInjection } from './types';
+import type { Insight, InsightInjection } from './types';
 
 // =============================================================================
 // Constants
 // =============================================================================
+
+type InsightCategory = NonNullable<Insight['category']>;
 
 const INSIGHT_TAG_COLORS = [
   { bg: 'bg-accent-muted', text: 'text-accent' },
@@ -42,7 +39,7 @@ function getInsightTagColor(tag: string): { bg: string; text: string } {
   return INSIGHT_TAG_COLORS[hash % INSIGHT_TAG_COLORS.length] ?? INSIGHT_TAG_COLORS[0];
 }
 
-const CATEGORY_STYLES: Record<string, string> = {
+const CATEGORY_STYLES: Record<InsightCategory, string> = {
   pattern: 'bg-accent-subtle text-accent',
   anti_pattern: 'bg-danger-subtle text-danger',
   decision: 'bg-done-subtle text-done',
@@ -50,7 +47,7 @@ const CATEGORY_STYLES: Record<string, string> = {
   error_lesson: 'bg-attention-subtle text-attention',
 };
 
-const CATEGORY_LABELS: Record<string, string> = {
+const CATEGORY_LABELS: Record<InsightCategory, string> = {
   pattern: 'Pattern',
   anti_pattern: 'Anti-Pattern',
   decision: 'Decision',
@@ -58,7 +55,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   error_lesson: 'Error Lesson',
 };
 
-const CATEGORY_DOT_COLORS: Record<string, string> = {
+const CATEGORY_DOT_COLORS: Record<InsightCategory, string> = {
   pattern: 'bg-accent',
   anti_pattern: 'bg-danger',
   decision: 'bg-done',
@@ -66,7 +63,7 @@ const CATEGORY_DOT_COLORS: Record<string, string> = {
   error_lesson: 'bg-attention',
 };
 
-const CATEGORY_GRADIENTS: Record<string, string> = {
+const CATEGORY_GRADIENTS: Record<InsightCategory, string> = {
   pattern: 'linear-gradient(135deg, rgba(88,166,255,0.07) 0%, transparent 50%)',
   anti_pattern: 'linear-gradient(135deg, rgba(218,54,51,0.06) 0%, transparent 50%)',
   decision: 'linear-gradient(135deg, rgba(163,113,247,0.06) 0%, transparent 50%)',
@@ -74,23 +71,31 @@ const CATEGORY_GRADIENTS: Record<string, string> = {
   error_lesson: 'linear-gradient(135deg, rgba(210,153,34,0.07) 0%, transparent 50%)',
 };
 
+function isCategoryKey(key: string | null | undefined): key is InsightCategory {
+  return key != null && key in CATEGORY_STYLES;
+}
+
 // =============================================================================
 // Sub-components
 // =============================================================================
 
+/** Shared shape for insight data passed to InsightCard. */
+export interface InsightData {
+  id: string;
+  content: string;
+  source: string;
+  tags: string[];
+  createdAt: string;
+  skillId: string | null;
+  status?: 'active' | 'pending_review' | 'rejected';
+  category?: string | null;
+  updatedAt?: string | null;
+  /** Effectiveness score in [-1, 1]. Displayed as a percentage. */
+  effectivenessScore?: number | null;
+}
+
 interface InsightCardProps {
-  insight: {
-    id: string;
-    content: string;
-    source: string;
-    tags: string[];
-    createdAt: string;
-    skillId: string | null;
-    status?: 'active' | 'pending_review' | 'rejected';
-    category?: string | null;
-    updatedAt?: string | null;
-    effectivenessScore?: number | null;
-  };
+  insight: InsightData;
   injections: Array<InsightInjection> | undefined;
   onDelete: (id: string) => undefined | Promise<boolean>;
   onExpand: (insightId: string) => void;
@@ -105,43 +110,44 @@ function EffectivenessScoreBadge({
 }): React.JSX.Element | null {
   if (score == null) return null;
 
-  const pct = Math.round(score * 100);
-  const isPositive = score > 0;
-  const isNeutral = score === 0;
+  const clamped = Math.max(-1, Math.min(1, score));
+  const pct = Math.round(clamped * 100);
+  const isPositive = pct > 0;
+  const isNegative = pct < 0;
+
+  let description: string;
+  if (isPositive) {
+    description = 'This insight correlates with successful task outcomes.';
+  } else if (isNegative) {
+    description = 'This insight correlates with task failures.';
+  } else {
+    description = 'Neutral impact on task outcomes.';
+  }
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={cn(
-              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
-              isPositive && 'bg-success-subtle text-success',
-              isNeutral && 'bg-surface-muted text-fg-muted',
-              !isPositive && !isNeutral && 'bg-danger-subtle text-danger'
-            )}
-          >
-            {isPositive ? (
-              <TrendUp size={10} weight="bold" />
-            ) : isNeutral ? null : (
-              <TrendDown size={10} weight="bold" />
-            )}
-            {isPositive ? '+' : ''}
-            {pct}%
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-[220px]">
-          <p className="font-medium">Effectiveness Score</p>
-          <p className="mt-0.5 text-fg-muted">
-            {isPositive
-              ? 'This insight correlates with successful task outcomes.'
-              : isNeutral
-                ? 'Neutral impact on task outcomes.'
-                : 'This insight correlates with task failures.'}
-          </p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Effectiveness score: ${isPositive ? '+' : ''}${pct}%`}
+          className={cn(
+            'inline-flex cursor-help items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
+            isPositive && 'bg-success-subtle text-success',
+            isNegative && 'bg-danger-subtle text-danger',
+            !isPositive && !isNegative && 'bg-surface-muted text-fg-muted'
+          )}
+        >
+          {isPositive && <TrendUp size={10} weight="bold" />}
+          {isNegative && <TrendDown size={10} weight="bold" />}
+          {isPositive ? '+' : ''}
+          {pct}%
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-[220px]">
+        <p className="font-medium">Effectiveness Score</p>
+        <p className="mt-0.5 text-fg-muted">{description}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -240,7 +246,7 @@ export function InsightCard({
       return { background: 'linear-gradient(135deg, rgba(218,54,51,0.05) 0%, transparent 40%)' };
     }
     // Category-based gradient
-    if (insight.category && CATEGORY_GRADIENTS[insight.category]) {
+    if (isCategoryKey(insight.category)) {
       return { background: CATEGORY_GRADIENTS[insight.category] };
     }
     // Fallback: neutral
@@ -299,19 +305,17 @@ export function InsightCard({
         <span
           className={cn(
             'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
-            insight.category && CATEGORY_STYLES[insight.category]
+            isCategoryKey(insight.category)
               ? CATEGORY_STYLES[insight.category]
               : 'bg-surface-muted text-fg-muted'
           )}
         >
-          {insight.category && CATEGORY_DOT_COLORS[insight.category] && (
+          {isCategoryKey(insight.category) && (
             <span
               className={cn('h-1.5 w-1.5 rounded-full', CATEGORY_DOT_COLORS[insight.category])}
             />
           )}
-          {insight.category && CATEGORY_LABELS[insight.category]
-            ? CATEGORY_LABELS[insight.category]
-            : 'Uncategorized'}
+          {isCategoryKey(insight.category) ? CATEGORY_LABELS[insight.category] : 'Uncategorized'}
         </span>
 
         {/* Status pill — always show */}

--- a/src/app/components/features/memory-view/memory-insights-tab.tsx
+++ b/src/app/components/features/memory-view/memory-insights-tab.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useCallback } from 'react';
 import { cn } from '@/lib/utils/cn';
 import { INPUT_CLASS } from './formatters';
+import type { InsightData } from './insight-card';
 import { InsightCard } from './insight-card';
 import { useMemory } from './memory-context';
 import type { Insight, InsightCategoryFilter, InsightStatusFilter, SearchResult } from './types';
@@ -97,18 +98,7 @@ function EmptyState({
   );
 }
 
-function toInsightCardProps(item: Insight | SearchResult): {
-  id: string;
-  content: string;
-  source: string;
-  tags: string[];
-  createdAt: string;
-  skillId: string | null;
-  status?: 'active' | 'pending_review' | 'rejected';
-  category?: string | null;
-  updatedAt?: string | null;
-  effectivenessScore?: number | null;
-} {
+function toInsightCardProps(item: Insight | SearchResult): InsightData {
   if ('source' in item) {
     return item;
   }

--- a/src/app/components/features/memory-view/memory-insights-tab.tsx
+++ b/src/app/components/features/memory-view/memory-insights-tab.tsx
@@ -107,6 +107,7 @@ function toInsightCardProps(item: Insight | SearchResult): {
   status?: 'active' | 'pending_review' | 'rejected';
   category?: string | null;
   updatedAt?: string | null;
+  effectivenessScore?: number | null;
 } {
   if ('source' in item) {
     return item;
@@ -121,6 +122,7 @@ function toInsightCardProps(item: Insight | SearchResult): {
     status: 'active' as const,
     category: null,
     updatedAt: null,
+    effectivenessScore: null,
   };
 }
 

--- a/src/app/components/features/memory-view/memory-overview.tsx
+++ b/src/app/components/features/memory-view/memory-overview.tsx
@@ -341,8 +341,8 @@ export function MemoryOverview(): React.JSX.Element {
         <h3 className="text-xs font-medium uppercase tracking-wider text-fg-subtle">Research</h3>
         <div className="rounded-xl border border-border bg-surface p-4">
           <div className="flex items-start gap-3">
-            <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-[rgba(163,113,247,0.12)]">
-              <Flask size={18} className="text-[#a371f7]" />
+            <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-done-subtle">
+              <Flask size={18} className="text-done" />
             </div>
             <div className="flex flex-col gap-1.5">
               <p className="text-sm text-fg">

--- a/src/app/components/features/memory-view/memory-overview.tsx
+++ b/src/app/components/features/memory-view/memory-overview.tsx
@@ -1,9 +1,11 @@
 import {
   ArrowRight,
+  ArrowSquareOut,
   Brain,
   ChartBar,
   CircleNotch,
   Eye,
+  Flask,
   Lightbulb,
   Sparkle,
 } from '@phosphor-icons/react';
@@ -332,6 +334,44 @@ export function MemoryOverview(): React.JSX.Element {
           Recent Activity
         </h3>
         <ActivityFeed items={recentActivity} />
+      </div>
+
+      {/* Research references */}
+      <div className="flex flex-col gap-3">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-fg-subtle">Research</h3>
+        <div className="rounded-xl border border-border bg-surface p-4">
+          <div className="flex items-start gap-3">
+            <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-[rgba(163,113,247,0.12)]">
+              <Flask size={18} className="text-[#a371f7]" />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <p className="text-sm text-fg">
+                AgentPane's memory system is inspired by research on automated context optimization
+                for LLM agents.
+              </p>
+              <div className="flex flex-col gap-1">
+                <a
+                  href="https://yoonholee.com/meta-harness/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group inline-flex items-center gap-1.5 text-xs text-accent hover:text-accent-emphasis transition-colors"
+                >
+                  <span className="font-medium">
+                    Meta-Harness: End-to-End Optimization of Model Harnesses
+                  </span>
+                  <ArrowSquareOut
+                    size={12}
+                    className="opacity-60 group-hover:opacity-100 transition-opacity"
+                  />
+                </a>
+                <span className="text-[11px] text-fg-subtle">
+                  Lee et al., Stanford &amp; MIT, 2026 — Credit assignment and outer-loop
+                  optimization for context selection
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/components/features/memory-view/memory-overview.tsx
+++ b/src/app/components/features/memory-view/memory-overview.tsx
@@ -365,7 +365,7 @@ export function MemoryOverview(): React.JSX.Element {
                   />
                 </a>
                 <span className="text-[11px] text-fg-subtle">
-                  Lee et al., Stanford &amp; MIT, 2026 — Credit assignment and outer-loop
+                  Lee et al., Stanford &amp; MIT, 2024 — Credit assignment and outer-loop
                   optimization for context selection
                 </span>
               </div>

--- a/src/app/components/features/memory-view/suggestion-card.tsx
+++ b/src/app/components/features/memory-view/suggestion-card.tsx
@@ -14,7 +14,7 @@ export interface SuggestionCardProps {
   onModify: (id: string) => void;
 }
 
-const TYPE_BADGE_STYLES: Record<string, string> = {
+const TYPE_BADGE_STYLES: Record<SkillSuggestion['suggestionType'], string> = {
   improve_prompt: 'bg-accent-subtle text-accent',
   add_example: 'bg-success-subtle text-success',
   fix_pattern: 'bg-attention-subtle text-attention',
@@ -22,14 +22,14 @@ const TYPE_BADGE_STYLES: Record<string, string> = {
   optimize_context: 'bg-secondary-subtle text-secondary',
 };
 
-const STATUS_BADGE_STYLES: Record<string, string> = {
+const STATUS_BADGE_STYLES: Record<SkillSuggestion['status'], string> = {
   pending: 'bg-attention-subtle text-attention',
   accepted: 'bg-success-subtle text-success',
   rejected: 'bg-danger-subtle text-danger',
   modified: 'bg-accent-subtle text-accent',
 };
 
-const TYPE_LABELS: Record<string, string> = {
+const TYPE_LABELS: Record<SkillSuggestion['suggestionType'], string> = {
   improve_prompt: 'Improve Prompt',
   add_example: 'Add Example',
   fix_pattern: 'Fix Pattern',

--- a/src/app/components/features/memory-view/suggestion-card.tsx
+++ b/src/app/components/features/memory-view/suggestion-card.tsx
@@ -19,6 +19,7 @@ const TYPE_BADGE_STYLES: Record<string, string> = {
   add_example: 'bg-success-subtle text-success',
   fix_pattern: 'bg-attention-subtle text-attention',
   new_skill: 'bg-done-subtle text-done',
+  optimize_context: 'bg-secondary-subtle text-secondary',
 };
 
 const STATUS_BADGE_STYLES: Record<string, string> = {
@@ -33,6 +34,7 @@ const TYPE_LABELS: Record<string, string> = {
   add_example: 'Add Example',
   fix_pattern: 'Fix Pattern',
   new_skill: 'New Skill',
+  optimize_context: 'Optimize Context',
 };
 
 function formatStatus(status: string): string {

--- a/src/db/schema/postgres/dream-sessions.ts
+++ b/src/db/schema/postgres/dream-sessions.ts
@@ -10,7 +10,9 @@ export const dreamSessions = pgTable(
       .$defaultFn(() => createId()),
     codespaceId: text('codespace_id').references(() => codespaces.id, { onDelete: 'cascade' }),
     type: text('type')
-      .$type<'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup'>()
+      .$type<
+        'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup' | 'context_optimization'
+      >()
       .notNull(),
     status: text('status').$type<'running' | 'completed' | 'error'>().notNull(),
     skillsAnalyzed: integer('skills_analyzed').default(0).notNull(),

--- a/src/db/schema/postgres/memory-insights.ts
+++ b/src/db/schema/postgres/memory-insights.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
-import { index, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { doublePrecision, index, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { codespaces } from './codespaces';
 import { sessions } from './sessions';
 
@@ -27,6 +27,7 @@ export const memoryInsights = pgTable(
     category: text('category').$type<
       'pattern' | 'anti_pattern' | 'decision' | 'architecture' | 'error_lesson'
     >(),
+    effectivenessScore: doublePrecision('effectiveness_score'),
     updatedAt: timestamp('updated_at', { mode: 'string' }),
     createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
   },

--- a/src/db/schema/postgres/skill-suggestions.ts
+++ b/src/db/schema/postgres/skill-suggestions.ts
@@ -18,7 +18,7 @@ export const skillSuggestions = pgTable(
     skillId: text('skill_id').notNull(),
     skillName: text('skill_name').notNull(),
     suggestionType: text('suggestion_type')
-      .$type<'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill'>()
+      .$type<'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill' | 'optimize_context'>()
       .notNull(),
     title: text('title').notNull(),
     reasoning: text('reasoning').notNull(),

--- a/src/db/schema/sqlite/dream-sessions.ts
+++ b/src/db/schema/sqlite/dream-sessions.ts
@@ -11,7 +11,9 @@ export const dreamSessions = sqliteTable(
       .$defaultFn(() => createId()),
     codespaceId: text('codespace_id').references(() => codespaces.id, { onDelete: 'cascade' }),
     type: text('type')
-      .$type<'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup'>()
+      .$type<
+        'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup' | 'context_optimization'
+      >()
       .notNull(),
     status: text('status').$type<'running' | 'completed' | 'error'>().notNull(),
     skillsAnalyzed: integer('skills_analyzed').default(0).notNull(),

--- a/src/db/schema/sqlite/memory-insights.ts
+++ b/src/db/schema/sqlite/memory-insights.ts
@@ -1,6 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import { sql } from 'drizzle-orm';
-import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { codespaces } from './codespaces';
 import { sessions } from './sessions';
 
@@ -28,6 +28,7 @@ export const memoryInsights = sqliteTable(
     category: text('category').$type<
       'pattern' | 'anti_pattern' | 'decision' | 'architecture' | 'error_lesson'
     >(),
+    effectivenessScore: real('effectiveness_score'),
     updatedAt: text('updated_at'),
     createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
   },

--- a/src/db/schema/sqlite/skill-suggestions.ts
+++ b/src/db/schema/sqlite/skill-suggestions.ts
@@ -19,7 +19,7 @@ export const skillSuggestions = sqliteTable(
     skillId: text('skill_id').notNull(),
     skillName: text('skill_name').notNull(),
     suggestionType: text('suggestion_type')
-      .$type<'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill'>()
+      .$type<'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill' | 'optimize_context'>()
       .notNull(),
     title: text('title').notNull(),
     reasoning: text('reasoning').notNull(),

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -276,4 +276,11 @@ END;
       `ALTER TABLE skill_executions ADD COLUMN insight_ids_used TEXT`,
     ],
   },
+
+  // 28. Memory insight effectiveness score column
+  {
+    version: 28,
+    name: 'memory-insight-effectiveness-score',
+    statements: [`ALTER TABLE memory_insights ADD COLUMN effectiveness_score REAL`],
+  },
 ];

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -16,7 +16,7 @@ import { resolveModel } from '../../lib/utils/resolve-model.js';
 import type { Result } from '../../lib/utils/result.js';
 import { err, ok } from '../../lib/utils/result.js';
 import type { Database } from '../../types/database.js';
-import type { MemoryService, MemorySessionRef } from '../memory/index.js';
+import type { MemoryService, MemorySessionRef, TaskOutcome } from '../memory/index.js';
 import type { SkillTrackingService } from '../memory/skill-tracking.service.js';
 import { createSessionEventWithMetadata } from '../session/event-metadata.js';
 import { getGlobalDefaultModel } from '../settings.service.js';
@@ -77,6 +77,8 @@ export class AgentExecutionService {
   private agentStartTimes = new Map<string, number>();
   private preToolHooks = new Map<string, PreToolUseHook[]>();
   private postToolHooks = new Map<string, PostToolUseHook[]>();
+  /** Insight IDs injected into agent prompts, keyed by agentId. Used for skill execution tracking. */
+  private agentInsightIds = new Map<string, string[]>();
   private queueService: AgentQueueService | null = null;
   private memoryService: MemoryService | null = null;
   private skillTrackingService: SkillTrackingService | null = null;
@@ -151,10 +153,11 @@ export class AgentExecutionService {
   private finalizeMemorySession(
     memoryRef: MemorySessionRef | null,
     agentId: string,
-    phase: string
+    phase: string,
+    outcome?: TaskOutcome
   ): void {
     if (!memoryRef || !this.memoryService) return;
-    this.memoryService.finalizeSession(memoryRef).catch((finalizeErr) => {
+    this.memoryService.finalizeSession(memoryRef, outcome).catch((finalizeErr) => {
       log.warn(`Failed to finalize memory session after ${phase}`, {
         error: finalizeErr instanceof Error ? finalizeErr : new Error(String(finalizeErr)),
         data: { agentId },
@@ -168,6 +171,7 @@ export class AgentExecutionService {
   private async recordSkillExecutionForTask(params: {
     taskId: string;
     agentRunId: string;
+    agentId?: string;
     sessionId: string;
     status: 'completed' | 'error' | 'turn_limit' | 'paused' | 'planning';
     turnCount: number;
@@ -180,6 +184,12 @@ export class AgentExecutionService {
       columns: { skillId: true, skillName: true, codespaceId: true, startedAt: true },
     });
     if (!taskForSkill?.skillId) return;
+
+    // Retrieve insight IDs that were injected into this agent's prompt
+    const insightIdsUsed = params.agentId
+      ? (this.agentInsightIds.get(params.agentId) ?? null)
+      : null;
+
     this.recordSkillExecution({
       codespaceId: taskForSkill.codespaceId,
       taskId: params.taskId,
@@ -192,6 +202,7 @@ export class AgentExecutionService {
       metrics: params.metrics,
       errorMessage: params.errorMessage,
       startedAt: taskForSkill.startedAt,
+      insightIdsUsed,
     });
   }
 
@@ -223,6 +234,7 @@ export class AgentExecutionService {
     };
     errorMessage?: string;
     startedAt?: string | null;
+    insightIdsUsed?: string[] | null;
   }): void {
     if (!this.skillTrackingService || !params.skillId) return;
 
@@ -261,6 +273,7 @@ export class AgentExecutionService {
         durationMs: params.metrics?.durationMs ?? null,
         costUsd: params.metrics?.totalCostUsd ?? null,
         errorMessage: params.errorMessage ?? null,
+        insightIdsUsed: params.insightIdsUsed ?? null,
         startedAt: params.startedAt ?? null,
         completedAt: now,
       })
@@ -493,6 +506,11 @@ export class AgentExecutionService {
             },
           });
 
+          // Track which insights were injected for skill execution recording
+          if (memoryResult.value.sources.insightIds.length > 0) {
+            this.agentInsightIds.set(agentId, memoryResult.value.sources.insightIds);
+          }
+
           if (memoryResult.value.sources.insightIds.length > 0) {
             await this.sessionService.publish(
               session.value.id,
@@ -711,6 +729,7 @@ export class AgentExecutionService {
       this.recordSkillExecutionForTask({
         taskId,
         agentRunId: runId,
+        agentId,
         sessionId,
         status: result.status,
         turnCount: result.turnCount,
@@ -724,6 +743,7 @@ export class AgentExecutionService {
 
       this.runningAgents.delete(agentId);
       this.agentStartTimes.delete(agentId);
+      this.agentInsightIds.delete(agentId);
       this.preToolHooks.delete(agentId);
       this.postToolHooks.delete(agentId);
 
@@ -768,6 +788,7 @@ export class AgentExecutionService {
       this.recordSkillExecutionForTask({
         taskId,
         agentRunId: runId,
+        agentId,
         sessionId,
         status: 'error',
         turnCount: 0,
@@ -1090,7 +1111,16 @@ export class AgentExecutionService {
         onMessage: this.buildOnMessageCallback(memoryRef, this.memoryService),
       });
 
-      this.finalizeMemorySession(memoryRef, agentId, 'execution');
+      const executionOutcome: TaskOutcome = {
+        status:
+          result.status === 'completed'
+            ? 'success'
+            : result.status === 'turn_limit'
+              ? 'turn_limit'
+              : 'failed',
+        turnsUsed: result.turnCount,
+      };
+      this.finalizeMemorySession(memoryRef, agentId, 'execution', executionOutcome);
 
       const dbStatus = this.mapStatusToDb(result.status);
       await this.db
@@ -1151,6 +1181,7 @@ export class AgentExecutionService {
       this.recordSkillExecutionForTask({
         taskId: task.id,
         agentRunId: runId,
+        agentId,
         sessionId,
         status: result.status,
         turnCount: result.turnCount,
@@ -1164,6 +1195,7 @@ export class AgentExecutionService {
 
       this.runningAgents.delete(agentId);
       this.agentStartTimes.delete(agentId);
+      this.agentInsightIds.delete(agentId);
       this.preToolHooks.delete(agentId);
       this.postToolHooks.delete(agentId);
 
@@ -1178,7 +1210,9 @@ export class AgentExecutionService {
       }
     } catch (error) {
       log.error('Agent execution failed', { error, data: { agentId } });
-      this.finalizeMemorySession(memoryRef, agentId, 'execution error');
+      this.finalizeMemorySession(memoryRef, agentId, 'execution error', {
+        status: 'failed',
+      });
 
       const errMsg = errorMessage(error);
 
@@ -1209,6 +1243,7 @@ export class AgentExecutionService {
       this.recordSkillExecutionForTask({
         taskId: task.id,
         agentRunId: runId,
+        agentId,
         sessionId,
         status: 'error',
         turnCount: 0,

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -172,6 +172,7 @@ export class AgentExecutionService {
     taskId: string;
     agentRunId: string;
     agentId?: string;
+    insightIds?: string[] | null;
     sessionId: string;
     status: 'completed' | 'error' | 'turn_limit' | 'paused' | 'planning';
     turnCount: number;
@@ -185,10 +186,7 @@ export class AgentExecutionService {
     });
     if (!taskForSkill?.skillId) return;
 
-    // Retrieve insight IDs that were injected into this agent's prompt
-    const insightIdsUsed = params.agentId
-      ? (this.agentInsightIds.get(params.agentId) ?? null)
-      : null;
+    const insightIdsUsed = params.insightIds ?? null;
 
     this.recordSkillExecution({
       codespaceId: taskForSkill.codespaceId,
@@ -494,7 +492,9 @@ export class AgentExecutionService {
       try {
         const memoryResult = await this.memoryService.getContext(
           agent.codespaceId,
-          task.title ?? ''
+          task.title ?? '',
+          undefined,
+          task.skillId ?? null
         );
         if (memoryResult.ok && memoryResult.value.text) {
           taskPrompt = `${taskPrompt}\n\n---\n\n${memoryResult.value.text}`;
@@ -506,12 +506,9 @@ export class AgentExecutionService {
             },
           });
 
-          // Track which insights were injected for skill execution recording
+          // Track which insights were injected for skill execution recording and notify UI
           if (memoryResult.value.sources.insightIds.length > 0) {
             this.agentInsightIds.set(agentId, memoryResult.value.sources.insightIds);
-          }
-
-          if (memoryResult.value.sources.insightIds.length > 0) {
             await this.sessionService.publish(
               session.value.id,
               createSessionEventWithMetadata({
@@ -726,10 +723,14 @@ export class AgentExecutionService {
           .where(eq(agents.id, agentId));
       }
 
+      // Read insight IDs before cleanup deletes them (fire-and-forget race fix)
+      const planInsightIds = this.agentInsightIds.get(agentId) ?? null;
+
       this.recordSkillExecutionForTask({
         taskId,
         agentRunId: runId,
         agentId,
+        insightIds: planInsightIds,
         sessionId,
         status: result.status,
         turnCount: result.turnCount,
@@ -758,7 +759,7 @@ export class AgentExecutionService {
       }
     } catch (error) {
       log.error('Agent execution failed', { error, data: { agentId } });
-      this.finalizeMemorySession(memoryRef, agentId, 'planning error');
+      this.finalizeMemorySession(memoryRef, agentId, 'planning error', { status: 'failed' });
 
       const errMsg = errorMessage(error);
       const recovery = handleAgentError(error instanceof Error ? error : new Error(errMsg), {
@@ -1119,6 +1120,7 @@ export class AgentExecutionService {
               ? 'turn_limit'
               : 'failed',
         turnsUsed: result.turnCount,
+        insightIdsUsed: this.agentInsightIds.get(agentId) ?? null,
       };
       this.finalizeMemorySession(memoryRef, agentId, 'execution', executionOutcome);
 
@@ -1178,10 +1180,14 @@ export class AgentExecutionService {
           .where(eq(agents.id, agentId));
       }
 
+      // Read insight IDs before cleanup deletes them (fire-and-forget race fix)
+      const execInsightIds = this.agentInsightIds.get(agentId) ?? null;
+
       this.recordSkillExecutionForTask({
         taskId: task.id,
         agentRunId: runId,
         agentId,
+        insightIds: execInsightIds,
         sessionId,
         status: result.status,
         turnCount: result.turnCount,

--- a/src/services/memory/__tests__/memory.service.test.ts
+++ b/src/services/memory/__tests__/memory.service.test.ts
@@ -177,6 +177,7 @@ describe('MemoryService', () => {
         'cs-1',
         'test query',
         undefined,
+        undefined,
         undefined
       );
       expect(result.ok).toBe(true);

--- a/src/services/memory/__tests__/memory.service.test.ts
+++ b/src/services/memory/__tests__/memory.service.test.ts
@@ -308,7 +308,7 @@ describe('MemoryService', () => {
 
       await service.finalizeSession(ref);
 
-      expect(deriver.deriveInsights).toHaveBeenCalledWith('msess-1', 'cs-1');
+      expect(deriver.deriveInsights).toHaveBeenCalledWith('msess-1', 'cs-1', undefined);
     });
 
     it('swallows derivation errors', async () => {

--- a/src/services/memory/dream.service.ts
+++ b/src/services/memory/dream.service.ts
@@ -13,7 +13,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { and, desc, eq, or } from 'drizzle-orm';
+import { and, desc, eq, or, sql } from 'drizzle-orm';
 import { agentPrompt } from '../../lib/agents/agent-sdk-utils.js';
 import type { MemoryError } from '../../lib/errors/memory-errors.js';
 import { MemoryErrors } from '../../lib/errors/memory-errors.js';
@@ -101,7 +101,7 @@ If the skill is performing well (>90% success rate, reasonable token usage), you
 Only return the JSON array, no additional text.`;
 
 interface ParsedSuggestion {
-  type: 'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill';
+  type: 'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill' | 'optimize_context';
   title: string;
   reasoning: string;
   suggestedContent: string;
@@ -341,6 +341,18 @@ export class DreamService {
             error: corrError instanceof Error ? corrError : new Error(String(corrError)),
           });
         }
+
+        // Refresh insight effectiveness scores based on execution outcomes
+        try {
+          await this.skillTrackingService.computeInsightScores(codespaceId);
+          log.info('Refreshed insight effectiveness scores during dream cycle', {
+            data: { codespaceId },
+          });
+        } catch (scoreError) {
+          log.warn('Failed to refresh insight effectiveness scores', {
+            error: scoreError instanceof Error ? scoreError : new Error(String(scoreError)),
+          });
+        }
       }
 
       // Update dream session
@@ -407,6 +419,224 @@ export class DreamService {
       }
 
       return err(MemoryErrors.DERIVATION_ERROR('Dream cycle failed'));
+    }
+  }
+
+  /**
+   * Analyze context assembly effectiveness and suggest parameter adjustments.
+   * Creates a 'context_optimization' dream session.
+   */
+  async analyzeContextEffectiveness(
+    codespaceId: string
+  ): Promise<Result<DreamSession, MemoryError>> {
+    const startedAt = new Date().toISOString();
+    const dreamId = createId();
+
+    try {
+      const { dreamSessions, skillExecutions, skillSuggestions } = await import(
+        '../../db/schema/index.js'
+      );
+
+      // Create dream session
+      await this.db.insert(dreamSessions).values({
+        id: dreamId,
+        codespaceId,
+        type: 'context_optimization',
+        status: 'running',
+        skillsAnalyzed: 0,
+        suggestionsGenerated: 0,
+        tokensUsed: 0,
+        startedAt,
+        createdAt: startedAt,
+      });
+
+      // Gather recent executions with insight data
+      const executions = await this.db
+        .select({
+          status: skillExecutions.status,
+          insightIdsUsed: skillExecutions.insightIdsUsed,
+          tokensUsed: skillExecutions.tokensUsed,
+          turnsUsed: skillExecutions.turnsUsed,
+          skillId: skillExecutions.skillId,
+          completedAt: skillExecutions.completedAt,
+        })
+        .from(skillExecutions)
+        .where(
+          and(
+            eq(skillExecutions.codespaceId, codespaceId),
+            sql`${skillExecutions.insightIdsUsed} IS NOT NULL`
+          )
+        )
+        .orderBy(desc(skillExecutions.completedAt))
+        .limit(50);
+
+      if (executions.length < 5) {
+        // Not enough data to analyze
+        await this.db
+          .update(dreamSessions)
+          .set({
+            status: 'completed',
+            completedAt: new Date().toISOString(),
+          })
+          .where(eq(dreamSessions.id, dreamId));
+
+        return ok({
+          id: dreamId,
+          codespaceId,
+          type: 'context_optimization' as const,
+          status: 'completed' as const,
+          skillsAnalyzed: 0,
+          suggestionsGenerated: 0,
+          tokensUsed: 0,
+          costUsd: null,
+          startedAt,
+          completedAt: new Date().toISOString(),
+          errorMessage: null,
+          createdAt: startedAt,
+        });
+      }
+
+      // Build analysis prompt
+      const executionSummary = executions
+        .map((e, i) => {
+          const insightCount = Array.isArray(e.insightIdsUsed)
+            ? (e.insightIdsUsed as string[]).length
+            : 0;
+          return `${i + 1}. Status: ${e.status}, Insights injected: ${insightCount}, Tokens: ${e.tokensUsed ?? 'N/A'}, Turns: ${e.turnsUsed ?? 'N/A'}, Skill: ${e.skillId}`;
+        })
+        .join('\n');
+
+      // Compute summary statistics
+      const successfulRuns = executions.filter((e) => e.status === 'success');
+      const failedRuns = executions.filter((e) => e.status === 'failed');
+      const avgInsightsSuccess =
+        successfulRuns.length > 0
+          ? successfulRuns.reduce(
+              (sum, e) =>
+                sum + (Array.isArray(e.insightIdsUsed) ? (e.insightIdsUsed as string[]).length : 0),
+              0
+            ) / successfulRuns.length
+          : 0;
+      const avgInsightsFailed =
+        failedRuns.length > 0
+          ? failedRuns.reduce(
+              (sum, e) =>
+                sum + (Array.isArray(e.insightIdsUsed) ? (e.insightIdsUsed as string[]).length : 0),
+              0
+            ) / failedRuns.length
+          : 0;
+
+      const prompt = `You are analyzing context assembly effectiveness for an AI agent memory system.
+
+## Execution Data (${executions.length} recent runs)
+${executionSummary}
+
+## Summary Statistics
+- Total runs: ${executions.length}
+- Successful: ${successfulRuns.length} (avg ${avgInsightsSuccess.toFixed(1)} insights injected)
+- Failed: ${failedRuns.length} (avg ${avgInsightsFailed.toFixed(1)} insights injected)
+
+## Current Configuration
+- Max tokens for context: 2000
+- Max insights: 10
+- Selection: Multi-signal relevance scoring (keyword overlap, category-intent match, skill match, effectiveness score, recency decay)
+
+## Instructions
+Analyze the correlation between context assembly parameters and execution outcomes.
+Suggest specific parameter adjustments to improve success rate and reduce token usage.
+
+Return a JSON array of suggestions:
+\`\`\`json
+[
+  {
+    "type": "optimize_context",
+    "title": "Short title",
+    "reasoning": "Evidence-based reasoning from the data",
+    "suggestedContent": "Specific parameter change recommendation"
+  }
+]
+\`\`\`
+
+If the current configuration is performing well, return an empty array \`[]\`.
+Only return the JSON array.`;
+
+      const model = await this.getModel();
+      const response = await agentPrompt(prompt, { model });
+      const tokensUsed = (response.usage?.inputTokens ?? 0) + (response.usage?.outputTokens ?? 0);
+
+      // Parse and store suggestions
+      const suggestions = this.parseSuggestions(response.text);
+      const now = new Date().toISOString();
+
+      for (const suggestion of suggestions) {
+        await this.db.insert(skillSuggestions).values({
+          id: createId(),
+          dreamSessionId: dreamId,
+          codespaceId,
+          skillId: '_context_assembly',
+          skillName: 'Context Assembly',
+          suggestionType: 'optimize_context',
+          title: suggestion.title,
+          reasoning: suggestion.reasoning,
+          currentContent: null,
+          suggestedContent: suggestion.suggestedContent,
+          diff: null,
+          status: 'pending',
+          createdAt: now,
+        });
+      }
+
+      const completedAt = new Date().toISOString();
+      await this.db
+        .update(dreamSessions)
+        .set({
+          status: 'completed',
+          suggestionsGenerated: suggestions.length,
+          tokensUsed,
+          completedAt,
+        })
+        .where(eq(dreamSessions.id, dreamId));
+
+      log.info('Context effectiveness analysis completed', {
+        data: { dreamId, suggestions: suggestions.length, tokensUsed },
+      });
+
+      return ok({
+        id: dreamId,
+        codespaceId,
+        type: 'context_optimization' as const,
+        status: 'completed' as const,
+        skillsAnalyzed: 0,
+        suggestionsGenerated: suggestions.length,
+        tokensUsed,
+        costUsd: null,
+        startedAt,
+        completedAt,
+        errorMessage: null,
+        createdAt: startedAt,
+      });
+    } catch (error) {
+      log.error('Context effectiveness analysis failed', {
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+
+      try {
+        const { dreamSessions } = await import('../../db/schema/index.js');
+        await this.db
+          .update(dreamSessions)
+          .set({
+            status: 'error',
+            errorMessage: error instanceof Error ? error.message : String(error),
+            completedAt: new Date().toISOString(),
+          })
+          .where(eq(dreamSessions.id, dreamId));
+      } catch (updateError) {
+        log.error('Failed to update dream session status', {
+          error: updateError instanceof Error ? updateError : new Error(String(updateError)),
+        });
+      }
+
+      return err(MemoryErrors.DERIVATION_ERROR('Context effectiveness analysis failed'));
     }
   }
 
@@ -584,7 +814,13 @@ export class DreamService {
 
       if (!Array.isArray(parsed)) return [];
 
-      const validTypes = new Set(['improve_prompt', 'add_example', 'fix_pattern', 'new_skill']);
+      const validTypes = new Set([
+        'improve_prompt',
+        'add_example',
+        'fix_pattern',
+        'new_skill',
+        'optimize_context',
+      ]);
 
       return parsed
         .filter(

--- a/src/services/memory/dream.service.ts
+++ b/src/services/memory/dream.service.ts
@@ -13,7 +13,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { and, desc, eq, or, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, or } from 'drizzle-orm';
 import { agentPrompt } from '../../lib/agents/agent-sdk-utils.js';
 import type { MemoryError } from '../../lib/errors/memory-errors.js';
 import { MemoryErrors } from '../../lib/errors/memory-errors.js';
@@ -464,7 +464,7 @@ export class DreamService {
         .where(
           and(
             eq(skillExecutions.codespaceId, codespaceId),
-            sql`${skillExecutions.insightIdsUsed} IS NOT NULL`
+            isNotNull(skillExecutions.insightIdsUsed)
           )
         )
         .orderBy(desc(skillExecutions.completedAt))

--- a/src/services/memory/index.ts
+++ b/src/services/memory/index.ts
@@ -4,6 +4,7 @@ export { MemoryService } from './memory.service.js';
 export { MemoryStoreService } from './memory-store.service.js';
 export type {
   DreamSession,
+  ExecutionTrace,
   HealthStatus,
   Insight,
   MemoryContext,
@@ -14,5 +15,6 @@ export type {
   SkillExecution,
   SkillMetrics,
   SkillSuggestion,
+  TaskOutcome,
 } from './types.js';
 export { EMPTY_CONTEXT } from './types.js';

--- a/src/services/memory/insight-deriver.service.ts
+++ b/src/services/memory/insight-deriver.service.ts
@@ -16,7 +16,7 @@ import { createLogger } from '../../lib/logging/logger.js';
 import type { Result } from '../../lib/utils/result.js';
 import { err, ok } from '../../lib/utils/result.js';
 import type { MemoryStoreService } from './memory-store.service.js';
-import type { Insight } from './types.js';
+import type { Insight, TaskOutcome } from './types.js';
 
 const log = createLogger('InsightDeriverService');
 
@@ -29,6 +29,12 @@ const DERIVATION_PROMPT = `You are analyzing an agent conversation to extract me
 
 ## Conversation
 {{conversation}}
+
+## Task Outcome
+{{taskOutcome}}
+
+## Execution Traces
+{{executionTraces}}
 
 ## Instructions
 
@@ -43,6 +49,9 @@ Focus on:
 - Patterns: What approaches worked well?
 - Architecture decisions: What structural choices were made?
 - Decisions: What trade-offs or choices were evaluated?
+- If task outcome data is available, evaluate whether the injected insights were helpful or misleading given the outcome.
+- For failed tasks, consider whether any injected insight may have been incorrect or outdated.
+- Use execution trace data (tool usage patterns, files modified, errors) to identify recurring tool patterns or common failure modes worth capturing as insights.
 
 Return ONLY a JSON array:
 \`\`\`json
@@ -77,7 +86,8 @@ export class InsightDeriverService {
    */
   async deriveInsights(
     memorySessionId: string,
-    codespaceId: string
+    codespaceId: string,
+    outcome?: TaskOutcome
   ): Promise<
     Result<
       { insightsCreated: number; insightsUpdated: number; insightsDeleted: number },
@@ -123,10 +133,64 @@ export class InsightDeriverService {
         conversationText += line;
       }
 
-      const prompt = DERIVATION_PROMPT.replace(
-        '{{existingInsights}}',
-        existingInsightsText
-      ).replace('{{conversation}}', conversationText);
+      // Extract trace summaries from message metadata
+      const toolUsage = new Map<string, { success: number; error: number }>();
+      const allFilesModified = new Set<string>();
+      let totalErrors = 0;
+
+      for (const m of messages) {
+        const meta = m.metadata as Record<string, unknown> | null;
+        if (!meta?.trace) continue;
+        const trace = meta.trace as {
+          toolCalls?: Array<{ tool: string; status: string }>;
+          filesModified?: string[];
+          errorCount?: number;
+        };
+        if (trace.toolCalls) {
+          for (const call of trace.toolCalls) {
+            const stats = toolUsage.get(call.tool) ?? { success: 0, error: 0 };
+            if (call.status === 'success') stats.success++;
+            else stats.error++;
+            toolUsage.set(call.tool, stats);
+          }
+        }
+        if (trace.filesModified) {
+          for (const f of trace.filesModified) allFilesModified.add(f);
+        }
+        if (trace.errorCount) totalErrors += trace.errorCount;
+      }
+
+      let traceText = '';
+      if (toolUsage.size > 0) {
+        const toolLines = [...toolUsage.entries()]
+          .sort((a, b) => b[1].success + b[1].error - (a[1].success + a[1].error))
+          .map(([tool, stats]) => `- ${tool}: ${stats.success} success, ${stats.error} error`)
+          .join('\n');
+        traceText += `\nTool usage:\n${toolLines}`;
+      }
+      if (allFilesModified.size > 0) {
+        traceText += `\nFiles modified: ${[...allFilesModified].slice(0, 20).join(', ')}`;
+      }
+      if (totalErrors > 0) {
+        traceText += `\nTotal errors encountered: ${totalErrors}`;
+      }
+
+      // Build outcome context if available
+      let outcomeText = 'No outcome data available';
+      if (outcome) {
+        const parts = [`Status: ${outcome.status}`];
+        if (outcome.tokensUsed != null) parts.push(`Tokens used: ${outcome.tokensUsed}`);
+        if (outcome.turnsUsed != null) parts.push(`Turns used: ${outcome.turnsUsed}`);
+        if (outcome.insightIdsUsed?.length) {
+          parts.push(`Insights injected: ${outcome.insightIdsUsed.join(', ')}`);
+        }
+        outcomeText = parts.join('\n');
+      }
+
+      const prompt = DERIVATION_PROMPT.replace('{{existingInsights}}', existingInsightsText)
+        .replace('{{conversation}}', conversationText)
+        .replace('{{taskOutcome}}', outcomeText)
+        .replace('{{executionTraces}}', traceText || 'No trace data available');
 
       // 4. Call Claude Haiku via Agent SDK for insight extraction
       const response = await agentPrompt(prompt, { model: HAIKU_MODEL });

--- a/src/services/memory/insight-deriver.service.ts
+++ b/src/services/memory/insight-deriver.service.ts
@@ -16,7 +16,7 @@ import { createLogger } from '../../lib/logging/logger.js';
 import type { Result } from '../../lib/utils/result.js';
 import { err, ok } from '../../lib/utils/result.js';
 import type { MemoryStoreService } from './memory-store.service.js';
-import type { Insight, TaskOutcome } from './types.js';
+import type { ExecutionTrace, Insight, TaskOutcome } from './types.js';
 
 const log = createLogger('InsightDeriverService');
 
@@ -140,24 +140,21 @@ export class InsightDeriverService {
 
       for (const m of messages) {
         const meta = m.metadata as Record<string, unknown> | null;
-        if (!meta?.trace) continue;
-        const trace = meta.trace as {
-          toolCalls?: Array<{ tool: string; status: string }>;
-          filesModified?: string[];
-          errorCount?: number;
-        };
-        if (trace.toolCalls) {
+        if (!meta?.trace || typeof meta.trace !== 'object') continue;
+        const trace = meta.trace as ExecutionTrace;
+        if (Array.isArray(trace.toolCalls)) {
           for (const call of trace.toolCalls) {
+            if (typeof call?.tool !== 'string') continue;
             const stats = toolUsage.get(call.tool) ?? { success: 0, error: 0 };
             if (call.status === 'success') stats.success++;
             else stats.error++;
             toolUsage.set(call.tool, stats);
           }
         }
-        if (trace.filesModified) {
+        if (Array.isArray(trace.filesModified)) {
           for (const f of trace.filesModified) allFilesModified.add(f);
         }
-        if (trace.errorCount) totalErrors += trace.errorCount;
+        if (typeof trace.errorCount === 'number') totalErrors += trace.errorCount;
       }
 
       let traceText = '';

--- a/src/services/memory/memory-store.service.ts
+++ b/src/services/memory/memory-store.service.ts
@@ -50,20 +50,22 @@ function scoreInsightRelevance(
 ): number {
   let score = 0;
 
-  // 1. Keyword overlap (0-0.4)
+  // 1. Keyword overlap (0-0.4) — set intersection of distinct words
   const queryWords = new Set(
     query
       .toLowerCase()
       .split(/\s+/)
       .filter((w) => w.length > 2)
   );
-  const contentWords = content
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((w) => w.length > 2);
-  if (queryWords.size > 0 && contentWords.length > 0) {
-    const matches = contentWords.filter((w) => queryWords.has(w)).length;
-    score += Math.min(0.4, (matches / queryWords.size) * 0.4);
+  const contentWordSet = new Set(
+    content
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w.length > 2)
+  );
+  if (queryWords.size > 0 && contentWordSet.size > 0) {
+    const matches = [...queryWords].filter((w) => contentWordSet.has(w)).length;
+    score += (matches / queryWords.size) * 0.4;
   }
 
   // 2. Category-intent match (0-0.15)
@@ -91,9 +93,12 @@ function scoreInsightRelevance(
   else if (source === 'dream') score += 0.025;
 
   // 6. Recency decay (0-0.05) — 30-day half-life
-  const ageMs = Date.now() - new Date(createdAt).getTime();
+  const createdTime = new Date(createdAt).getTime();
   const HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000;
-  score += 0.05 * 0.5 ** (ageMs / HALF_LIFE_MS);
+  if (Number.isFinite(createdTime)) {
+    const ageMs = Math.max(0, Date.now() - createdTime);
+    score += 0.05 * 0.5 ** (ageMs / HALF_LIFE_MS);
+  }
 
   return score;
 }

--- a/src/services/memory/memory-store.service.ts
+++ b/src/services/memory/memory-store.service.ts
@@ -28,6 +28,76 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
+/** Category-to-task-intent mapping for relevance boosting. */
+const CATEGORY_INTENT_MAP: Record<string, string[]> = {
+  error_lesson: ['fix', 'bug', 'error', 'issue', 'broken', 'failing', 'crash', 'debug'],
+  pattern: ['add', 'implement', 'create', 'build', 'feature', 'new'],
+  anti_pattern: ['fix', 'refactor', 'avoid', 'bug', 'issue'],
+  architecture: ['design', 'architect', 'structure', 'refactor', 'restructure', 'migrate'],
+  decision: ['choose', 'decide', 'evaluate', 'compare', 'option'],
+};
+
+/** Compute a relevance score for an insight against a query. */
+function scoreInsightRelevance(
+  content: string,
+  category: string | null,
+  effectivenessScore: number | null,
+  source: string,
+  createdAt: string,
+  skillId: string | null,
+  query: string,
+  taskSkillId?: string | null
+): number {
+  let score = 0;
+
+  // 1. Keyword overlap (0-0.4)
+  const queryWords = new Set(
+    query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w.length > 2)
+  );
+  const contentWords = content
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 2);
+  if (queryWords.size > 0 && contentWords.length > 0) {
+    const matches = contentWords.filter((w) => queryWords.has(w)).length;
+    score += Math.min(0.4, (matches / queryWords.size) * 0.4);
+  }
+
+  // 2. Category-intent match (0-0.15)
+  if (category && CATEGORY_INTENT_MAP[category]) {
+    const intents = CATEGORY_INTENT_MAP[category];
+    const queryLower = query.toLowerCase();
+    if (intents.some((intent) => queryLower.includes(intent))) {
+      score += 0.15;
+    }
+  }
+
+  // 3. Skill match bonus (0-0.2)
+  if (taskSkillId && skillId && taskSkillId === skillId) {
+    score += 0.2;
+  }
+
+  // 4. Effectiveness score (0-0.15)
+  if (effectivenessScore != null) {
+    // Normalize from [-1, 1] to [0, 0.15]
+    score += Math.max(0, (effectivenessScore + 1) / 2) * 0.15;
+  }
+
+  // 5. Source priority (0-0.05)
+  if (source === 'manual') score += 0.05;
+  else if (source === 'dream') score += 0.025;
+
+  // 6. Recency decay (0-0.05) — 30-day half-life
+  const ageMs = Date.now() - new Date(createdAt).getTime();
+  const HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000;
+  score += 0.05 * 0.5 ** (ageMs / HALF_LIFE_MS);
+
+  return score;
+}
+
 export class MemoryStoreService {
   constructor(private db: Database) {}
 
@@ -77,6 +147,7 @@ export class MemoryStoreService {
         metadata: params.metadata ?? null,
         status,
         category,
+        effectivenessScore: null,
         updatedAt: null,
         createdAt: now,
       };
@@ -127,6 +198,7 @@ export class MemoryStoreService {
         metadata: row.metadata as Record<string, unknown> | null,
         status: row.status ?? 'active',
         category: row.category ?? null,
+        effectivenessScore: row.effectivenessScore ?? null,
         updatedAt: row.updatedAt ?? null,
         createdAt: row.createdAt,
       };
@@ -186,6 +258,7 @@ export class MemoryStoreService {
         metadata: row.metadata as Record<string, unknown> | null,
         status: row.status ?? 'active',
         category: row.category ?? null,
+        effectivenessScore: row.effectivenessScore ?? null,
         updatedAt: row.updatedAt ?? null,
         createdAt: row.createdAt,
       }));
@@ -251,6 +324,7 @@ export class MemoryStoreService {
         metadata: row.metadata as Record<string, unknown> | null,
         status: row.status ?? 'active',
         category: row.category ?? null,
+        effectivenessScore: row.effectivenessScore ?? null,
         updatedAt: row.updatedAt ?? null,
         createdAt: row.createdAt,
       }));
@@ -269,42 +343,42 @@ export class MemoryStoreService {
     codespaceId: string | null,
     query: string,
     maxTokens = 2000,
-    maxInsights = 10
+    maxInsights = 10,
+    taskSkillId?: string | null
   ): Promise<Result<MemoryContext, MemoryError>> {
     try {
-      const likeCondition = sql`${memoryInsights.content} LIKE ${`%${escapeLikeQuery(query)}%`} ESCAPE '\\'`;
       const activeCondition = eq(memoryInsights.status, 'active');
-      const sourcePriority = sql`CASE WHEN ${memoryInsights.source} = 'manual' THEN 0 WHEN ${memoryInsights.source} = 'dream' THEN 1 ELSE 2 END`;
+      const whereClause = codespaceId
+        ? and(eq(memoryInsights.codespaceId, codespaceId), activeCondition)
+        : activeCondition;
 
-      const searchWhere = codespaceId
-        ? and(eq(memoryInsights.codespaceId, codespaceId), likeCondition, activeCondition)
-        : and(likeCondition, activeCondition);
-
-      // First try search-relevant insights, then fall back to recent
-      let rows = await this.db
+      // Fetch all active insights (capped at 200 for scoring)
+      const rows = await this.db
         .select()
         .from(memoryInsights)
-        .where(searchWhere)
-        .orderBy(sourcePriority, desc(memoryInsights.createdAt))
-        .limit(50);
-
-      // If no search matches, get recent active insights
-      if (rows.length === 0) {
-        const recentWhere = codespaceId
-          ? and(eq(memoryInsights.codespaceId, codespaceId), activeCondition)
-          : activeCondition;
-
-        rows = await this.db
-          .select()
-          .from(memoryInsights)
-          .where(recentWhere)
-          .orderBy(sourcePriority, desc(memoryInsights.createdAt))
-          .limit(50);
-      }
+        .where(whereClause)
+        .orderBy(desc(memoryInsights.createdAt))
+        .limit(200);
 
       if (rows.length === 0) {
         return ok({ text: '', tokenCount: 0, sources: { insights: 0, insightIds: [] } });
       }
+
+      // Score and sort by relevance
+      const scored = rows.map((row) => ({
+        row,
+        score: scoreInsightRelevance(
+          row.content,
+          row.category,
+          row.effectivenessScore ?? null,
+          row.source,
+          row.createdAt,
+          row.skillId,
+          query,
+          taskSkillId
+        ),
+      }));
+      scored.sort((a, b) => b.score - a.score);
 
       // Collect insights within token and count budgets
       let insightCount = 0;
@@ -312,23 +386,15 @@ export class MemoryStoreService {
       const categorized = new Map<string, string[]>();
       const uncategorized: string[] = [];
 
-      for (const row of rows) {
-        if (insightCount >= maxInsights) {
-          break;
-        }
+      for (const { row } of scored) {
+        if (insightCount >= maxInsights) break;
         const line = `- ${row.content}`;
-        // Estimate with a generous header allowance
         const candidateText = `## Memory Context\n\n${[...categorized.values()].flat().join('\n')}\n${uncategorized.join('\n')}\n${line}\n`;
         const candidateTokens = estimateTokens(candidateText);
-        if (candidateTokens > maxTokens) {
-          break;
-        }
+        if (candidateTokens > maxTokens) break;
         if (row.category) {
-          const cat = row.category;
-          if (!categorized.has(cat)) {
-            categorized.set(cat, []);
-          }
-          categorized.get(cat)?.push(line);
+          if (!categorized.has(row.category)) categorized.set(row.category, []);
+          categorized.get(row.category)?.push(line);
         } else {
           uncategorized.push(line);
         }

--- a/src/services/memory/memory.service.ts
+++ b/src/services/memory/memory.service.ts
@@ -156,10 +156,17 @@ export class MemoryService {
   async getContext(
     codespaceId: string,
     query: string,
-    maxInsights?: number
+    maxInsights?: number,
+    taskSkillId?: string | null
   ): Promise<Result<MemoryContext, MemoryError>> {
     try {
-      return await this.store.assembleContext(codespaceId, query, undefined, maxInsights);
+      return await this.store.assembleContext(
+        codespaceId,
+        query,
+        undefined,
+        maxInsights,
+        taskSkillId
+      );
     } catch (error) {
       log.warn('Memory context retrieval failed', {
         error: error instanceof Error ? error : new Error(String(error)),

--- a/src/services/memory/memory.service.ts
+++ b/src/services/memory/memory.service.ts
@@ -28,6 +28,7 @@ import type {
   MemorySessionRef,
   PaginationOptions,
   SearchResult,
+  TaskOutcome,
 } from './types.js';
 import { EMPTY_CONTEXT } from './types.js';
 
@@ -76,7 +77,8 @@ export interface MemoryStoreInterface {
     codespaceId: string | null,
     query: string,
     maxTokens?: number,
-    maxInsights?: number
+    maxInsights?: number,
+    taskSkillId?: string | null
   ): Promise<Result<MemoryContext, MemoryError>>;
   insertMessage(params: {
     codespaceId: string;
@@ -96,7 +98,8 @@ export interface MemoryStoreInterface {
 export interface InsightDeriverInterface {
   deriveInsights(
     memorySessionId: string,
-    codespaceId: string
+    codespaceId: string,
+    outcome?: TaskOutcome
   ): Promise<
     Result<
       { insightsCreated: number; insightsUpdated: number; insightsDeleted: number },
@@ -225,9 +228,13 @@ export class MemoryService {
   }
 
   /** Finalize a memory session (triggers insight derivation). Fire-and-forget. */
-  async finalizeSession(ref: MemorySessionRef): Promise<void> {
+  async finalizeSession(ref: MemorySessionRef, outcome?: TaskOutcome): Promise<void> {
     try {
-      const result = await this.deriver.deriveInsights(ref.memorySessionId, ref.codespaceId);
+      const result = await this.deriver.deriveInsights(
+        ref.memorySessionId,
+        ref.codespaceId,
+        outcome
+      );
       if (!result.ok) {
         log.warn('Insight derivation returned error', {
           error: new Error(String(result.error)),

--- a/src/services/memory/skill-tracking.service.ts
+++ b/src/services/memory/skill-tracking.service.ts
@@ -388,4 +388,83 @@ export class SkillTrackingService {
       return err(MemoryErrors.QUERY_ERROR('Failed to get insight correlations'));
     }
   }
+
+  /**
+   * Compute effectiveness scores for all insights in a codespace based on
+   * execution outcomes. Score = (successes - failures) / total_uses, weighted
+   * by recency (exponential decay, 30-day half-life).
+   */
+  async computeInsightScores(codespaceId: string): Promise<Result<void, MemoryError>> {
+    try {
+      const { skillExecutions, memoryInsights } = await import('../../db/schema/index.js');
+
+      // Get all executions with insightIdsUsed
+      const executions = await this.db
+        .select({
+          status: skillExecutions.status,
+          insightIdsUsed: skillExecutions.insightIdsUsed,
+          completedAt: skillExecutions.completedAt,
+        })
+        .from(skillExecutions)
+        .where(
+          and(
+            eq(skillExecutions.codespaceId, codespaceId),
+            sql`${skillExecutions.insightIdsUsed} IS NOT NULL`
+          )
+        );
+
+      // Aggregate per insight with recency weighting
+      const now = Date.now();
+      const HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+      const insightStats = new Map<
+        string,
+        { weightedSuccesses: number; weightedFailures: number; totalWeight: number }
+      >();
+
+      for (const exec of executions) {
+        const ids = exec.insightIdsUsed as string[] | null;
+        if (!Array.isArray(ids)) continue;
+
+        const completedAt = exec.completedAt ? new Date(exec.completedAt).getTime() : now;
+        const age = now - completedAt;
+        const weight = 0.5 ** (age / HALF_LIFE_MS);
+
+        for (const insightId of ids) {
+          const stats = insightStats.get(insightId) ?? {
+            weightedSuccesses: 0,
+            weightedFailures: 0,
+            totalWeight: 0,
+          };
+          stats.totalWeight += weight;
+          if (exec.status === 'success') {
+            stats.weightedSuccesses += weight;
+          } else if (exec.status === 'failed') {
+            stats.weightedFailures += weight;
+          }
+          insightStats.set(insightId, stats);
+        }
+      }
+
+      // Update scores in DB
+      for (const [insightId, stats] of insightStats.entries()) {
+        if (stats.totalWeight === 0) continue;
+        const score = (stats.weightedSuccesses - stats.weightedFailures) / stats.totalWeight;
+        await this.db
+          .update(memoryInsights)
+          .set({ effectivenessScore: Math.round(score * 1000) / 1000 })
+          .where(eq(memoryInsights.id, insightId));
+      }
+
+      log.debug('Computed insight effectiveness scores', {
+        data: { codespaceId, insightsScored: insightStats.size },
+      });
+
+      return ok(undefined);
+    } catch (error) {
+      log.error('Failed to compute insight scores', {
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      return err(MemoryErrors.QUERY_ERROR('Failed to compute insight scores'));
+    }
+  }
 }

--- a/src/services/memory/skill-tracking.service.ts
+++ b/src/services/memory/skill-tracking.service.ts
@@ -445,15 +445,18 @@ export class SkillTrackingService {
         }
       }
 
-      // Update scores in DB
-      for (const [insightId, stats] of insightStats.entries()) {
-        if (stats.totalWeight === 0) continue;
-        const score = (stats.weightedSuccesses - stats.weightedFailures) / stats.totalWeight;
-        await this.db
-          .update(memoryInsights)
-          .set({ effectivenessScore: Math.round(score * 1000) / 1000 })
-          .where(eq(memoryInsights.id, insightId));
-      }
+      // Update scores in DB (batched)
+      await Promise.all(
+        [...insightStats.entries()]
+          .filter(([_, stats]) => stats.totalWeight > 0)
+          .map(([insightId, stats]) => {
+            const score = (stats.weightedSuccesses - stats.weightedFailures) / stats.totalWeight;
+            return this.db
+              .update(memoryInsights)
+              .set({ effectivenessScore: Math.round(score * 1000) / 1000 })
+              .where(eq(memoryInsights.id, insightId));
+          })
+      );
 
       log.debug('Computed insight effectiveness scores', {
         data: { codespaceId, insightsScored: insightStats.size },

--- a/src/services/memory/skill-tracking.service.ts
+++ b/src/services/memory/skill-tracking.service.ts
@@ -6,7 +6,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
 import type { MemoryError } from '../../lib/errors/memory-errors.js';
 import { MemoryErrors } from '../../lib/errors/memory-errors.js';
 import { createLogger } from '../../lib/logging/logger.js';
@@ -355,7 +355,7 @@ export class SkillTrackingService {
         .where(
           and(
             eq(skillExecutions.codespaceId, codespaceId),
-            sql`${skillExecutions.insightIdsUsed} IS NOT NULL`
+            isNotNull(skillExecutions.insightIdsUsed)
           )
         );
 
@@ -409,7 +409,7 @@ export class SkillTrackingService {
         .where(
           and(
             eq(skillExecutions.codespaceId, codespaceId),
-            sql`${skillExecutions.insightIdsUsed} IS NOT NULL`
+            isNotNull(skillExecutions.insightIdsUsed)
           )
         );
 

--- a/src/services/memory/types.ts
+++ b/src/services/memory/types.ts
@@ -14,6 +14,26 @@ export interface MemorySessionRef {
 }
 
 /**
+ * Task execution outcome passed to memory finalization for feedback-aware derivation.
+ */
+export interface TaskOutcome {
+  status: 'success' | 'failed' | 'cancelled' | 'turn_limit';
+  tokensUsed?: number | null;
+  turnsUsed?: number | null;
+  insightIdsUsed?: string[] | null;
+}
+
+/**
+ * Lightweight execution trace summary stored in message metadata.
+ * Only captures tool names and statuses, not full results, to minimize storage impact.
+ */
+export interface ExecutionTrace {
+  toolCalls?: Array<{ tool: string; status: 'success' | 'error' }>;
+  filesModified?: string[];
+  errorCount?: number;
+}
+
+/**
  * Assembled memory context for agent prompt injection.
  */
 export interface MemoryContext {
@@ -39,6 +59,7 @@ export interface Insight {
   metadata: Record<string, unknown> | null;
   status: 'active' | 'pending_review' | 'rejected';
   category: 'pattern' | 'anti_pattern' | 'decision' | 'architecture' | 'error_lesson' | null;
+  effectivenessScore: number | null;
   updatedAt: string | null;
   createdAt: string;
 }
@@ -111,7 +132,7 @@ export interface SkillMetrics {
 export interface DreamSession {
   id: string;
   codespaceId: string | null;
-  type: 'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup';
+  type: 'conclusion_derivation' | 'skill_improvement' | 'metrics_rollup' | 'context_optimization';
   status: 'running' | 'completed' | 'error';
   skillsAnalyzed: number;
   suggestionsGenerated: number;
@@ -132,7 +153,12 @@ export interface SkillSuggestion {
   codespaceId: string;
   skillId: string;
   skillName: string;
-  suggestionType: 'improve_prompt' | 'add_example' | 'fix_pattern' | 'new_skill';
+  suggestionType:
+    | 'improve_prompt'
+    | 'add_example'
+    | 'fix_pattern'
+    | 'new_skill'
+    | 'optimize_context';
   title: string;
   reasoning: string;
   currentContent: string | null;

--- a/tests/integration/memory-lifecycle.integration.test.ts
+++ b/tests/integration/memory-lifecycle.integration.test.ts
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS memory_insights (
   metadata TEXT,
   status TEXT NOT NULL DEFAULT 'active',
   category TEXT,
+  effectiveness_score REAL,
   updated_at TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/tests/integration/memory-service.integration.test.ts
+++ b/tests/integration/memory-service.integration.test.ts
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS memory_insights (
   metadata TEXT,
   status TEXT NOT NULL DEFAULT 'active',
   category TEXT,
+  effectiveness_score REAL,
   updated_at TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );


### PR DESCRIPTION
## Summary
This PR introduces automated context assembly optimization and insight effectiveness scoring to the memory system. It enables the agent to analyze how well injected insights correlate with task outcomes and suggest parameter adjustments to improve context selection.

## Key Changes

### Context Optimization Analysis
- **New dream session type**: Added `context_optimization` dream session that analyzes execution patterns with injected insights
- **New method**: `DreamService.analyzeContextEffectiveness()` gathers recent executions, computes statistics on insight injection effectiveness, and generates optimization suggestions
- **Multi-signal relevance scoring**: Implemented `scoreInsightRelevance()` in `MemoryStoreService` that combines:
  - Keyword overlap (0-0.4)
  - Category-intent matching (0-0.15)
  - Skill match bonus (0-0.2)
  - Effectiveness score (0-0.15)
  - Source priority (0-0.05)
  - Recency decay with 30-day half-life (0-0.05)

### Insight Effectiveness Tracking
- **New field**: `effectivenessScore` ([-1, 1] range) added to `memoryInsights` table to track correlation between insights and task outcomes
- **New method**: `SkillTrackingService.computeInsightScores()` computes weighted effectiveness scores based on execution outcomes with exponential recency decay
- **Automatic refresh**: Dream cycle now calls `computeInsightScores()` after corrections to update effectiveness metrics
- **UI display**: Added `EffectivenessScoreBadge` component showing effectiveness as percentage with trend indicators

### Task Outcome Tracking
- **New types**: `TaskOutcome` and `ExecutionTrace` interfaces for capturing execution context
- **Insight injection tracking**: `AgentExecutionService` now tracks which insights were injected into agent prompts via `agentInsightIds` map
- **Outcome-aware derivation**: `InsightDeriverService.deriveInsights()` now accepts optional `TaskOutcome` to evaluate whether injected insights were helpful or misleading
- **Execution trace capture**: Lightweight trace summaries (tool calls, files modified, error counts) stored in message metadata for pattern analysis

### Database Schema Updates
- Added `effectiveness_score` column to `memory_insights` table (PostgreSQL: `doublePrecision`, SQLite: `real`)
- Updated `dream_sessions` type enum to include `'context_optimization'`
- Updated `skill_suggestions` type enum to include `'optimize_context'`

### Memory Context Assembly
- **Enhanced `assembleContext()`**: Now accepts optional `taskSkillId` parameter for skill-specific context matching
- **Relevance-based ranking**: Replaced simple keyword search + recency with multi-signal relevance scoring
- **Improved selection**: Insights are scored and sorted by relevance before token/count budgets are applied

### UI Enhancements
- Added research reference section in memory overview linking to Meta-Harness paper on context optimization
- Updated insight card to display effectiveness scores with tooltips explaining correlation
- Type-safe suggestion and dream session type handling in components

## Implementation Details
- Effectiveness scores use weighted aggregation with exponential decay (30-day half-life) to emphasize recent outcomes
- Context optimization analysis requires minimum 5 executions with insight data to proceed
- Suggestion parsing validates against expanded type set including `'optimize_context'`
- All effectiveness score computations are batched for database efficiency
- Execution traces are minimal (tool names, status, file paths) to minimize storage overhead

https://claude.ai/code/session_01B7PfnR7hzWd1oCgxVWjRVg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
