### PR TITLE
Migrate to v0.2.1 Agent Sandbox API with condition-based status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,32 +179,3 @@ jobs:
           name: integration-test-results-shard-${{ strategy.job-index }}
           path: test-results/
           retention-days: 7
-
-  e2e-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: [build, test]
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup environment
-        uses: ./.github/actions/setup-bun-env
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Install Playwright Chromium
-        run: bunx playwright install chromium --with-deps
-
-      - name: Run E2E tests
-        run: bun scripts/e2e-test.ts
-        env:
-          E2E_PORT: '3000'
-          E2E_HOST: 'localhost'
-          NODE_ENV: test
-
-      - name: Upload E2E screenshots on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-screenshots
-          path: tests/e2e/screenshots/
-          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,32 @@ jobs:
           name: integration-test-results-shard-${{ strategy.job-index }}
           path: test-results/
           retention-days: 7
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build, test]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: bun scripts/e2e-test.ts
+        env:
+          E2E_PORT: '3000'
+          E2E_HOST: 'localhost'
+          NODE_ENV: test
+
+      - name: Upload E2E screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-screenshots
+          path: tests/e2e/screenshots/
+          retention-days: 7

--- a/charts/agentpane/templates/sandbox-rbac.yaml
+++ b/charts/agentpane/templates/sandbox-rbac.yaml
@@ -24,7 +24,7 @@ rules:
     verbs: ["create", "get", "list", "watch", "delete"]
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxwarmpools"]
-    verbs: ["create", "get", "list", "watch", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
   # Pod lifecycle management
   - apiGroups: [""]
     resources: ["pods"]

--- a/charts/agentpane/templates/sandbox-rbac.yaml
+++ b/charts/agentpane/templates/sandbox-rbac.yaml
@@ -8,20 +8,21 @@ metadata:
   labels:
     {{- include "agentpane.labels" . | nindent 4 }}
 rules:
-  # Agent Sandbox CRD resources (agents.x-k8s.io/v1alpha1)
+  # Agent Sandbox core CRD (agents.x-k8s.io/v1alpha1)
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes/status"]
     verbs: ["get"]
-  - apiGroups: ["agents.x-k8s.io"]
+  # Agent Sandbox extensions CRD (extensions.agents.x-k8s.io/v1alpha1)
+  - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxtemplates"]
     verbs: ["create", "get", "list", "watch", "delete"]
-  - apiGroups: ["agents.x-k8s.io"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
     verbs: ["create", "get", "list", "watch", "delete"]
-  - apiGroups: ["agents.x-k8s.io"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxwarmpools"]
     verbs: ["create", "get", "list", "watch", "delete"]
   # Pod lifecycle management

--- a/k8s/manifests/agentpane-sandbox-template.yaml
+++ b/k8s/manifests/agentpane-sandbox-template.yaml
@@ -6,7 +6,9 @@
 #
 # This replaces the manual pod spec building from Phase 1 k8s-provider.ts
 # with a declarative CRD resource managed by the cluster controller.
-apiVersion: agents.x-k8s.io/v1alpha1
+#
+# v0.2.1: SandboxTemplate moved to extensions API group
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
   name: agentpane-default
@@ -18,7 +20,8 @@ metadata:
   annotations:
     agentpane.io/description: "Default sandbox template for AgentPane agent execution"
 spec:
-  podTemplateSpec:
+  podTemplate:
+    metadata: {}
     spec:
       runtimeClassName: gvisor
       containers:
@@ -45,13 +48,11 @@ spec:
         - name: workspace
           emptyDir:
             sizeLimit: 10Gi
+  networkPolicyManagement: Managed
   networkPolicy:
-    allowedEgressPorts:
-      - port: 443
-        protocol: TCP
-      - port: 80
-        protocol: TCP
-    allowedEgressHosts:
-      - "*.github.com"
-      - "*.npmjs.org"
-      - "registry.npmjs.org"
+    egress:
+      - ports:
+          - port: 443
+            protocol: TCP
+          - port: 80
+            protocol: TCP

--- a/k8s/manifests/agentpane-warm-pool.yaml
+++ b/k8s/manifests/agentpane-warm-pool.yaml
@@ -4,13 +4,15 @@
 # instead of waiting for cold-start pod creation (~10-30s).
 #
 # The CRD controller manages the pool lifecycle:
-#   - Maintains desiredReady sandboxes in a Ready state
+#   - Maintains desired sandboxes in a Ready state
 #   - Replaces claimed or unhealthy sandboxes automatically
-#   - Respects maxSize to bound cluster resource usage
+#   - HPA-compatible scaling via scale subresource
 #
 # This replaces the ~1000 LOC manual warm pool in Phase 1 k8s-warm-pool.ts
 # with a single declarative CRD resource.
-apiVersion: agents.x-k8s.io/v1alpha1
+#
+# v0.2.1: SandboxWarmPool moved to extensions API group
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxWarmPool
 metadata:
   name: agentpane-warm-pool
@@ -22,7 +24,6 @@ metadata:
   annotations:
     agentpane.io/description: "Pre-warmed sandbox pool for fast agent allocation"
 spec:
-  templateRef:
+  sandboxTemplateRef:
     name: agentpane-default
-  desiredReady: 2
-  maxSize: 5
+  replicas: 2

--- a/k8s/manifests/crds.yaml
+++ b/k8s/manifests/crds.yaml
@@ -17,7 +17,7 @@ spec:
     plural: sandboxes
     singular: sandbox
     shortNames:
-      - sb
+      - sandbox
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -46,23 +46,17 @@ spec:
                   enum:
                     - Delete
                     - Retain
+                replicas:
+                  type: integer
+                  minimum: 0
+                  maximum: 1
             status:
               type: object
               properties:
-                podName:
+                serviceFQDN:
                   type: string
-                podIP:
-                  type: string
-                startTime:
-                  type: string
-                  format: date-time
                 service:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    port:
-                      type: integer
+                  type: string
                 replicas:
                   type: integer
                 selector:
@@ -86,10 +80,14 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .status.selector
       additionalPrinterColumns:
-        - name: Pod
+        - name: Ready
           type: string
-          jsonPath: .status.podName
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
         - name: Replicas
           type: integer
           jsonPath: .status.replicas
@@ -109,7 +107,7 @@ spec:
     plural: sandboxtemplates
     singular: sandboxtemplate
     shortNames:
-      - sbt
+      - sandboxtemplate
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -135,12 +133,6 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
             status:
               type: object
-              properties:
-                conditions:
-                  type: array
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
           x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
@@ -161,7 +153,7 @@ spec:
     plural: sandboxclaims
     singular: sandboxclaim
     shortNames:
-      - sbc
+      - sandboxclaim
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -184,8 +176,9 @@ spec:
                 lifecycle:
                   type: object
                   properties:
-                    timeoutSeconds:
-                      type: integer
+                    shutdownTime:
+                      type: string
+                      format: date-time
                     shutdownPolicy:
                       type: string
                       enum:
@@ -194,32 +187,23 @@ spec:
             status:
               type: object
               properties:
-                phase:
-                  type: string
-                  enum:
-                    - Pending
-                    - Bound
-                    - Failed
-                sandboxRef:
-                  type: object
-                  properties:
-                    name:
-                      type: string
                 conditions:
                   type: array
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                sandbox:
+                  type: object
+                  properties:
+                    Name:
+                      type: string
           x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: Phase
-          type: string
-          jsonPath: .status.phase
         - name: Sandbox
           type: string
-          jsonPath: .status.sandboxRef.name
+          jsonPath: .status.sandbox.Name
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -236,7 +220,7 @@ spec:
     plural: sandboxwarmpools
     singular: sandboxwarmpool
     shortNames:
-      - sbwp
+      - swp
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -262,21 +246,16 @@ spec:
             status:
               type: object
               properties:
+                replicas:
+                  type: integer
                 readyReplicas:
                   type: integer
-                availableReplicas:
-                  type: integer
-                conditions:
-                  type: array
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
           x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
         scale:
           specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.readyReplicas
+          statusReplicasPath: .status.replicas
       additionalPrinterColumns:
         - name: Ready
           type: integer

--- a/k8s/manifests/crds.yaml
+++ b/k8s/manifests/crds.yaml
@@ -1,7 +1,10 @@
 ---
 # Agent Sandbox CRD definitions
 # These define the custom resource types for the Agent Sandbox controller
-# Based on the agents.x-k8s.io/v1alpha1 API group
+#
+# v0.2.1 API group split:
+#   - Sandbox stays under agents.x-k8s.io
+#   - SandboxTemplate, SandboxClaim, SandboxWarmPool move to extensions.agents.x-k8s.io
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -27,39 +30,25 @@ spec:
             spec:
               type: object
               properties:
-                sandboxTemplateRef:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                  required:
-                    - name
-                podTemplateSpec:
+                podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                networkPolicy:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                volumeClaims:
+                volumeClaimTemplates:
                   type: array
                   items:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                runtimeClassName:
+                shutdownTime:
                   type: string
-                ttlSecondsAfterFinished:
-                  type: integer
+                  format: date-time
+                shutdownPolicy:
+                  type: string
+                  enum:
+                    - Delete
+                    - Retain
             status:
               type: object
               properties:
-                phase:
-                  type: string
-                  enum:
-                    - Pending
-                    - Running
-                    - Paused
-                    - Succeeded
-                    - Failed
                 podName:
                   type: string
                 podIP:
@@ -67,6 +56,17 @@ spec:
                 startTime:
                   type: string
                   format: date-time
+                service:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                replicas:
+                  type: integer
+                selector:
+                  type: string
                 conditions:
                   type: array
                   items:
@@ -87,12 +87,12 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: Phase
-          type: string
-          jsonPath: .status.phase
         - name: Pod
           type: string
           jsonPath: .status.podName
+        - name: Replicas
+          type: integer
+          jsonPath: .status.replicas
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -100,9 +100,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sandboxtemplates.agents.x-k8s.io
+  name: sandboxtemplates.extensions.agents.x-k8s.io
 spec:
-  group: agents.x-k8s.io
+  group: extensions.agents.x-k8s.io
   names:
     kind: SandboxTemplate
     listKind: SandboxTemplateList
@@ -122,19 +122,17 @@ spec:
             spec:
               type: object
               properties:
-                podTemplateSpec:
+                podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                networkPolicyManagement:
+                  type: string
+                  enum:
+                    - Managed
+                    - Unmanaged
                 networkPolicy:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                volumeClaims:
-                  type: array
-                  items:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                runtimeClassName:
-                  type: string
             status:
               type: object
               properties:
@@ -154,9 +152,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sandboxclaims.agents.x-k8s.io
+  name: sandboxclaims.extensions.agents.x-k8s.io
 spec:
-  group: agents.x-k8s.io
+  group: extensions.agents.x-k8s.io
   names:
     kind: SandboxClaim
     listKind: SandboxClaimList
@@ -183,6 +181,16 @@ spec:
                       type: string
                   required:
                     - name
+                lifecycle:
+                  type: object
+                  properties:
+                    timeoutSeconds:
+                      type: integer
+                    shutdownPolicy:
+                      type: string
+                      enum:
+                        - Delete
+                        - Retain
             status:
               type: object
               properties:
@@ -219,9 +227,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sandboxwarmpools.agents.x-k8s.io
+  name: sandboxwarmpools.extensions.agents.x-k8s.io
 spec:
-  group: agents.x-k8s.io
+  group: extensions.agents.x-k8s.io
   names:
     kind: SandboxWarmPool
     listKind: SandboxWarmPoolList
@@ -241,19 +249,16 @@ spec:
             spec:
               type: object
               properties:
-                templateRef:
+                sandboxTemplateRef:
                   type: object
                   properties:
                     name:
                       type: string
                   required:
                     - name
-                desiredReady:
+                replicas:
                   type: integer
                   minimum: 0
-                maxSize:
-                  type: integer
-                  minimum: 1
             status:
               type: object
               properties:
@@ -269,13 +274,16 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.readyReplicas
       additionalPrinterColumns:
         - name: Ready
           type: integer
           jsonPath: .status.readyReplicas
         - name: Desired
           type: integer
-          jsonPath: .spec.desiredReady
+          jsonPath: .spec.replicas
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp

--- a/packages/agent-sandbox-sdk/__tests__/builders.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/builders.test.ts
@@ -3,7 +3,7 @@ import { SandboxClaimBuilder } from '../src/builders/claim.js';
 import { SandboxBuilder } from '../src/builders/sandbox.js';
 import { SandboxTemplateBuilder } from '../src/builders/template.js';
 import { SandboxWarmPoolBuilder } from '../src/builders/warm-pool.js';
-import { CRD_ANNOTATIONS, CRD_API, CRD_KINDS } from '../src/constants.js';
+import { CRD_ANNOTATIONS, CRD_API, CRD_EXTENSIONS_API, CRD_KINDS } from '../src/constants.js';
 
 describe('SandboxBuilder', () => {
   it('builds a minimal sandbox with correct apiVersion and kind', () => {
@@ -20,28 +20,10 @@ describe('SandboxBuilder', () => {
     expect(sandbox.metadata.namespace).toBe('default');
   });
 
-  it('sets template ref', () => {
-    const sandbox = new SandboxBuilder('test').fromTemplate('my-template').build();
-
-    expect(sandbox.spec.sandboxTemplateRef).toEqual({
-      name: 'my-template',
-      namespace: undefined,
-    });
-  });
-
-  it('sets template ref with namespace', () => {
-    const sandbox = new SandboxBuilder('test').fromTemplate('my-template', 'template-ns').build();
-
-    expect(sandbox.spec.sandboxTemplateRef).toEqual({
-      name: 'my-template',
-      namespace: 'template-ns',
-    });
-  });
-
   it('builds a sandbox with inline image', () => {
     const sandbox = new SandboxBuilder('test').image('ubuntu:24.04').build();
 
-    const container = sandbox.spec.podTemplateSpec?.spec?.containers?.[0];
+    const container = sandbox.spec.podTemplate?.spec?.containers?.[0];
     expect(container?.name).toBe('sandbox');
     expect(container?.image).toBe('ubuntu:24.04');
   });
@@ -52,16 +34,16 @@ describe('SandboxBuilder', () => {
       .resources({ cpu: '500m', memory: '512Mi' })
       .build();
 
-    const container = sandbox.spec.podTemplateSpec?.spec?.containers?.[0];
+    const container = sandbox.spec.podTemplate?.spec?.containers?.[0];
     expect(container?.image).toBe('ubuntu:24.04');
     expect(container?.resources?.limits).toEqual({ cpu: '500m', memory: '512Mi' });
   });
 
-  it('resources creates podTemplateSpec if not present', () => {
+  it('resources creates podTemplate if not present', () => {
     const sandbox = new SandboxBuilder('test').resources({ cpu: '1', memory: '1Gi' }).build();
 
-    expect(sandbox.spec.podTemplateSpec).toBeDefined();
-    const container = sandbox.spec.podTemplateSpec?.spec?.containers?.[0];
+    expect(sandbox.spec.podTemplate).toBeDefined();
+    const container = sandbox.spec.podTemplate?.spec?.containers?.[0];
     expect(container?.resources?.limits).toEqual({ cpu: '1', memory: '1Gi' });
   });
 
@@ -135,90 +117,79 @@ describe('SandboxBuilder', () => {
     expect(sandbox.spec.replicas).toBe(0);
   });
 
-  it('sets TTL', () => {
-    const sandbox = new SandboxBuilder('test').ttl(3600).build();
+  it('sets shutdownTime', () => {
+    const sandbox = new SandboxBuilder('test').shutdownTime('2026-04-01T00:00:00Z').build();
 
-    expect(sandbox.spec.ttlSecondsAfterFinished).toBe(3600);
+    expect(sandbox.spec.shutdownTime).toBe('2026-04-01T00:00:00Z');
   });
 
-  it('sets runtimeClass', () => {
+  it('sets shutdownPolicy', () => {
+    const sandbox = new SandboxBuilder('test').shutdownPolicy('Retain').build();
+
+    expect(sandbox.spec.shutdownPolicy).toBe('Retain');
+  });
+
+  it('sets runtimeClass on podTemplate.spec', () => {
     const sandbox = new SandboxBuilder('test').runtimeClass('gvisor').build();
 
-    expect(sandbox.spec.runtimeClassName).toBe('gvisor');
+    expect(sandbox.spec.podTemplate?.spec?.runtimeClassName).toBe('gvisor');
   });
 
-  it('sets networkPolicy', () => {
-    const sandbox = new SandboxBuilder('test').networkPolicy({ egress: [], ingress: [] }).build();
-
-    expect(sandbox.spec.networkPolicy).toEqual({ egress: [], ingress: [] });
-  });
-
-  it('adds volume claims', () => {
+  it('adds volume claim templates', () => {
     const sandbox = new SandboxBuilder('test')
-      .addVolumeClaim({
-        name: 'data',
-        accessModes: ['ReadWriteOnce'],
-        resources: { requests: { storage: '1Gi' } },
+      .addVolumeClaimTemplate({
+        metadata: { name: 'data' },
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          resources: { requests: { storage: '1Gi' } },
+        },
       })
-      .addVolumeClaim({
-        name: 'logs',
-        accessModes: ['ReadWriteOnce'],
-        resources: { requests: { storage: '500Mi' } },
+      .addVolumeClaimTemplate({
+        metadata: { name: 'logs' },
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          resources: { requests: { storage: '500Mi' } },
+        },
       })
       .build();
 
-    expect(sandbox.spec.volumeClaims).toHaveLength(2);
-    expect(sandbox.spec.volumeClaims![0].name).toBe('data');
-    expect(sandbox.spec.volumeClaims![1].name).toBe('logs');
-  });
-
-  it('sets pod template directly', () => {
-    const podTemplateSpec = {
-      spec: {
-        containers: [{ name: 'custom', image: 'nginx:latest' }],
-      },
-    };
-    const sandbox = new SandboxBuilder('test').withPodTemplate(podTemplateSpec).build();
-
-    expect(sandbox.spec.podTemplateSpec).toEqual(podTemplateSpec);
+    expect(sandbox.spec.volumeClaimTemplates).toHaveLength(2);
+    expect(sandbox.spec.volumeClaimTemplates![0].metadata.name).toBe('data');
+    expect(sandbox.spec.volumeClaimTemplates![1].metadata.name).toBe('logs');
   });
 
   it('supports fluent API chaining', () => {
     const sandbox = new SandboxBuilder('full-sandbox')
       .namespace('production')
-      .fromTemplate('base-template')
       .labels({ env: 'prod' })
       .annotations({ note: 'test' })
       .replicas(1)
-      .ttl(7200)
+      .shutdownTime('2026-04-01T00:00:00Z')
+      .shutdownPolicy('Delete')
       .runtimeClass('kata')
-      .networkPolicy({ egress: [] })
-      .addVolumeClaim({
-        name: 'data',
-        accessModes: ['ReadWriteOnce'],
-        resources: { requests: { storage: '10Gi' } },
+      .addVolumeClaimTemplate({
+        metadata: { name: 'data' },
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          resources: { requests: { storage: '10Gi' } },
+        },
       })
       .agentPaneContext({ projectId: 'p1', taskId: 't1' })
       .build();
 
     expect(sandbox.metadata.name).toBe('full-sandbox');
     expect(sandbox.metadata.namespace).toBe('production');
-    expect(sandbox.spec.sandboxTemplateRef?.name).toBe('base-template');
     expect(sandbox.spec.replicas).toBe(1);
-    expect(sandbox.spec.ttlSecondsAfterFinished).toBe(7200);
-    expect(sandbox.spec.runtimeClassName).toBe('kata');
-    expect(sandbox.spec.volumeClaims).toHaveLength(1);
+    expect(sandbox.spec.shutdownTime).toBe('2026-04-01T00:00:00Z');
+    expect(sandbox.spec.shutdownPolicy).toBe('Delete');
+    expect(sandbox.spec.podTemplate?.spec?.runtimeClassName).toBe('kata');
+    expect(sandbox.spec.volumeClaimTemplates).toHaveLength(1);
   });
 
-  it('image() updates existing podTemplateSpec container', () => {
-    const sandbox = new SandboxBuilder('test')
-      .withPodTemplate({
-        spec: { containers: [{ name: 'sandbox', image: 'old:v1' }] },
-      })
-      .image('new:v2')
-      .build();
+  it('image() updates existing podTemplate container', () => {
+    const sandbox = new SandboxBuilder('test').image('old:v1').image('new:v2').build();
 
-    expect(sandbox.spec.podTemplateSpec?.spec?.containers?.[0]?.image).toBe('new:v2');
+    expect(sandbox.spec.podTemplate?.spec?.containers?.[0]?.image).toBe('new:v2');
   });
 });
 
@@ -226,7 +197,7 @@ describe('SandboxTemplateBuilder', () => {
   it('builds a template with correct apiVersion and kind', () => {
     const template = new SandboxTemplateBuilder('base-template').build();
 
-    expect(template.apiVersion).toBe(CRD_API.apiVersion);
+    expect(template.apiVersion).toBe(CRD_EXTENSIONS_API.apiVersion);
     expect(template.kind).toBe(CRD_KINDS.sandboxTemplate);
     expect(template.metadata.name).toBe('base-template');
   });
@@ -243,7 +214,7 @@ describe('SandboxTemplateBuilder', () => {
       .resources({ cpu: '1', memory: '1Gi' })
       .build();
 
-    const container = template.spec.podTemplateSpec?.spec?.containers?.[0];
+    const container = template.spec.podTemplate?.spec?.containers?.[0];
     expect(container?.image).toBe('node:22');
     expect(container?.resources?.limits).toEqual({ cpu: '1', memory: '1Gi' });
   });
@@ -254,40 +225,30 @@ describe('SandboxTemplateBuilder', () => {
     expect(template.metadata.labels).toEqual({ tier: 'base' });
   });
 
-  it('sets runtimeClass', () => {
-    const template = new SandboxTemplateBuilder('test').runtimeClass('kata').build();
-
-    expect(template.spec.runtimeClassName).toBe('kata');
-  });
-
-  it('sets networkPolicy', () => {
+  it('sets networkPolicy with K8s-native types', () => {
     const template = new SandboxTemplateBuilder('test').networkPolicy({ egress: [] }).build();
 
     expect(template.spec.networkPolicy).toEqual({ egress: [] });
   });
 
-  it('adds volume claims', () => {
+  it('sets networkPolicyManagement mode', () => {
     const template = new SandboxTemplateBuilder('test')
-      .addVolumeClaim({
-        name: 'workspace',
-        accessModes: ['ReadWriteOnce'],
-        resources: { requests: { storage: '5Gi' } },
-      })
+      .networkPolicyManagement('Unmanaged')
       .build();
 
-    expect(template.spec.volumeClaims).toHaveLength(1);
-    expect(template.spec.volumeClaims![0].name).toBe('workspace');
+    expect(template.spec.networkPolicyManagement).toBe('Unmanaged');
   });
 
-  it('sets podTemplateSpec directly', () => {
-    const podTemplateSpec = {
+  it('sets podTemplate directly', () => {
+    const podTemplate = {
       spec: {
         containers: [{ name: 'sandbox', image: 'ubuntu:24.04' }],
       },
+      metadata: {},
     };
-    const template = new SandboxTemplateBuilder('test').podTemplateSpec(podTemplateSpec).build();
+    const template = new SandboxTemplateBuilder('test').podTemplate(podTemplate as any).build();
 
-    expect(template.spec.podTemplateSpec).toEqual(podTemplateSpec);
+    expect(template.spec.podTemplate).toEqual(podTemplate);
   });
 
   it('supports fluent chaining', () => {
@@ -296,17 +257,12 @@ describe('SandboxTemplateBuilder', () => {
       .labels({ version: 'v1' })
       .image('python:3.12')
       .resources({ cpu: '2', memory: '4Gi' })
-      .runtimeClass('gvisor')
       .networkPolicy({ ingress: [] })
-      .addVolumeClaim({
-        name: 'data',
-        accessModes: ['ReadWriteOnce'],
-        resources: { requests: { storage: '10Gi' } },
-      })
+      .networkPolicyManagement('Managed')
       .build();
 
     expect(template.metadata.name).toBe('full-template');
-    expect(template.spec.runtimeClassName).toBe('gvisor');
+    expect(template.spec.networkPolicyManagement).toBe('Managed');
   });
 });
 
@@ -314,7 +270,7 @@ describe('SandboxClaimBuilder', () => {
   it('builds a claim with correct apiVersion and kind', () => {
     const claim = new SandboxClaimBuilder('my-claim').build();
 
-    expect(claim.apiVersion).toBe(CRD_API.apiVersion);
+    expect(claim.apiVersion).toBe(CRD_EXTENSIONS_API.apiVersion);
     expect(claim.kind).toBe(CRD_KINDS.sandboxClaim);
     expect(claim.metadata.name).toBe('my-claim');
   });
@@ -325,30 +281,32 @@ describe('SandboxClaimBuilder', () => {
     expect(claim.metadata.namespace).toBe('default');
   });
 
-  it('sets template ref', () => {
+  it('sets template ref (name only)', () => {
     const claim = new SandboxClaimBuilder('test').templateRef('my-template').build();
 
     expect(claim.spec.sandboxTemplateRef).toEqual({
       name: 'my-template',
-      namespace: undefined,
     });
   });
 
-  it('sets template ref with namespace', () => {
-    const claim = new SandboxClaimBuilder('test').templateRef('my-template', 'tpl-ns').build();
+  it('sets lifecycle with shutdownTime and shutdownPolicy', () => {
+    const claim = new SandboxClaimBuilder('test')
+      .lifecycle({ shutdownTime: '2026-04-01T00:00:00Z', shutdownPolicy: 'Delete' })
+      .build();
 
-    expect(claim.spec.sandboxTemplateRef).toEqual({
-      name: 'my-template',
-      namespace: 'tpl-ns',
+    expect(claim.spec.lifecycle).toEqual({
+      shutdownTime: '2026-04-01T00:00:00Z',
+      shutdownPolicy: 'Delete',
     });
   });
 
-  it('sets warm pool ref', () => {
-    const claim = new SandboxClaimBuilder('test').warmPoolRef('my-pool', 'pool-ns').build();
+  it('sets lifecycle with only shutdownTime', () => {
+    const claim = new SandboxClaimBuilder('test')
+      .lifecycle({ shutdownTime: '2026-04-01T00:00:00Z' })
+      .build();
 
-    expect(claim.spec.warmPoolRef).toEqual({
-      name: 'my-pool',
-      namespace: 'pool-ns',
+    expect(claim.spec.lifecycle).toEqual({
+      shutdownTime: '2026-04-01T00:00:00Z',
     });
   });
 
@@ -362,14 +320,14 @@ describe('SandboxClaimBuilder', () => {
     const claim = new SandboxClaimBuilder('my-claim')
       .namespace('default')
       .templateRef('my-template')
-      .warmPoolRef('my-pool')
+      .lifecycle({ shutdownPolicy: 'Retain' })
       .labels({ app: 'test' })
       .build();
 
     expect(claim.metadata.name).toBe('my-claim');
     expect(claim.metadata.namespace).toBe('default');
     expect(claim.spec.sandboxTemplateRef?.name).toBe('my-template');
-    expect(claim.spec.warmPoolRef?.name).toBe('my-pool');
+    expect(claim.spec.lifecycle?.shutdownPolicy).toBe('Retain');
   });
 });
 
@@ -377,7 +335,7 @@ describe('SandboxWarmPoolBuilder', () => {
   it('builds a warm pool with correct apiVersion and kind', () => {
     const pool = new SandboxWarmPoolBuilder('my-pool').build();
 
-    expect(pool.apiVersion).toBe(CRD_API.apiVersion);
+    expect(pool.apiVersion).toBe(CRD_EXTENSIONS_API.apiVersion);
     expect(pool.kind).toBe(CRD_KINDS.sandboxWarmPool);
     expect(pool.metadata.name).toBe('my-pool');
   });
@@ -388,34 +346,18 @@ describe('SandboxWarmPoolBuilder', () => {
     expect(pool.metadata.namespace).toBe('default');
   });
 
-  it('sets replicas (desiredReady)', () => {
+  it('sets replicas', () => {
     const pool = new SandboxWarmPoolBuilder('test').replicas(3).build();
 
-    expect(pool.spec.desiredReady).toBe(3);
+    expect(pool.spec.replicas).toBe(3);
   });
 
-  it('sets template ref', () => {
-    const pool = new SandboxWarmPoolBuilder('test').templateRef('base-template').build();
+  it('sets sandboxTemplateRef (name only)', () => {
+    const pool = new SandboxWarmPoolBuilder('test').sandboxTemplateRef('base-template').build();
 
-    expect(pool.spec.templateRef).toEqual({
+    expect(pool.spec.sandboxTemplateRef).toEqual({
       name: 'base-template',
-      namespace: undefined,
     });
-  });
-
-  it('sets template ref with namespace', () => {
-    const pool = new SandboxWarmPoolBuilder('test').templateRef('base-template', 'tpl-ns').build();
-
-    expect(pool.spec.templateRef).toEqual({
-      name: 'base-template',
-      namespace: 'tpl-ns',
-    });
-  });
-
-  it('sets maxSize', () => {
-    const pool = new SandboxWarmPoolBuilder('test').autoscale(10).build();
-
-    expect(pool.spec.maxSize).toBe(10);
   });
 
   it('sets labels', () => {
@@ -428,15 +370,13 @@ describe('SandboxWarmPoolBuilder', () => {
     const pool = new SandboxWarmPoolBuilder('my-pool')
       .namespace('default')
       .replicas(3)
-      .templateRef('base-template')
-      .autoscale(10)
+      .sandboxTemplateRef('base-template')
       .labels({ tier: 'warm' })
       .build();
 
     expect(pool.metadata.name).toBe('my-pool');
     expect(pool.metadata.namespace).toBe('default');
-    expect(pool.spec.desiredReady).toBe(3);
-    expect(pool.spec.templateRef?.name).toBe('base-template');
-    expect(pool.spec.maxSize).toBe(10);
+    expect(pool.spec.replicas).toBe(3);
+    expect(pool.spec.sandboxTemplateRef?.name).toBe('base-template');
   });
 });

--- a/packages/agent-sandbox-sdk/__tests__/builders.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/builders.test.ts
@@ -14,6 +14,14 @@ describe('SandboxBuilder', () => {
     expect(sandbox.metadata.name).toBe('my-sandbox');
   });
 
+  it('uses core API group (not extensions) for Sandbox', () => {
+    const sandbox = new SandboxBuilder('test').build();
+
+    // Sandbox is in the core group, not extensions
+    expect(sandbox.apiVersion).toBe('agents.x-k8s.io/v1alpha1');
+    expect(sandbox.apiVersion).not.toContain('extensions');
+  });
+
   it('sets namespace', () => {
     const sandbox = new SandboxBuilder('test').namespace('default').build();
 
@@ -308,6 +316,17 @@ describe('SandboxClaimBuilder', () => {
     expect(claim.spec.lifecycle).toEqual({
       shutdownTime: '2026-04-01T00:00:00Z',
     });
+  });
+
+  it('sets lifecycle with only shutdownPolicy', () => {
+    const claim = new SandboxClaimBuilder('test')
+      .lifecycle({ shutdownPolicy: 'Retain' })
+      .build();
+
+    expect(claim.spec.lifecycle).toEqual({
+      shutdownPolicy: 'Retain',
+    });
+    expect(claim.spec.lifecycle?.shutdownTime).toBeUndefined();
   });
 
   it('sets labels', () => {

--- a/packages/agent-sandbox-sdk/__tests__/builders.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/builders.test.ts
@@ -319,9 +319,7 @@ describe('SandboxClaimBuilder', () => {
   });
 
   it('sets lifecycle with only shutdownPolicy', () => {
-    const claim = new SandboxClaimBuilder('test')
-      .lifecycle({ shutdownPolicy: 'Retain' })
-      .build();
+    const claim = new SandboxClaimBuilder('test').lifecycle({ shutdownPolicy: 'Retain' }).build();
 
     expect(claim.spec.lifecycle).toEqual({
       shutdownPolicy: 'Retain',

--- a/packages/agent-sandbox-sdk/__tests__/client.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/client.test.ts
@@ -207,6 +207,28 @@ describe('AgentSandboxClient', () => {
       });
       expect(await client.sandboxExists('missing')).toBe(false);
     });
+
+    it('sandbox CRUD uses core API group (not extensions)', async () => {
+      mockCustomObjectsApi.createNamespacedCustomObject.mockResolvedValue({});
+      mockCustomObjectsApi.getNamespacedCustomObject.mockResolvedValue({});
+      mockCustomObjectsApi.listNamespacedCustomObject.mockResolvedValue({ items: [] });
+      mockCustomObjectsApi.deleteNamespacedCustomObject.mockResolvedValue({});
+
+      await client.createSandbox({ apiVersion: 'agents.x-k8s.io/v1alpha1', kind: 'Sandbox', metadata: { name: 'test' }, spec: {} } as any);
+      await client.getSandbox('test');
+      await client.listSandboxes();
+      await client.deleteSandbox('test');
+
+      for (const call of [
+        ...mockCustomObjectsApi.createNamespacedCustomObject.mock.calls,
+        ...mockCustomObjectsApi.getNamespacedCustomObject.mock.calls,
+        ...mockCustomObjectsApi.listNamespacedCustomObject.mock.calls,
+        ...mockCustomObjectsApi.deleteNamespacedCustomObject.mock.calls,
+      ]) {
+        expect(call[0].group).toBe('agents.x-k8s.io');
+        expect(call[0].group).not.toContain('extensions');
+      }
+    });
   });
 
   describe('Template CRUD', () => {
@@ -261,6 +283,24 @@ describe('AgentSandboxClient', () => {
           plural: 'sandboxtemplates',
         })
       );
+    });
+
+    it('template CRUD uses extensions API group consistently', async () => {
+      mockCustomObjectsApi.getNamespacedCustomObject.mockResolvedValue({});
+      mockCustomObjectsApi.listNamespacedCustomObject.mockResolvedValue({ items: [] });
+      mockCustomObjectsApi.deleteNamespacedCustomObject.mockResolvedValue({});
+
+      await client.getTemplate('tpl');
+      await client.listTemplates();
+      await client.deleteTemplate('tpl');
+
+      for (const call of [
+        ...mockCustomObjectsApi.getNamespacedCustomObject.mock.calls,
+        ...mockCustomObjectsApi.listNamespacedCustomObject.mock.calls,
+        ...mockCustomObjectsApi.deleteNamespacedCustomObject.mock.calls,
+      ]) {
+        expect(call[0].group).toBe('extensions.agents.x-k8s.io');
+      }
     });
   });
 
@@ -528,6 +568,36 @@ describe('AgentSandboxClient', () => {
 
       expect(health.healthy).toBe(true);
       expect(health.controllerInstalled).toBe(false);
+    });
+
+    it('checks both core and extensions CRDs during healthCheck', async () => {
+      mockVersionApi.getCode.mockResolvedValue({ gitVersion: 'v1.30.0' });
+      mockApiExtApi.readCustomResourceDefinition.mockResolvedValue({});
+      mockCoreApi.readNamespace.mockResolvedValue({});
+      mockAppsApi.listNamespacedDeployment.mockResolvedValue({ items: [] });
+
+      await client.healthCheck();
+
+      // Verify both the core Sandbox CRD and extensions SandboxTemplate CRD are checked
+      expect(mockApiExtApi.readCustomResourceDefinition).toHaveBeenCalledWith({
+        name: 'sandboxes.agents.x-k8s.io',
+      });
+      expect(mockApiExtApi.readCustomResourceDefinition).toHaveBeenCalledWith({
+        name: 'sandboxtemplates.extensions.agents.x-k8s.io',
+      });
+    });
+
+    it('reports CRD not registered when extensions CRD is missing', async () => {
+      mockVersionApi.getCode.mockResolvedValue({ gitVersion: 'v1.30.0' });
+      // First call (core CRD) succeeds, second (extensions CRD) fails
+      mockApiExtApi.readCustomResourceDefinition
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce({ statusCode: 404 });
+      mockCoreApi.readNamespace.mockResolvedValue({});
+
+      const health = await client.healthCheck();
+
+      expect(health.crdRegistered).toBe(false);
     });
   });
 });

--- a/packages/agent-sandbox-sdk/__tests__/client.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/client.test.ts
@@ -210,19 +210,19 @@ describe('AgentSandboxClient', () => {
   });
 
   describe('Template CRUD', () => {
-    it('createTemplate uses agents group and sandboxtemplates plural', async () => {
+    it('createTemplate uses extensions group and sandboxtemplates plural', async () => {
       const template = {
-        apiVersion: 'agents.x-k8s.io/v1alpha1',
+        apiVersion: 'extensions.agents.x-k8s.io/v1alpha1',
         kind: 'SandboxTemplate',
         metadata: { name: 'base' },
-        spec: { podTemplateSpec: {} },
+        spec: { podTemplate: { spec: { containers: [] }, metadata: {} } },
       };
       mockCustomObjectsApi.createNamespacedCustomObject.mockResolvedValue(template);
 
       await client.createTemplate(template as any);
       expect(mockCustomObjectsApi.createNamespacedCustomObject).toHaveBeenCalledWith(
         expect.objectContaining({
-          group: 'agents.x-k8s.io',
+          group: 'extensions.agents.x-k8s.io',
           plural: 'sandboxtemplates',
         })
       );
@@ -265,9 +265,9 @@ describe('AgentSandboxClient', () => {
   });
 
   describe('Claim CRUD', () => {
-    it('createClaim uses agents group and sandboxclaims plural', async () => {
+    it('createClaim uses extensions group and sandboxclaims plural', async () => {
       const claim = {
-        apiVersion: 'agents.x-k8s.io/v1alpha1',
+        apiVersion: 'extensions.agents.x-k8s.io/v1alpha1',
         kind: 'SandboxClaim',
         metadata: { name: 'claim-1' },
         spec: { sandboxTemplateRef: { name: 'base' } },
@@ -277,7 +277,7 @@ describe('AgentSandboxClient', () => {
       await client.createClaim(claim as any);
       expect(mockCustomObjectsApi.createNamespacedCustomObject).toHaveBeenCalledWith(
         expect.objectContaining({
-          group: 'agents.x-k8s.io',
+          group: 'extensions.agents.x-k8s.io',
           plural: 'sandboxclaims',
         })
       );
@@ -320,19 +320,19 @@ describe('AgentSandboxClient', () => {
   });
 
   describe('WarmPool CRUD', () => {
-    it('createWarmPool uses agents group and sandboxwarmpools plural', async () => {
+    it('createWarmPool uses extensions group and sandboxwarmpools plural', async () => {
       const pool = {
-        apiVersion: 'agents.x-k8s.io/v1alpha1',
+        apiVersion: 'extensions.agents.x-k8s.io/v1alpha1',
         kind: 'SandboxWarmPool',
         metadata: { name: 'pool-1' },
-        spec: { desiredReady: 3, templateRef: { name: 'base' } },
+        spec: { replicas: 3, sandboxTemplateRef: { name: 'base' } },
       };
       mockCustomObjectsApi.createNamespacedCustomObject.mockResolvedValue(pool);
 
       await client.createWarmPool(pool as any);
       expect(mockCustomObjectsApi.createNamespacedCustomObject).toHaveBeenCalledWith(
         expect.objectContaining({
-          group: 'agents.x-k8s.io',
+          group: 'extensions.agents.x-k8s.io',
           plural: 'sandboxwarmpools',
         })
       );

--- a/packages/agent-sandbox-sdk/__tests__/client.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/client.test.ts
@@ -214,7 +214,12 @@ describe('AgentSandboxClient', () => {
       mockCustomObjectsApi.listNamespacedCustomObject.mockResolvedValue({ items: [] });
       mockCustomObjectsApi.deleteNamespacedCustomObject.mockResolvedValue({});
 
-      await client.createSandbox({ apiVersion: 'agents.x-k8s.io/v1alpha1', kind: 'Sandbox', metadata: { name: 'test' }, spec: {} } as any);
+      await client.createSandbox({
+        apiVersion: 'agents.x-k8s.io/v1alpha1',
+        kind: 'Sandbox',
+        metadata: { name: 'test' },
+        spec: {},
+      } as any);
       await client.getSandbox('test');
       await client.listSandboxes();
       await client.deleteSandbox('test');

--- a/packages/agent-sandbox-sdk/__tests__/exec.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/exec.test.ts
@@ -410,9 +410,9 @@ describe('execInSandbox', () => {
     ).rejects.toThrow('network error');
   });
 
-  it('uses podName from sandbox status when available', async () => {
+  it('uses podName from sandbox annotation when available', async () => {
     mockGetNamespacedCustomObject.mockResolvedValue({
-      status: { podName: 'resolved-pod' },
+      metadata: { annotations: { 'agents.x-k8s.io/pod-name': 'resolved-pod' } },
     });
 
     mockExec.mockImplementation(
@@ -443,9 +443,9 @@ describe('execInSandbox', () => {
     expect(result.stdout).toBe('resolved-pod');
   });
 
-  it('falls back to sandbox name when status has no podName', async () => {
+  it('falls back to sandbox name when annotation has no pod-name', async () => {
     mockGetNamespacedCustomObject.mockResolvedValue({
-      status: {},
+      metadata: {},
     });
 
     mockExec.mockImplementation(

--- a/packages/agent-sandbox-sdk/__tests__/kubeconfig.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/kubeconfig.test.ts
@@ -14,6 +14,7 @@ const mockGetCurrentContext = vi.fn();
 const mockGetCurrentCluster = vi.fn();
 const mockGetContextObject = vi.fn();
 const mockGetCluster = vi.fn();
+const mockClusters: Array<{ server: string; skipTLSVerify?: boolean }> = [];
 
 vi.mock('@kubernetes/client-node', () => ({
   KubeConfig: class MockKubeConfig {
@@ -25,6 +26,7 @@ vi.mock('@kubernetes/client-node', () => ({
     getCurrentCluster = mockGetCurrentCluster;
     getContextObject = mockGetContextObject;
     getCluster = mockGetCluster;
+    clusters = mockClusters;
   },
 }));
 
@@ -39,6 +41,7 @@ describe('loadKubeConfig', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockClusters.length = 0;
     process.env = { ...originalEnv };
     delete process.env.K8S_KUBECONFIG;
     delete process.env.KUBECONFIG;
@@ -197,18 +200,18 @@ describe('loadKubeConfig', () => {
     it('applies skipTLSVerify when set', () => {
       mockExistsSync.mockReturnValue(false);
       const cluster = { server: 'https://localhost', skipTLSVerify: false };
-      mockGetCurrentCluster.mockReturnValue(cluster);
+      mockClusters.push(cluster);
 
       loadKubeConfig({ skipTLSVerify: true });
 
       expect(cluster.skipTLSVerify).toBe(true);
     });
 
-    it('does not set skipTLSVerify when cluster is null', () => {
+    it('does not set skipTLSVerify when clusters array is empty', () => {
       mockExistsSync.mockReturnValue(false);
-      mockGetCurrentCluster.mockReturnValue(null);
+      // mockClusters is empty by default (cleared in beforeEach)
 
-      // Should not throw
+      // Should not throw — iterating an empty array is fine
       expect(() => loadKubeConfig({ skipTLSVerify: true })).not.toThrow();
     });
 

--- a/packages/agent-sandbox-sdk/__tests__/schemas.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/schemas.test.ts
@@ -209,7 +209,12 @@ describe('sandboxStatusSchema', () => {
     const result = sandboxStatusSchema.safeParse({
       replicas: 0,
       conditions: [
-        { type: 'Ready', status: 'False', reason: 'SandboxExpired', message: 'Sandbox has expired' },
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'SandboxExpired',
+          message: 'Sandbox has expired',
+        },
       ],
     });
     expect(result.success).toBe(true);

--- a/packages/agent-sandbox-sdk/__tests__/schemas.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/schemas.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { sandboxClaimSchema, sandboxClaimSpecSchema } from '../src/schemas/claim.js';
 import {
+  sandboxClaimSchema,
+  sandboxClaimSpecSchema,
+  sandboxClaimStatusSchema,
+} from '../src/schemas/claim.js';
+import {
+  podMetadataSchema,
+  podTemplateSchema,
   sandboxSchema,
   sandboxSpecSchema,
   sandboxStatusSchema,
-  sandboxVolumeClaimSchema,
+  shutdownPolicySchema,
 } from '../src/schemas/sandbox.js';
 import { sandboxTemplateSchema, sandboxTemplateSpecSchema } from '../src/schemas/template.js';
 import { sandboxWarmPoolSchema, sandboxWarmPoolSpecSchema } from '../src/schemas/warm-pool.js';
@@ -14,7 +20,12 @@ describe('sandboxSchema', () => {
     apiVersion: 'agents.x-k8s.io/v1alpha1',
     kind: 'Sandbox',
     metadata: { name: 'test-sandbox' },
-    spec: {},
+    spec: {
+      podTemplate: {
+        spec: { containers: [{ name: 'main', image: 'ubuntu:24.04' }] },
+        metadata: {},
+      },
+    },
   };
 
   it('accepts a valid minimal sandbox', () => {
@@ -22,22 +33,14 @@ describe('sandboxSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts a sandbox with template ref', () => {
+  it('accepts a sandbox with lifecycle fields', () => {
     const result = sandboxSchema.safeParse({
       ...validSandbox,
       spec: {
-        sandboxTemplateRef: { name: 'my-template' },
+        ...validSandbox.spec,
         replicas: 1,
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts sandbox with template ref and namespace', () => {
-    const result = sandboxSchema.safeParse({
-      ...validSandbox,
-      spec: {
-        sandboxTemplateRef: { name: 'my-template', namespace: 'tpl-ns' },
+        shutdownTime: '2026-12-31T23:59:59Z',
+        shutdownPolicy: 'Delete',
       },
     });
     expect(result.success).toBe(true);
@@ -69,9 +72,9 @@ describe('sandboxSchema', () => {
     const result = sandboxSchema.safeParse({
       ...validSandbox,
       status: {
-        phase: 'Running',
-        podName: 'test-pod',
-        podIP: '10.0.0.1',
+        replicas: 1,
+        serviceFQDN: 'sandbox.default.svc.cluster.local',
+        service: 'test-service',
       },
     });
     expect(result.success).toBe(true);
@@ -100,68 +103,63 @@ describe('sandboxSchema', () => {
 });
 
 describe('sandboxSpecSchema', () => {
-  it('accepts empty spec', () => {
-    const result = sandboxSpecSchema.safeParse({});
+  const minimalSpec = {
+    podTemplate: {
+      spec: { containers: [] },
+      metadata: {},
+    },
+  };
+
+  it('accepts spec with podTemplate', () => {
+    const result = sandboxSpecSchema.safeParse(minimalSpec);
     expect(result.success).toBe(true);
   });
 
   it('accepts spec with replicas 0', () => {
-    const result = sandboxSpecSchema.safeParse({ replicas: 0 });
+    const result = sandboxSpecSchema.safeParse({ ...minimalSpec, replicas: 0 });
     expect(result.success).toBe(true);
   });
 
   it('accepts spec with replicas 1', () => {
-    const result = sandboxSpecSchema.safeParse({ replicas: 1 });
+    const result = sandboxSpecSchema.safeParse({ ...minimalSpec, replicas: 1 });
     expect(result.success).toBe(true);
   });
 
   it('rejects spec with replicas > 1', () => {
-    const result = sandboxSpecSchema.safeParse({ replicas: 2 });
+    const result = sandboxSpecSchema.safeParse({ ...minimalSpec, replicas: 2 });
     expect(result.success).toBe(false);
   });
 
   it('rejects spec with negative replicas', () => {
-    const result = sandboxSpecSchema.safeParse({ replicas: -1 });
+    const result = sandboxSpecSchema.safeParse({ ...minimalSpec, replicas: -1 });
     expect(result.success).toBe(false);
   });
 
   it('rejects spec with non-integer replicas', () => {
-    const result = sandboxSpecSchema.safeParse({ replicas: 0.5 });
+    const result = sandboxSpecSchema.safeParse({ ...minimalSpec, replicas: 0.5 });
     expect(result.success).toBe(false);
   });
 
-  it('accepts spec with runtimeClassName', () => {
-    const result = sandboxSpecSchema.safeParse({ runtimeClassName: 'gvisor' });
+  it('accepts spec with shutdownPolicy', () => {
+    const result = sandboxSpecSchema.safeParse({ ...minimalSpec, shutdownPolicy: 'Delete' });
     expect(result.success).toBe(true);
   });
 
-  it('accepts spec with ttlSecondsAfterFinished', () => {
-    const result = sandboxSpecSchema.safeParse({ ttlSecondsAfterFinished: 3600 });
-    expect(result.success).toBe(true);
-  });
-
-  it('rejects negative ttlSecondsAfterFinished', () => {
-    const result = sandboxSpecSchema.safeParse({ ttlSecondsAfterFinished: -1 });
-    expect(result.success).toBe(false);
-  });
-
-  it('accepts spec with networkPolicy', () => {
+  it('accepts spec with shutdownTime', () => {
     const result = sandboxSpecSchema.safeParse({
-      networkPolicy: {
-        egress: [{ ports: [{ port: 443, protocol: 'TCP' }] }],
-        ingress: [],
-      },
+      ...minimalSpec,
+      shutdownTime: '2026-12-31T23:59:59Z',
     });
     expect(result.success).toBe(true);
   });
 
-  it('accepts spec with volumeClaims', () => {
+  it('accepts spec with volumeClaimTemplates', () => {
     const result = sandboxSpecSchema.safeParse({
-      volumeClaims: [
+      ...minimalSpec,
+      volumeClaimTemplates: [
         {
-          name: 'data',
-          accessModes: ['ReadWriteOnce'],
-          resources: { requests: { storage: '1Gi' } },
+          metadata: { name: 'data' },
+          spec: { accessModes: ['ReadWriteOnce'] },
         },
       ],
     });
@@ -170,78 +168,67 @@ describe('sandboxSpecSchema', () => {
 });
 
 describe('sandboxStatusSchema', () => {
-  it('accepts valid phases', () => {
-    for (const phase of ['Pending', 'Running', 'Paused', 'Succeeded', 'Failed', 'Unknown']) {
-      const result = sandboxStatusSchema.safeParse({ phase });
-      expect(result.success).toBe(true);
-    }
+  it('requires replicas field', () => {
+    const result = sandboxStatusSchema.safeParse({});
+    expect(result.success).toBe(false);
   });
 
-  it('rejects invalid phase', () => {
-    const result = sandboxStatusSchema.safeParse({ phase: 'InvalidPhase' });
-    expect(result.success).toBe(false);
+  it('accepts status with replicas only', () => {
+    const result = sandboxStatusSchema.safeParse({ replicas: 0 });
+    expect(result.success).toBe(true);
   });
 
   it('accepts status with all fields', () => {
     const result = sandboxStatusSchema.safeParse({
-      phase: 'Running',
-      podName: 'sandbox-pod',
       serviceFQDN: 'sandbox.default.svc.cluster.local',
-      podIP: '10.0.0.1',
-      readyReplicas: 1,
-      readyAt: '2026-01-01T00:00:00Z',
+      service: 'test-service',
+      conditions: [],
+      replicas: 1,
+      selector: 'app=sandbox',
     });
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts empty status', () => {
-    const result = sandboxStatusSchema.safeParse({});
     expect(result.success).toBe(true);
   });
 });
 
-describe('sandboxVolumeClaimSchema', () => {
-  it('accepts valid volume claim', () => {
-    const result = sandboxVolumeClaimSchema.safeParse({
-      name: 'data',
-      accessModes: ['ReadWriteOnce'],
-      resources: { requests: { storage: '1Gi' } },
+describe('shutdownPolicySchema', () => {
+  it('accepts Delete', () => {
+    const result = shutdownPolicySchema.safeParse('Delete');
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts Retain', () => {
+    const result = shutdownPolicySchema.safeParse('Retain');
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid policy', () => {
+    const result = shutdownPolicySchema.safeParse('Destroy');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('podTemplateSchema', () => {
+  it('requires metadata (not optional)', () => {
+    const result = podTemplateSchema.safeParse({
+      spec: { containers: [] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts with metadata and spec', () => {
+    const result = podTemplateSchema.safeParse({
+      spec: { containers: [] },
+      metadata: {},
     });
     expect(result.success).toBe(true);
   });
 
-  it('accepts volume claim with storageClassName', () => {
-    const result = sandboxVolumeClaimSchema.safeParse({
-      name: 'data',
-      storageClassName: 'fast-ssd',
-      accessModes: ['ReadWriteOnce'],
-      resources: { requests: { storage: '10Gi' } },
+  it('accepts metadata with labels and annotations', () => {
+    const result = podMetadataSchema.safeParse({
+      labels: { app: 'test' },
+      annotations: { note: 'hello' },
     });
     expect(result.success).toBe(true);
-  });
-
-  it('rejects volume claim without name', () => {
-    const result = sandboxVolumeClaimSchema.safeParse({
-      accessModes: ['ReadWriteOnce'],
-      resources: { requests: { storage: '1Gi' } },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects volume claim without accessModes', () => {
-    const result = sandboxVolumeClaimSchema.safeParse({
-      name: 'data',
-      resources: { requests: { storage: '1Gi' } },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects volume claim without resources', () => {
-    const result = sandboxVolumeClaimSchema.safeParse({
-      name: 'data',
-      accessModes: ['ReadWriteOnce'],
-    });
-    expect(result.success).toBe(false);
   });
 });
 
@@ -251,8 +238,9 @@ describe('sandboxTemplateSchema', () => {
     kind: 'SandboxTemplate',
     metadata: { name: 'base' },
     spec: {
-      podTemplateSpec: {
+      podTemplate: {
         spec: { containers: [{ name: 'sandbox', image: 'ubuntu:24.04' }] },
+        metadata: {},
       },
     },
   };
@@ -281,25 +269,18 @@ describe('sandboxTemplateSchema', () => {
   it('accepts template with status', () => {
     const result = sandboxTemplateSchema.safeParse({
       ...validTemplate,
-      status: { sandboxCount: 5 },
+      status: {},
     });
     expect(result.success).toBe(true);
   });
 
-  it('accepts template with optional spec fields', () => {
+  it('accepts template with networkPolicy and networkPolicyManagement', () => {
     const result = sandboxTemplateSchema.safeParse({
       ...validTemplate,
       spec: {
         ...validTemplate.spec,
-        runtimeClassName: 'gvisor',
-        networkPolicy: { egress: [] },
-        volumeClaims: [
-          {
-            name: 'ws',
-            accessModes: ['ReadWriteOnce'],
-            resources: { requests: { storage: '5Gi' } },
-          },
-        ],
+        networkPolicy: { egress: [], ingress: [] },
+        networkPolicyManagement: 'Managed',
       },
     });
     expect(result.success).toBe(true);
@@ -307,33 +288,38 @@ describe('sandboxTemplateSchema', () => {
 });
 
 describe('sandboxTemplateSpecSchema', () => {
-  it('accepts spec with podTemplateSpec as any object', () => {
-    const result = sandboxTemplateSpecSchema.safeParse({
-      podTemplateSpec: { spec: { containers: [] } },
-    });
+  const minimalSpec = {
+    podTemplate: {
+      spec: { containers: [] },
+      metadata: {},
+    },
+  };
+
+  it('accepts spec with podTemplate', () => {
+    const result = sandboxTemplateSpecSchema.safeParse(minimalSpec);
     expect(result.success).toBe(true);
   });
 
-  it('accepts spec without podTemplateSpec (z.any allows undefined)', () => {
-    // podTemplateSpec is typed as z.any() which permits undefined
+  it('rejects spec without podTemplate', () => {
     const result = sandboxTemplateSpecSchema.safeParse({});
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
   it('accepts spec with all optional fields', () => {
     const result = sandboxTemplateSpecSchema.safeParse({
-      podTemplateSpec: { spec: { containers: [] } },
-      runtimeClassName: 'gvisor',
+      ...minimalSpec,
       networkPolicy: { egress: [], ingress: [] },
-      volumeClaims: [
-        {
-          name: 'data',
-          accessModes: ['ReadWriteOnce'],
-          resources: { requests: { storage: '1Gi' } },
-        },
-      ],
+      networkPolicyManagement: 'Unmanaged',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid networkPolicyManagement', () => {
+    const result = sandboxTemplateSpecSchema.safeParse({
+      ...minimalSpec,
+      networkPolicyManagement: 'Invalid',
+    });
+    expect(result.success).toBe(false);
   });
 });
 
@@ -368,45 +354,38 @@ describe('sandboxClaimSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts claim with warmPoolRef', () => {
+  it('accepts claim with lifecycle', () => {
     const result = sandboxClaimSchema.safeParse({
       ...validClaim,
       spec: {
         sandboxTemplateRef: { name: 'my-template' },
-        warmPoolRef: { name: 'my-pool', namespace: 'pool-ns' },
+        lifecycle: {
+          shutdownTime: '2026-12-31T23:59:59Z',
+          shutdownPolicy: 'Retain',
+        },
       },
     });
     expect(result.success).toBe(true);
   });
 
-  it('accepts claim with status', () => {
+  it('accepts claim with status containing sandbox Name', () => {
     const result = sandboxClaimSchema.safeParse({
       ...validClaim,
       status: {
-        phase: 'Bound',
-        sandboxRef: { name: 'sb-123' },
-        boundAt: '2026-01-01T00:00:00Z',
+        sandbox: { Name: 'sb-123' },
       },
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects claim status with invalid phase', () => {
+  it('accepts claim with status conditions', () => {
     const result = sandboxClaimSchema.safeParse({
       ...validClaim,
-      status: { phase: 'Running' },
+      status: {
+        conditions: [{ type: 'Ready', status: 'True' }],
+      },
     });
-    expect(result.success).toBe(false);
-  });
-
-  it('accepts claim with all valid status phases', () => {
-    for (const phase of ['Pending', 'Bound', 'Failed']) {
-      const result = sandboxClaimSchema.safeParse({
-        ...validClaim,
-        status: { phase },
-      });
-      expect(result.success).toBe(true);
-    }
+    expect(result.success).toBe(true);
   });
 });
 
@@ -423,9 +402,27 @@ describe('sandboxClaimSpecSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts sandboxTemplateRef with namespace', () => {
+  it('sandboxTemplateRef has no namespace field (v0.2.1)', () => {
     const result = sandboxClaimSpecSchema.safeParse({
-      sandboxTemplateRef: { name: 'tpl', namespace: 'ns' },
+      sandboxTemplateRef: { name: 'tpl' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // namespace should not be in the parsed result
+      expect(result.data.sandboxTemplateRef).toEqual({ name: 'tpl' });
+    }
+  });
+});
+
+describe('sandboxClaimStatusSchema', () => {
+  it('accepts empty status', () => {
+    const result = sandboxClaimStatusSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts status with sandbox Name (capital N)', () => {
+    const result = sandboxClaimStatusSchema.safeParse({
+      sandbox: { Name: 'my-sandbox' },
     });
     expect(result.success).toBe(true);
   });
@@ -437,8 +434,8 @@ describe('sandboxWarmPoolSchema', () => {
     kind: 'SandboxWarmPool',
     metadata: { name: 'my-pool' },
     spec: {
-      desiredReady: 3,
-      templateRef: { name: 'base' },
+      replicas: 3,
+      sandboxTemplateRef: { name: 'base' },
     },
   };
 
@@ -455,47 +452,36 @@ describe('sandboxWarmPoolSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects warm pool with negative desiredReady', () => {
+  it('rejects warm pool with negative replicas', () => {
     const result = sandboxWarmPoolSchema.safeParse({
       ...validPool,
-      spec: { ...validPool.spec, desiredReady: -1 },
+      spec: { ...validPool.spec, replicas: -1 },
     });
     expect(result.success).toBe(false);
   });
 
-  it('accepts warm pool with zero desiredReady', () => {
+  it('accepts warm pool with zero replicas', () => {
     const result = sandboxWarmPoolSchema.safeParse({
       ...validPool,
-      spec: { ...validPool.spec, desiredReady: 0 },
+      spec: { ...validPool.spec, replicas: 0 },
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects warm pool with non-integer desiredReady', () => {
+  it('rejects warm pool with non-integer replicas', () => {
     const result = sandboxWarmPoolSchema.safeParse({
       ...validPool,
-      spec: { ...validPool.spec, desiredReady: 1.5 },
+      spec: { ...validPool.spec, replicas: 1.5 },
     });
     expect(result.success).toBe(false);
-  });
-
-  it('accepts warm pool with maxSize', () => {
-    const result = sandboxWarmPoolSchema.safeParse({
-      ...validPool,
-      spec: {
-        ...validPool.spec,
-        maxSize: 10,
-      },
-    });
-    expect(result.success).toBe(true);
   });
 
   it('accepts warm pool with status', () => {
     const result = sandboxWarmPoolSchema.safeParse({
       ...validPool,
       status: {
-        readyReplicas: 3,
-        availableReplicas: 1,
+        replicas: 3,
+        readyReplicas: 2,
       },
     });
     expect(result.success).toBe(true);
@@ -511,24 +497,24 @@ describe('sandboxWarmPoolSchema', () => {
 });
 
 describe('sandboxWarmPoolSpecSchema', () => {
-  it('requires desiredReady', () => {
+  it('requires replicas', () => {
     const result = sandboxWarmPoolSpecSchema.safeParse({
-      templateRef: { name: 'base' },
+      sandboxTemplateRef: { name: 'base' },
     });
     expect(result.success).toBe(false);
   });
 
-  it('requires templateRef', () => {
+  it('requires sandboxTemplateRef', () => {
     const result = sandboxWarmPoolSpecSchema.safeParse({
-      desiredReady: 3,
+      replicas: 3,
     });
     expect(result.success).toBe(false);
   });
 
-  it('requires templateRef.name', () => {
+  it('requires sandboxTemplateRef.name', () => {
     const result = sandboxWarmPoolSpecSchema.safeParse({
-      desiredReady: 3,
-      templateRef: {},
+      replicas: 3,
+      sandboxTemplateRef: {},
     });
     expect(result.success).toBe(false);
   });

--- a/packages/agent-sandbox-sdk/__tests__/schemas.test.ts
+++ b/packages/agent-sandbox-sdk/__tests__/schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  lifecycleSchema,
   sandboxClaimSchema,
   sandboxClaimSpecSchema,
   sandboxClaimStatusSchema,
@@ -12,7 +13,11 @@ import {
   sandboxStatusSchema,
   shutdownPolicySchema,
 } from '../src/schemas/sandbox.js';
-import { sandboxTemplateSchema, sandboxTemplateSpecSchema } from '../src/schemas/template.js';
+import {
+  networkPolicyManagementSchema,
+  sandboxTemplateSchema,
+  sandboxTemplateSpecSchema,
+} from '../src/schemas/template.js';
 import { sandboxWarmPoolSchema, sandboxWarmPoolSpecSchema } from '../src/schemas/warm-pool.js';
 
 describe('sandboxSchema', () => {
@@ -188,6 +193,27 @@ describe('sandboxStatusSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('accepts status with condition-based Ready=True (v0.2.1)', () => {
+    const result = sandboxStatusSchema.safeParse({
+      replicas: 1,
+      conditions: [
+        { type: 'Ready', status: 'True', lastTransitionTime: '2026-01-01T00:00:00Z' },
+        { type: 'PodReady', status: 'True' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts status with condition-based Ready=False and SandboxExpired reason', () => {
+    const result = sandboxStatusSchema.safeParse({
+      replicas: 0,
+      conditions: [
+        { type: 'Ready', status: 'False', reason: 'SandboxExpired', message: 'Sandbox has expired' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('shutdownPolicySchema', () => {
@@ -323,6 +349,58 @@ describe('sandboxTemplateSpecSchema', () => {
   });
 });
 
+describe('lifecycleSchema', () => {
+  it('accepts empty lifecycle', () => {
+    const result = lifecycleSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts lifecycle with shutdownTime only', () => {
+    const result = lifecycleSchema.safeParse({ shutdownTime: '2026-12-31T23:59:59Z' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts lifecycle with shutdownPolicy only', () => {
+    const result = lifecycleSchema.safeParse({ shutdownPolicy: 'Delete' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts lifecycle with both fields', () => {
+    const result = lifecycleSchema.safeParse({
+      shutdownTime: '2026-12-31T23:59:59Z',
+      shutdownPolicy: 'Retain',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid shutdownPolicy in lifecycle', () => {
+    const result = lifecycleSchema.safeParse({ shutdownPolicy: 'Destroy' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('networkPolicyManagementSchema', () => {
+  it('accepts Managed', () => {
+    const result = networkPolicyManagementSchema.safeParse('Managed');
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts Unmanaged', () => {
+    const result = networkPolicyManagementSchema.safeParse('Unmanaged');
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects lowercase managed', () => {
+    const result = networkPolicyManagementSchema.safeParse('managed');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown management mode', () => {
+    const result = networkPolicyManagementSchema.safeParse('Disabled');
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('sandboxClaimSchema', () => {
   const validClaim = {
     apiVersion: 'agents.x-k8s.io/v1alpha1',
@@ -423,6 +501,34 @@ describe('sandboxClaimStatusSchema', () => {
   it('accepts status with sandbox Name (capital N)', () => {
     const result = sandboxClaimStatusSchema.safeParse({
       sandbox: { Name: 'my-sandbox' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('sandbox.Name is optional (empty sandbox object is valid)', () => {
+    const result = sandboxClaimStatusSchema.safeParse({
+      sandbox: {},
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sandbox?.Name).toBeUndefined();
+    }
+  });
+
+  it('accepts status with conditions array', () => {
+    const result = sandboxClaimStatusSchema.safeParse({
+      conditions: [
+        { type: 'Ready', status: 'True', lastTransitionTime: '2026-01-01T00:00:00Z' },
+        { type: 'Bound', status: 'True' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts status with both conditions and sandbox', () => {
+    const result = sandboxClaimStatusSchema.safeParse({
+      conditions: [{ type: 'Ready', status: 'True' }],
+      sandbox: { Name: 'claimed-sandbox-abc' },
     });
     expect(result.success).toBe(true);
   });

--- a/packages/agent-sandbox-sdk/src/builders/claim.ts
+++ b/packages/agent-sandbox-sdk/src/builders/claim.ts
@@ -1,5 +1,6 @@
-import { CRD_API, CRD_KINDS } from '../constants.js';
+import { CRD_EXTENSIONS_API, CRD_KINDS } from '../constants.js';
 import type { SandboxClaim, SandboxClaimSpec } from '../types/claim.js';
+import type { Lifecycle, ShutdownPolicy } from '../types/common.js';
 
 export class SandboxClaimBuilder {
   private resource: {
@@ -15,7 +16,7 @@ export class SandboxClaimBuilder {
 
   constructor(name: string) {
     this.resource = {
-      apiVersion: CRD_API.apiVersion,
+      apiVersion: CRD_EXTENSIONS_API.apiVersion,
       kind: CRD_KINDS.sandboxClaim,
       metadata: { name },
       spec: {},
@@ -35,15 +36,22 @@ export class SandboxClaimBuilder {
     return this;
   }
 
-  /** Reference the template */
-  templateRef(name: string, namespace?: string): this {
-    this.resource.spec.sandboxTemplateRef = { name, namespace };
+  /** Reference the sandbox template (name only, no namespace) */
+  templateRef(name: string): this {
+    this.resource.spec.sandboxTemplateRef = { name };
     return this;
   }
 
-  /** Reference a warm pool */
-  warmPoolRef(name: string, namespace?: string): this {
-    this.resource.spec.warmPoolRef = { name, namespace };
+  /** Set lifecycle options (shutdown time and/or policy) */
+  lifecycle(opts: { shutdownTime?: string; shutdownPolicy?: ShutdownPolicy }): this {
+    const lc: Lifecycle = {};
+    if (opts.shutdownTime !== undefined) {
+      lc.shutdownTime = opts.shutdownTime;
+    }
+    if (opts.shutdownPolicy !== undefined) {
+      lc.shutdownPolicy = opts.shutdownPolicy;
+    }
+    this.resource.spec.lifecycle = lc;
     return this;
   }
 

--- a/packages/agent-sandbox-sdk/src/builders/sandbox.ts
+++ b/packages/agent-sandbox-sdk/src/builders/sandbox.ts
@@ -1,11 +1,11 @@
-import type { V1Container, V1PodTemplateSpec } from '@kubernetes/client-node';
+import type { V1Container, V1PodSpec } from '@kubernetes/client-node';
 import { CRD_ANNOTATIONS, CRD_API, CRD_KINDS } from '../constants.js';
 import type {
-  Sandbox,
-  SandboxNetworkPolicy,
-  SandboxSpec,
-  SandboxVolumeClaim,
-} from '../types/sandbox.js';
+  PersistentVolumeClaimTemplate,
+  PodTemplate,
+  ShutdownPolicy,
+} from '../types/common.js';
+import type { Sandbox, SandboxSpec } from '../types/sandbox.js';
 
 export class SandboxBuilder {
   private resource: {
@@ -50,18 +50,6 @@ export class SandboxBuilder {
     return this;
   }
 
-  /** Use a SandboxTemplate by name */
-  fromTemplate(name: string, namespace?: string): this {
-    this.resource.spec.sandboxTemplateRef = { name, namespace };
-    return this;
-  }
-
-  /** Inline pod template */
-  withPodTemplate(template: V1PodTemplateSpec): this {
-    this.resource.spec.podTemplateSpec = template;
-    return this;
-  }
-
   /** Set container image */
   image(image: string): this {
     this.ensureSandboxContainer().image = image;
@@ -75,34 +63,35 @@ export class SandboxBuilder {
     return this;
   }
 
-  /** Set runtime class (e.g., "gvisor") */
+  /** Set runtime class (e.g., "gvisor") on podTemplate.spec */
   runtimeClass(name: string): this {
-    this.resource.spec.runtimeClassName = name;
+    const podTemplate = this.ensurePodTemplate();
+    podTemplate.spec.runtimeClassName = name;
     return this;
   }
 
-  /** Add volume claim */
-  addVolumeClaim(claim: SandboxVolumeClaim): this {
-    this.resource.spec.volumeClaims ??= [];
-    this.resource.spec.volumeClaims.push(claim);
+  /** Add a volume claim template */
+  addVolumeClaimTemplate(template: PersistentVolumeClaimTemplate): this {
+    this.resource.spec.volumeClaimTemplates ??= [];
+    this.resource.spec.volumeClaimTemplates.push(template);
     return this;
   }
 
-  /** Set network policy */
-  networkPolicy(policy: SandboxNetworkPolicy): this {
-    this.resource.spec.networkPolicy = policy;
+  /** Set shutdown time (ISO date-time string) */
+  shutdownTime(time: string): this {
+    this.resource.spec.shutdownTime = time;
+    return this;
+  }
+
+  /** Set shutdown policy */
+  shutdownPolicy(policy: ShutdownPolicy): this {
+    this.resource.spec.shutdownPolicy = policy;
     return this;
   }
 
   /** Set replicas (0 = paused, 1 = running) */
   replicas(count: number): this {
     this.resource.spec.replicas = count;
-    return this;
-  }
-
-  /** Set TTL after completion */
-  ttl(seconds: number): this {
-    this.resource.spec.ttlSecondsAfterFinished = seconds;
     return this;
   }
 
@@ -121,25 +110,30 @@ export class SandboxBuilder {
   }
 
   /**
-   * Ensure the podTemplateSpec has a 'sandbox' container and return a mutable
-   * reference to it. Creates the podTemplateSpec and container array if needed.
+   * Ensure the podTemplate exists and return a mutable reference to it.
    */
-  private ensureSandboxContainer(): V1Container {
-    if (!this.resource.spec.podTemplateSpec) {
-      this.resource.spec.podTemplateSpec = {
-        spec: { containers: [{ name: 'sandbox' }] },
+  private ensurePodTemplate(): PodTemplate {
+    if (!this.resource.spec.podTemplate) {
+      this.resource.spec.podTemplate = {
+        spec: { containers: [{ name: 'sandbox' }] } as V1PodSpec,
+        metadata: {},
       };
     }
+    return this.resource.spec.podTemplate;
+  }
 
-    const spec = this.resource.spec.podTemplateSpec.spec;
-    if (!spec) {
-      throw new Error('podTemplateSpec.spec is unexpectedly undefined');
-    }
-    if (!spec.containers || spec.containers.length === 0) {
-      spec.containers = [{ name: 'sandbox' }];
+  /**
+   * Ensure the podTemplate has a 'sandbox' container and return a mutable
+   * reference to it. Creates the podTemplate and container array if needed.
+   */
+  private ensureSandboxContainer(): V1Container {
+    const podTemplate = this.ensurePodTemplate();
+
+    if (!podTemplate.spec.containers || podTemplate.spec.containers.length === 0) {
+      podTemplate.spec.containers = [{ name: 'sandbox' }];
     }
 
-    const container = spec.containers[0];
+    const container = podTemplate.spec.containers[0];
     if (!container) {
       throw new Error('sandbox container is unexpectedly undefined');
     }

--- a/packages/agent-sandbox-sdk/src/builders/template.ts
+++ b/packages/agent-sandbox-sdk/src/builders/template.ts
@@ -1,6 +1,6 @@
-import type { V1PodTemplateSpec } from '@kubernetes/client-node';
-import { CRD_API, CRD_KINDS } from '../constants.js';
-import type { SandboxNetworkPolicy, SandboxVolumeClaim } from '../types/sandbox.js';
+import type { V1PodSpec } from '@kubernetes/client-node';
+import { CRD_EXTENSIONS_API, CRD_KINDS } from '../constants.js';
+import type { NetworkPolicyManagement, NetworkPolicySpec, PodTemplate } from '../types/common.js';
 import type { SandboxTemplate, SandboxTemplateSpec } from '../types/template.js';
 
 export class SandboxTemplateBuilder {
@@ -17,7 +17,7 @@ export class SandboxTemplateBuilder {
 
   constructor(name: string) {
     this.resource = {
-      apiVersion: CRD_API.apiVersion,
+      apiVersion: CRD_EXTENSIONS_API.apiVersion,
       kind: CRD_KINDS.sandboxTemplate,
       metadata: { name },
       spec: {},
@@ -38,67 +38,54 @@ export class SandboxTemplateBuilder {
   }
 
   /** Set the pod template */
-  podTemplateSpec(template: V1PodTemplateSpec): this {
-    this.resource.spec.podTemplateSpec = template;
+  podTemplate(template: PodTemplate): this {
+    this.resource.spec.podTemplate = template;
     return this;
   }
 
   /** Set container image */
   image(image: string): this {
-    if (!this.resource.spec.podTemplateSpec) {
-      this.resource.spec.podTemplateSpec = {
-        spec: { containers: [{ name: 'sandbox', image }] },
-      };
-    } else {
-      const containers = this.resource.spec.podTemplateSpec.spec?.containers;
-      if (containers && containers.length > 0 && containers[0]) {
-        containers[0].image = image;
-      } else {
-        this.resource.spec.podTemplateSpec.spec = {
-          ...this.resource.spec.podTemplateSpec.spec,
-          containers: [{ name: 'sandbox', image }],
-        };
-      }
+    const podTemplate = this.ensurePodTemplate();
+    const containers = podTemplate.spec.containers;
+    if (containers && containers.length > 0 && containers[0]) {
+      containers[0].image = image;
     }
     return this;
   }
 
   /** Set resource limits */
   resources(limits: { cpu: string; memory: string }): this {
-    if (!this.resource.spec.podTemplateSpec) {
-      this.resource.spec.podTemplateSpec = {
-        spec: {
-          containers: [{ name: 'sandbox', resources: { limits } }],
-        },
-      };
-    } else {
-      const containers = this.resource.spec.podTemplateSpec.spec?.containers;
-      if (containers && containers.length > 0 && containers[0]) {
-        containers[0].resources = { ...containers[0].resources, limits };
-      }
+    const podTemplate = this.ensurePodTemplate();
+    const containers = podTemplate.spec.containers;
+    if (containers && containers.length > 0 && containers[0]) {
+      containers[0].resources = { ...containers[0].resources, limits };
     }
     return this;
   }
 
-  /** Set runtime class */
-  runtimeClass(name: string): this {
-    this.resource.spec.runtimeClassName = name;
-    return this;
-  }
-
-  /** Set network policy */
-  networkPolicy(policy: SandboxNetworkPolicy): this {
+  /** Set network policy using K8s-native NetworkPolicySpec */
+  networkPolicy(policy: NetworkPolicySpec): this {
     this.resource.spec.networkPolicy = policy;
     return this;
   }
 
-  /** Add volume claim template */
-  addVolumeClaim(claim: SandboxVolumeClaim): this {
-    if (!this.resource.spec.volumeClaims) {
-      this.resource.spec.volumeClaims = [];
-    }
-    this.resource.spec.volumeClaims.push(claim);
+  /** Set network policy management mode */
+  networkPolicyManagement(mode: NetworkPolicyManagement): this {
+    this.resource.spec.networkPolicyManagement = mode;
     return this;
+  }
+
+  /**
+   * Ensure the podTemplate exists and return a mutable reference to it.
+   */
+  private ensurePodTemplate(): PodTemplate {
+    if (!this.resource.spec.podTemplate) {
+      this.resource.spec.podTemplate = {
+        spec: { containers: [{ name: 'sandbox' }] } as V1PodSpec,
+        metadata: {},
+      };
+    }
+    return this.resource.spec.podTemplate;
   }
 
   /** Build the SandboxTemplate resource */

--- a/packages/agent-sandbox-sdk/src/builders/warm-pool.ts
+++ b/packages/agent-sandbox-sdk/src/builders/warm-pool.ts
@@ -1,4 +1,4 @@
-import { CRD_API, CRD_KINDS } from '../constants.js';
+import { CRD_EXTENSIONS_API, CRD_KINDS } from '../constants.js';
 import type { SandboxWarmPool, SandboxWarmPoolSpec } from '../types/warm-pool.js';
 
 export class SandboxWarmPoolBuilder {
@@ -15,7 +15,7 @@ export class SandboxWarmPoolBuilder {
 
   constructor(name: string) {
     this.resource = {
-      apiVersion: CRD_API.apiVersion,
+      apiVersion: CRD_EXTENSIONS_API.apiVersion,
       kind: CRD_KINDS.sandboxWarmPool,
       metadata: { name },
       spec: {},
@@ -37,19 +37,13 @@ export class SandboxWarmPoolBuilder {
 
   /** Set desired number of warm sandboxes to keep ready */
   replicas(count: number): this {
-    this.resource.spec.desiredReady = count;
+    this.resource.spec.replicas = count;
     return this;
   }
 
-  /** Reference the template */
-  templateRef(name: string, namespace?: string): this {
-    this.resource.spec.templateRef = { name, namespace };
-    return this;
-  }
-
-  /** Set maximum pool size */
-  autoscale(max: number): this {
-    this.resource.spec.maxSize = max;
+  /** Reference the sandbox template (name only, no namespace) */
+  sandboxTemplateRef(name: string): this {
+    this.resource.spec.sandboxTemplateRef = { name };
     return this;
   }
 

--- a/packages/agent-sandbox-sdk/src/client.ts
+++ b/packages/agent-sandbox-sdk/src/client.ts
@@ -1,6 +1,6 @@
 import type { KubeConfig } from '@kubernetes/client-node';
 import * as k8s from '@kubernetes/client-node';
-import { CRD_API, CRD_PLURALS } from './constants.js';
+import { CRD_API, CRD_EXTENSIONS_API, CRD_PLURALS } from './constants.js';
 import { loadKubeConfig } from './kubeconfig.js';
 import { CustomResourceCrud } from './operations/crud.js';
 import { execInSandbox, execStreamInSandbox } from './operations/exec.js';
@@ -56,20 +56,20 @@ export class AgentSandboxClient {
     });
 
     this.templateCrud = new CustomResourceCrud<SandboxTemplate>(this.kubeConfig, {
-      group: CRD_API.group,
-      version: CRD_API.version,
+      group: CRD_EXTENSIONS_API.group,
+      version: CRD_EXTENSIONS_API.version,
       plural: CRD_PLURALS.sandboxTemplate,
     });
 
     this.claimCrud = new CustomResourceCrud<SandboxClaim>(this.kubeConfig, {
-      group: CRD_API.group,
-      version: CRD_API.version,
+      group: CRD_EXTENSIONS_API.group,
+      version: CRD_EXTENSIONS_API.version,
       plural: CRD_PLURALS.sandboxClaim,
     });
 
     this.warmPoolCrud = new CustomResourceCrud<SandboxWarmPool>(this.kubeConfig, {
-      group: CRD_API.group,
-      version: CRD_API.version,
+      group: CRD_EXTENSIONS_API.group,
+      version: CRD_EXTENSIONS_API.version,
       plural: CRD_PLURALS.sandboxWarmPool,
     });
   }
@@ -223,7 +223,11 @@ export class AgentSandboxClient {
   watchClaims(callback: WatchCallback<SandboxClaim>, options?: Partial<WatchOptions>): WatchHandle {
     return startWatch<SandboxClaim>(
       this.kubeConfig,
-      { group: CRD_API.group, version: CRD_API.version, plural: CRD_PLURALS.sandboxClaim },
+      {
+        group: CRD_EXTENSIONS_API.group,
+        version: CRD_EXTENSIONS_API.version,
+        plural: CRD_PLURALS.sandboxClaim,
+      },
       { namespace: options?.namespace ?? this.namespace, ...options },
       callback
     );
@@ -261,11 +265,14 @@ export class AgentSandboxClient {
       };
     }
 
-    // Check if CRD is registered
+    // Check if CRDs are registered (both core and extensions)
     try {
       const apiExtApi = this.kubeConfig.makeApiClient(k8s.ApiextensionsV1Api);
       await apiExtApi.readCustomResourceDefinition({
         name: `sandboxes.${CRD_API.group}`,
+      });
+      await apiExtApi.readCustomResourceDefinition({
+        name: `sandboxtemplates.${CRD_EXTENSIONS_API.group}`,
       });
       crdRegistered = true;
     } catch {

--- a/packages/agent-sandbox-sdk/src/constants.ts
+++ b/packages/agent-sandbox-sdk/src/constants.ts
@@ -13,6 +13,20 @@ export const CRD_API = {
 } as const;
 
 /**
+ * Extensions group CRD API constants
+ */
+export const CRD_EXTENSIONS_API = {
+  /** API group for extension CRDs */
+  group: 'extensions.agents.x-k8s.io',
+
+  /** Current API version */
+  version: 'v1alpha1',
+
+  /** Fully qualified apiVersion string */
+  apiVersion: 'extensions.agents.x-k8s.io/v1alpha1',
+} as const;
+
+/**
  * Resource plurals for K8s API paths
  */
 export const CRD_PLURALS = {
@@ -73,6 +87,9 @@ export const CRD_CONDITIONS = {
 
   /** Sandbox is paused */
   paused: 'Paused',
+
+  /** Sandbox has expired (reason, not condition type) */
+  expired: 'SandboxExpired',
 } as const;
 
 /**
@@ -93,4 +110,7 @@ export const CRD_LABELS = {
 
   /** Warm pool state */
   warmPoolState: 'agentpane.io/warm-pool-state',
+
+  /** Claim UID association */
+  claimUid: 'agents.x-k8s.io/claim-uid',
 } as const;

--- a/packages/agent-sandbox-sdk/src/index.ts
+++ b/packages/agent-sandbox-sdk/src/index.ts
@@ -19,6 +19,7 @@ export {
   CRD_ANNOTATIONS,
   CRD_API,
   CRD_CONDITIONS,
+  CRD_EXTENSIONS_API,
   CRD_KINDS,
   CRD_LABELS,
   CRD_PLURALS,
@@ -45,19 +46,27 @@ export { pause, resume, waitForReady } from './operations/lifecycle.js';
 export type { WatchCallback, WatchHandle, WatchOptions } from './operations/watch.js';
 export { startWatch } from './operations/watch.js';
 export {
+  claimSandboxStatusSchema,
+  lifecycleSchema,
   sandboxClaimSchema,
   sandboxClaimSpecSchema,
   sandboxClaimStatusSchema,
+  sandboxTemplateRefSchema,
 } from './schemas/claim.js';
 // Schemas
 export {
-  sandboxNetworkRuleSchema,
+  embeddedObjectMetadataSchema,
+  persistentVolumeClaimTemplateSchema,
+  podMetadataSchema,
+  podTemplateSchema,
   sandboxSchema,
   sandboxSpecSchema,
   sandboxStatusSchema,
-  sandboxVolumeClaimSchema,
+  shutdownPolicySchema,
 } from './schemas/sandbox.js';
 export {
+  networkPolicyManagementSchema,
+  networkPolicySpecSchema,
   sandboxTemplateSchema,
   sandboxTemplateSpecSchema,
   sandboxTemplateStatusSchema,
@@ -72,12 +81,22 @@ export type {
   SandboxClaimList,
   SandboxClaimSpec,
   SandboxClaimStatus,
+  SandboxTemplateRef,
 } from './types/claim.js';
 // Types
 export type {
+  ClaimSandboxStatus,
   Condition,
   CRDResource,
   CRDResourceList,
+  EmbeddedObjectMetadata,
+  Lifecycle,
+  NetworkPolicyManagement,
+  NetworkPolicySpec,
+  PersistentVolumeClaimTemplate,
+  PodMetadata,
+  PodTemplate,
+  ShutdownPolicy,
   WatchEvent,
   WatchEventType,
 } from './types/common.js';
@@ -90,11 +109,8 @@ export type {
 export type {
   Sandbox,
   SandboxList,
-  SandboxNetworkPolicy,
-  SandboxNetworkRule,
   SandboxSpec,
   SandboxStatus,
-  SandboxVolumeClaim,
 } from './types/sandbox.js';
 export type {
   SandboxTemplate,

--- a/packages/agent-sandbox-sdk/src/operations/exec.ts
+++ b/packages/agent-sandbox-sdk/src/operations/exec.ts
@@ -153,8 +153,9 @@ export async function execStreamInSandbox(
 
 /**
  * Resolve the pod name from a sandbox resource.
- * Reads the sandbox status.podName, falling back to the sandbox name
- * only if the sandbox CRD resource is not found (404).
+ * In v0.2.1, the controller stores the pod name in the annotation
+ * `agents.x-k8s.io/pod-name`. Falls back to the sandbox name
+ * if the annotation is absent or the CRD resource is not found (404).
  * Propagates auth, network, and other errors.
  */
 async function resolvePodName(
@@ -170,8 +171,9 @@ async function resolvePodName(
       namespace,
       plural: 'sandboxes',
       name: sandboxName,
-    })) as { status?: { podName?: string } };
-    return sandbox.status?.podName ?? sandboxName;
+    })) as { metadata?: { annotations?: Record<string, string> } };
+    // v0.2.1: pod name is in annotation, not status.podName
+    return sandbox.metadata?.annotations?.['agents.x-k8s.io/pod-name'] ?? sandboxName;
   } catch (error) {
     // Only fall back for 404 (sandbox CRD not found — might be using raw pods).
     // Propagate auth, network, and other real errors.

--- a/packages/agent-sandbox-sdk/src/operations/lifecycle.ts
+++ b/packages/agent-sandbox-sdk/src/operations/lifecycle.ts
@@ -37,10 +37,14 @@ export async function waitForReady(
       return sandbox;
     }
 
-    // Check for terminal failure via Ready condition with False status
+    // Check for terminal failure via Ready condition with False status and a terminal reason
     if (readyCondition?.status === 'False') {
-      const failMessage = readyCondition.message ?? 'Sandbox failed to become ready';
-      throw new Error(failMessage);
+      const terminalReasons = ['PodCreationFailed', 'TemplateNotFound', 'SandboxExpired'];
+      if (terminalReasons.includes(readyCondition.reason ?? '')) {
+        const failMessage = readyCondition.message ?? 'Sandbox failed to become ready';
+        throw new Error(failMessage);
+      }
+      // Transient reasons (PodNotReady, ContainersNotReady) — continue polling
     }
 
     await sleep(pollIntervalMs);

--- a/packages/agent-sandbox-sdk/src/operations/lifecycle.ts
+++ b/packages/agent-sandbox-sdk/src/operations/lifecycle.ts
@@ -37,11 +37,9 @@ export async function waitForReady(
       return sandbox;
     }
 
-    // Check for terminal failure
-    if (sandbox.status?.phase === 'Failed') {
-      const failMessage =
-        sandbox.status.conditions?.find((c) => c.status === 'False')?.message ??
-        'Sandbox entered Failed phase';
+    // Check for terminal failure via Ready condition with False status
+    if (readyCondition?.status === 'False') {
+      const failMessage = readyCondition.message ?? 'Sandbox failed to become ready';
       throw new Error(failMessage);
     }
 
@@ -83,14 +81,15 @@ export async function resume(
   namespace: string,
   name: string
 ): Promise<Sandbox> {
-  return crud.patch(namespace, name, {
+  const patch: Record<string, unknown> = {
     spec: { replicas: 1 },
     metadata: {
       annotations: {
         [CRD_ANNOTATIONS.pauseReason]: '',
       },
     },
-  } as Partial<Sandbox>);
+  };
+  return crud.patch(namespace, name, patch as Partial<Sandbox>);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/agent-sandbox-sdk/src/schemas/claim.ts
+++ b/packages/agent-sandbox-sdk/src/schemas/claim.ts
@@ -1,28 +1,29 @@
 import { z } from 'zod';
+import { shutdownPolicySchema } from './sandbox.js';
+
+export const sandboxTemplateRefSchema = z.object({
+  name: z.string(),
+  // No namespace - v0.2.1 SandboxTemplateRef is name-only
+});
+
+export const lifecycleSchema = z.object({
+  shutdownTime: z.string().optional(),
+  shutdownPolicy: shutdownPolicySchema.optional(),
+});
+
+// CRITICAL: Capital-N "Name" matches upstream json:"Name,omitempty"
+export const claimSandboxStatusSchema = z.object({
+  Name: z.string().optional(),
+});
 
 export const sandboxClaimSpecSchema = z.object({
-  sandboxTemplateRef: z.object({
-    name: z.string(),
-    namespace: z.string().optional(),
-  }),
-  warmPoolRef: z
-    .object({
-      name: z.string(),
-      namespace: z.string().optional(),
-    })
-    .optional(),
+  sandboxTemplateRef: sandboxTemplateRefSchema,
+  lifecycle: lifecycleSchema.optional(),
 });
 
 export const sandboxClaimStatusSchema = z.object({
-  phase: z.enum(['Pending', 'Bound', 'Failed']).optional(),
-  sandboxRef: z
-    .object({
-      name: z.string(),
-      namespace: z.string().optional(),
-    })
-    .optional(),
   conditions: z.array(z.any()).optional(),
-  boundAt: z.string().optional(),
+  sandbox: claimSandboxStatusSchema.optional(),
 });
 
 export const sandboxClaimSchema = z.object({

--- a/packages/agent-sandbox-sdk/src/schemas/sandbox.ts
+++ b/packages/agent-sandbox-sdk/src/schemas/sandbox.ts
@@ -1,79 +1,43 @@
 import { z } from 'zod';
 
-export const sandboxNetworkRuleSchema = z.object({
-  ports: z
-    .array(
-      z.object({
-        port: z.number(),
-        protocol: z.string(),
-      })
-    )
-    .optional(),
-  to: z
-    .array(
-      z.object({
-        ipBlock: z
-          .object({
-            cidr: z.string(),
-            except: z.array(z.string()).optional(),
-          })
-          .optional(),
-      })
-    )
-    .optional(),
-  from: z
-    .array(
-      z.object({
-        ipBlock: z
-          .object({
-            cidr: z.string(),
-            except: z.array(z.string()).optional(),
-          })
-          .optional(),
-      })
-    )
-    .optional(),
+export const podMetadataSchema = z.object({
+  labels: z.record(z.string(), z.string()).optional(),
+  annotations: z.record(z.string(), z.string()).optional(),
 });
 
-export const sandboxVolumeClaimSchema = z.object({
-  name: z.string(),
-  storageClassName: z.string().optional(),
-  accessModes: z.array(z.string()),
-  resources: z.object({
-    requests: z.object({
-      storage: z.string(),
-    }),
-  }),
+export const podTemplateSchema = z.object({
+  spec: z.any(), // V1PodSpec - too complex for Zod, use any
+  metadata: podMetadataSchema, // NOT optional (no omitempty upstream)
 });
+
+export const embeddedObjectMetadataSchema = z.object({
+  name: z.string().optional(),
+  labels: z.record(z.string(), z.string()).optional(),
+  annotations: z.record(z.string(), z.string()).optional(),
+});
+
+export const persistentVolumeClaimTemplateSchema = z.object({
+  metadata: embeddedObjectMetadataSchema,
+  spec: z.any(), // V1PersistentVolumeClaimSpec
+});
+
+export const shutdownPolicySchema = z.enum(['Delete', 'Retain']);
 
 export const sandboxSpecSchema = z.object({
-  sandboxTemplateRef: z
-    .object({
-      name: z.string(),
-      namespace: z.string().optional(),
-    })
-    .optional(),
-  podTemplateSpec: z.any().optional(),
+  podTemplate: podTemplateSchema,
+  volumeClaimTemplates: z.array(persistentVolumeClaimTemplateSchema).optional(),
+  // Lifecycle fields inlined (not nested)
+  shutdownTime: z.string().optional(),
+  shutdownPolicy: shutdownPolicySchema.optional(),
   replicas: z.number().int().min(0).max(1).optional(),
-  networkPolicy: z
-    .object({
-      egress: z.array(sandboxNetworkRuleSchema).optional(),
-      ingress: z.array(sandboxNetworkRuleSchema).optional(),
-    })
-    .optional(),
-  volumeClaims: z.array(sandboxVolumeClaimSchema).optional(),
-  runtimeClassName: z.string().optional(),
-  ttlSecondsAfterFinished: z.number().int().positive().optional(),
 });
 
 export const sandboxStatusSchema = z.object({
-  phase: z.enum(['Pending', 'Running', 'Paused', 'Succeeded', 'Failed', 'Unknown']).optional(),
-  conditions: z.array(z.any()).optional(),
-  podName: z.string().optional(),
   serviceFQDN: z.string().optional(),
-  podIP: z.string().optional(),
-  readyReplicas: z.number().optional(),
-  readyAt: z.string().optional(),
+  service: z.string().optional(),
+  conditions: z.array(z.any()).optional(),
+  replicas: z.number(), // NOT optional (always present, defaults to 0)
+  selector: z.string().optional(),
 });
 
 export const sandboxSchema = z.object({

--- a/packages/agent-sandbox-sdk/src/schemas/template.ts
+++ b/packages/agent-sandbox-sdk/src/schemas/template.ts
@@ -1,21 +1,20 @@
 import { z } from 'zod';
-import { sandboxNetworkRuleSchema, sandboxVolumeClaimSchema } from './sandbox.js';
+import { podTemplateSchema } from './sandbox.js';
+
+export const networkPolicySpecSchema = z.object({
+  ingress: z.array(z.any()).optional(), // V1NetworkPolicyIngressRule[]
+  egress: z.array(z.any()).optional(), // V1NetworkPolicyEgressRule[]
+});
+
+export const networkPolicyManagementSchema = z.enum(['Managed', 'Unmanaged']);
 
 export const sandboxTemplateSpecSchema = z.object({
-  podTemplateSpec: z.any(),
-  networkPolicy: z
-    .object({
-      egress: z.array(sandboxNetworkRuleSchema).optional(),
-      ingress: z.array(sandboxNetworkRuleSchema).optional(),
-    })
-    .optional(),
-  runtimeClassName: z.string().optional(),
-  volumeClaims: z.array(sandboxVolumeClaimSchema).optional(),
+  podTemplate: podTemplateSchema,
+  networkPolicy: networkPolicySpecSchema.optional(),
+  networkPolicyManagement: networkPolicyManagementSchema.optional(),
 });
 
-export const sandboxTemplateStatusSchema = z.object({
-  sandboxCount: z.number().optional(),
-});
+export const sandboxTemplateStatusSchema = z.object({});
 
 export const sandboxTemplateSchema = z.object({
   apiVersion: z.string(),

--- a/packages/agent-sandbox-sdk/src/schemas/warm-pool.ts
+++ b/packages/agent-sandbox-sdk/src/schemas/warm-pool.ts
@@ -1,18 +1,14 @@
 import { z } from 'zod';
+import { sandboxTemplateRefSchema } from './claim.js';
 
 export const sandboxWarmPoolSpecSchema = z.object({
-  desiredReady: z.number().int().min(0),
-  templateRef: z.object({
-    name: z.string(),
-    namespace: z.string().optional(),
-  }),
-  maxSize: z.number().int().min(0).optional(),
+  replicas: z.number().int().min(0), // was desiredReady
+  sandboxTemplateRef: sandboxTemplateRefSchema, // was templateRef
 });
 
 export const sandboxWarmPoolStatusSchema = z.object({
+  replicas: z.number().optional(),
   readyReplicas: z.number().optional(),
-  availableReplicas: z.number().optional(),
-  conditions: z.array(z.any()).optional(),
 });
 
 export const sandboxWarmPoolSchema = z.object({

--- a/packages/agent-sandbox-sdk/src/types/claim.ts
+++ b/packages/agent-sandbox-sdk/src/types/claim.ts
@@ -1,40 +1,27 @@
-import type { Condition, CRDResource, CRDResourceList } from './common.js';
+import type { V1Condition } from '@kubernetes/client-node';
+import type { ClaimSandboxStatus, CRDResource, CRDResourceList, Lifecycle } from './common.js';
 
 /**
- * SandboxClaim spec -- used to request a sandbox from a warm pool
+ * SandboxTemplateRef - name only, no namespace
  */
-export interface SandboxClaimSpec {
-  /** Reference to the SandboxTemplate */
-  sandboxTemplateRef: {
-    name: string;
-    namespace?: string;
-  };
-
-  /** Reference to the WarmPool to claim from */
-  warmPoolRef?: {
-    name: string;
-    namespace?: string;
-  };
+export interface SandboxTemplateRef {
+  name: string;
 }
 
 /**
- * SandboxClaim status
+ * SandboxClaim spec - v0.2.1
+ */
+export interface SandboxClaimSpec {
+  sandboxTemplateRef: SandboxTemplateRef;
+  lifecycle?: Lifecycle; // nested (not inlined)
+}
+
+/**
+ * SandboxClaim status - v0.2.1
  */
 export interface SandboxClaimStatus {
-  /** Phase of the claim */
-  phase?: 'Pending' | 'Bound' | 'Failed';
-
-  /** Name of the sandbox bound to this claim */
-  sandboxRef?: {
-    name: string;
-    namespace?: string;
-  };
-
-  /** Conditions */
-  conditions?: Condition[];
-
-  /** When the claim was bound */
-  boundAt?: string;
+  conditions?: V1Condition[];
+  sandbox?: ClaimSandboxStatus; // { Name?: string } with capital N
 }
 
 /**

--- a/packages/agent-sandbox-sdk/src/types/common.ts
+++ b/packages/agent-sandbox-sdk/src/types/common.ts
@@ -1,4 +1,11 @@
-import type { V1Condition, V1ObjectMeta } from '@kubernetes/client-node';
+import type {
+  V1Condition,
+  V1NetworkPolicyEgressRule,
+  V1NetworkPolicyIngressRule,
+  V1ObjectMeta,
+  V1PersistentVolumeClaimSpec,
+  V1PodSpec,
+} from '@kubernetes/client-node';
 
 /**
  * Base interface for all CRD resources
@@ -38,3 +45,71 @@ export interface WatchEvent<T extends CRDResource> {
  * Standard condition from K8s status
  */
 export type Condition = V1Condition;
+
+/**
+ * Pod metadata (labels + annotations only)
+ */
+export interface PodMetadata {
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+}
+
+/**
+ * Pod template used by Sandbox and SandboxTemplate specs
+ */
+export interface PodTemplate {
+  spec: V1PodSpec;
+  metadata: PodMetadata; // NOT optional - always serialized (no omitempty in upstream)
+}
+
+/**
+ * Embedded metadata for PVC templates
+ */
+export interface EmbeddedObjectMetadata {
+  name?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+}
+
+/**
+ * PVC template for Sandbox volumeClaimTemplates
+ */
+export interface PersistentVolumeClaimTemplate {
+  metadata: EmbeddedObjectMetadata; // NOT optional
+  spec: V1PersistentVolumeClaimSpec;
+}
+
+/**
+ * Shutdown policy enum
+ */
+export type ShutdownPolicy = 'Delete' | 'Retain';
+
+/**
+ * Lifecycle for SandboxClaim (nested object)
+ * NOTE: For Sandbox, these fields are INLINED (top-level on SandboxSpec)
+ */
+export interface Lifecycle {
+  shutdownTime?: string; // ISO date-time
+  shutdownPolicy?: ShutdownPolicy;
+}
+
+/**
+ * Network policy management mode
+ */
+export type NetworkPolicyManagement = 'Managed' | 'Unmanaged';
+
+/**
+ * Network policy spec using K8s-native types
+ */
+export interface NetworkPolicySpec {
+  ingress?: V1NetworkPolicyIngressRule[];
+  egress?: V1NetworkPolicyEgressRule[];
+}
+
+/**
+ * Extensions-local SandboxStatus (used in SandboxClaim status)
+ * CRITICAL: The JSON key is "Name" with capital N
+ */
+export interface ClaimSandboxStatus {
+  Name?: string; // Capital N - matches upstream json:"Name,omitempty"
+}

--- a/packages/agent-sandbox-sdk/src/types/sandbox.ts
+++ b/packages/agent-sandbox-sdk/src/types/sandbox.ts
@@ -1,88 +1,34 @@
-import type { V1PodTemplateSpec } from '@kubernetes/client-node';
-import type { Condition, CRDResource, CRDResourceList } from './common.js';
+import type { V1Condition } from '@kubernetes/client-node';
+import type {
+  CRDResource,
+  CRDResourceList,
+  PersistentVolumeClaimTemplate,
+  PodTemplate,
+  ShutdownPolicy,
+} from './common.js';
 
 /**
- * Sandbox spec
+ * Sandbox spec - v0.2.1
+ * NOTE: shutdownTime and shutdownPolicy are INLINED from Lifecycle (not nested)
  */
 export interface SandboxSpec {
-  /** Reference to a SandboxTemplate */
-  sandboxTemplateRef?: {
-    name: string;
-    namespace?: string;
-  };
-
-  /** Inline pod template spec (alternative to templateRef) */
-  podTemplateSpec?: V1PodTemplateSpec;
-
-  /** Number of replicas (0 = paused, 1 = running) */
-  replicas?: number;
-
-  /** Network policy configuration */
-  networkPolicy?: SandboxNetworkPolicy;
-
-  /** Volume claims for persistent storage */
-  volumeClaims?: SandboxVolumeClaim[];
-
-  /** Runtime class name (e.g., "gvisor", "kata") */
-  runtimeClassName?: string;
-
-  /** Time-to-live after completion */
-  ttlSecondsAfterFinished?: number;
+  podTemplate: PodTemplate;
+  volumeClaimTemplates?: PersistentVolumeClaimTemplate[];
+  // Lifecycle fields inlined (json:",inline" in Go)
+  shutdownTime?: string;
+  shutdownPolicy?: ShutdownPolicy;
+  replicas?: number; // 0 or 1
 }
 
 /**
- * Network policy embedded in sandbox spec
- */
-export interface SandboxNetworkPolicy {
-  egress?: SandboxNetworkRule[];
-  ingress?: SandboxNetworkRule[];
-}
-
-/**
- * Network rule
- */
-export interface SandboxNetworkRule {
-  ports?: Array<{ port: number; protocol: string }>;
-  to?: Array<{ ipBlock?: { cidr: string; except?: string[] } }>;
-  from?: Array<{ ipBlock?: { cidr: string; except?: string[] } }>;
-}
-
-/**
- * Volume claim in sandbox
- */
-export interface SandboxVolumeClaim {
-  name: string;
-  storageClassName?: string;
-  accessModes: string[];
-  resources: {
-    requests: { storage: string };
-  };
-}
-
-/**
- * Sandbox status
+ * Sandbox status - v0.2.1 (condition-based, no phase field)
  */
 export interface SandboxStatus {
-  /** Current phase */
-  phase?: 'Pending' | 'Running' | 'Paused' | 'Succeeded' | 'Failed' | 'Unknown';
-
-  /** Standard conditions */
-  conditions?: Condition[];
-
-  /** Pod name backing this sandbox */
-  podName?: string;
-
-  /** Stable service FQDN */
   serviceFQDN?: string;
-
-  /** IP address of the sandbox pod */
-  podIP?: string;
-
-  /** Ready replicas count */
-  readyReplicas?: number;
-
-  /** When the sandbox became ready */
-  readyAt?: string;
+  service?: string;
+  conditions?: V1Condition[];
+  replicas: number; // NOT optional (no omitempty, no pointer in upstream)
+  selector?: string; // LabelSelector string
 }
 
 /**

--- a/packages/agent-sandbox-sdk/src/types/template.ts
+++ b/packages/agent-sandbox-sdk/src/types/template.ts
@@ -1,36 +1,24 @@
-import type { V1PodTemplateSpec } from '@kubernetes/client-node';
-import type { CRDResource, CRDResourceList } from './common.js';
-import type { SandboxNetworkPolicy } from './sandbox.js';
+import type {
+  CRDResource,
+  CRDResourceList,
+  NetworkPolicyManagement,
+  NetworkPolicySpec,
+  PodTemplate,
+} from './common.js';
 
 /**
- * SandboxTemplate spec
+ * SandboxTemplate spec - v0.2.1
  */
 export interface SandboxTemplateSpec {
-  /** Pod template spec for sandboxes created from this template */
-  podTemplateSpec: V1PodTemplateSpec;
-
-  /** Default network policy for sandboxes */
-  networkPolicy?: SandboxNetworkPolicy;
-
-  /** Default runtime class */
-  runtimeClassName?: string;
-
-  /** Default volume claims */
-  volumeClaims?: Array<{
-    name: string;
-    storageClassName?: string;
-    accessModes: string[];
-    resources: { requests: { storage: string } };
-  }>;
+  podTemplate: PodTemplate;
+  networkPolicy?: NetworkPolicySpec;
+  networkPolicyManagement?: NetworkPolicyManagement; // default: 'Managed'
 }
 
 /**
- * SandboxTemplate status
+ * SandboxTemplate status (empty - matches upstream)
  */
-export interface SandboxTemplateStatus {
-  /** Number of sandboxes using this template */
-  sandboxCount?: number;
-}
+export type SandboxTemplateStatus = {};
 
 /**
  * Full SandboxTemplate resource

--- a/packages/agent-sandbox-sdk/src/types/template.ts
+++ b/packages/agent-sandbox-sdk/src/types/template.ts
@@ -18,7 +18,7 @@ export interface SandboxTemplateSpec {
 /**
  * SandboxTemplate status (empty - matches upstream)
  */
-export type SandboxTemplateStatus = {};
+export type SandboxTemplateStatus = Record<string, never>;
 
 /**
  * Full SandboxTemplate resource

--- a/packages/agent-sandbox-sdk/src/types/warm-pool.ts
+++ b/packages/agent-sandbox-sdk/src/types/warm-pool.ts
@@ -1,34 +1,20 @@
-import type { Condition, CRDResource, CRDResourceList } from './common.js';
+import type { SandboxTemplateRef } from './claim.js';
+import type { CRDResource, CRDResourceList } from './common.js';
 
 /**
- * SandboxWarmPool spec
+ * SandboxWarmPool spec - v0.2.1
  */
 export interface SandboxWarmPoolSpec {
-  /** Number of warm sandboxes to keep ready */
-  desiredReady: number;
-
-  /** Reference to the SandboxTemplate used for pool members */
-  templateRef: {
-    name: string;
-    namespace?: string;
-  };
-
-  /** Maximum pool size (for autoscaling) */
-  maxSize?: number;
+  replicas: number; // was desiredReady
+  sandboxTemplateRef: SandboxTemplateRef; // was templateRef with namespace
 }
 
 /**
- * SandboxWarmPool status
+ * SandboxWarmPool status - v0.2.1
  */
 export interface SandboxWarmPoolStatus {
-  /** Number of ready warm sandboxes */
+  replicas?: number;
   readyReplicas?: number;
-
-  /** Number of available sandboxes */
-  availableReplicas?: number;
-
-  /** Conditions */
-  conditions?: Condition[];
 }
 
 /**

--- a/scripts/k8s-teardown-minikube.sh
+++ b/scripts/k8s-teardown-minikube.sh
@@ -130,7 +130,7 @@ else
 fi
 
 # Delete warm pools
-if kubectl get crd sandboxwarmpools.agents.x-k8s.io &>/dev/null 2>&1; then
+if kubectl get crd sandboxwarmpools.extensions.agents.x-k8s.io &>/dev/null 2>&1; then
   log_info "Deleting SandboxWarmPools..."
   if kubectl delete sandboxwarmpools --all -n "$NAMESPACE" --timeout=60s 2>/dev/null; then
     log_success "SandboxWarmPools deleted"
@@ -142,7 +142,7 @@ else
 fi
 
 # Delete sandbox templates
-if kubectl get crd sandboxtemplates.agents.x-k8s.io &>/dev/null 2>&1; then
+if kubectl get crd sandboxtemplates.extensions.agents.x-k8s.io &>/dev/null 2>&1; then
   log_info "Deleting SandboxTemplates..."
   if kubectl delete sandboxtemplates --all -n "$NAMESPACE" --timeout=60s 2>/dev/null; then
     log_success "SandboxTemplates deleted"

--- a/src/lib/sandbox/controllers/sandbox-controller.ts
+++ b/src/lib/sandbox/controllers/sandbox-controller.ts
@@ -3,6 +3,7 @@ import {
   AlreadyExistsError,
   CRD_API,
   CRD_CONDITIONS,
+  CRD_EXTENSIONS_API,
   CRD_LABELS,
   CRD_PLURALS,
   NotFoundError,
@@ -212,24 +213,28 @@ export class SandboxController {
       }
     }
 
-    // Resolve template if the sandbox references one
+    // Resolve template if the sandbox references one.
+    // NOTE: sandboxTemplateRef is an internal convention used by the warm pool
+    // reconciler -- it's not part of the v0.2.1 SandboxSpec CRD type.
     let template: SandboxTemplate | undefined;
-    if (sandbox.spec?.sandboxTemplateRef?.name) {
+    const specAny = sandbox.spec as unknown as Record<string, unknown> | undefined;
+    const templateRefName = (specAny?.sandboxTemplateRef as { name?: string } | undefined)?.name;
+    if (templateRefName) {
       try {
-        template = await this.client.getTemplate(sandbox.spec.sandboxTemplateRef.name);
+        template = await this.client.getTemplate(templateRefName);
       } catch (err) {
         log.error('Failed to resolve template', {
-          data: { templateName: sandbox.spec.sandboxTemplateRef.name },
+          data: { templateName: templateRefName },
           error: err,
         });
         await this.patchSandboxStatus(sandboxName, {
-          phase: 'Failed',
+          replicas: 0,
           conditions: [
             {
               type: CRD_CONDITIONS.ready,
               status: 'False',
               reason: 'TemplateNotFound',
-              message: `Template ${sandbox.spec.sandboxTemplateRef.name} not found`,
+              message: `Template ${templateRefName} not found`,
               lastTransitionTime: new Date(),
             },
           ],
@@ -250,7 +255,7 @@ export class SandboxController {
       }
       log.error('Failed to create pod for sandbox', { data: { sandboxName }, error: err });
       await this.patchSandboxStatus(sandboxName, {
-        phase: 'Failed',
+        replicas: 0,
         conditions: [
           {
             type: CRD_CONDITIONS.ready,
@@ -266,8 +271,17 @@ export class SandboxController {
 
     // Update sandbox status to reflect that we've created the pod
     await this.patchSandboxStatus(sandboxName, {
-      phase: 'Pending',
-      podName: sandboxName,
+      replicas: 0,
+      service: sandboxName,
+      conditions: [
+        {
+          type: CRD_CONDITIONS.ready,
+          status: 'False',
+          reason: 'PodNotReady',
+          message: 'Pod created, waiting for readiness',
+          lastTransitionTime: new Date(),
+        },
+      ],
     });
 
     log.info('Created pod for sandbox', { data: { sandboxName } });
@@ -327,10 +341,10 @@ export class SandboxController {
       },
     ];
 
-    // Resolve runtime class name
+    // Resolve runtime class name from pod template spec
     const runtimeClassName = this.resolveRuntimeClassName(
-      sandbox.spec?.runtimeClassName,
-      template?.spec?.runtimeClassName
+      sandbox.spec?.podTemplate?.spec?.runtimeClassName,
+      template?.spec?.podTemplate?.spec?.runtimeClassName
     );
 
     const pod: k8s.V1Pod = {
@@ -444,8 +458,6 @@ export class SandboxController {
         if (!sandboxName) continue;
 
         const podPhase = pod.status?.phase;
-        const podIP = pod.status?.podIP;
-        const podName = pod.metadata?.name;
 
         // Determine whether all containers are ready
         const allContainersReady =
@@ -488,16 +500,17 @@ export class SandboxController {
           lastTransitionTime: new Date(),
         };
 
-        const readyReplicas = sandboxPhase === 'Running' ? 1 : 0;
-        const readyAt = sandboxPhase === 'Running' ? new Date().toISOString() : undefined;
+        const replicas = sandboxPhase === 'Running' ? 1 : 0;
+        const serviceFQDN =
+          sandboxPhase === 'Running'
+            ? `${sandboxName}.${this.namespace}.svc.cluster.local`
+            : undefined;
 
         await this.patchSandboxStatus(sandboxName, {
-          phase: sandboxPhase,
-          podName,
-          podIP,
+          replicas,
+          service: sandboxName,
           conditions: [readyCondition, podReadyCondition],
-          readyReplicas,
-          ...(readyAt ? { readyAt } : {}),
+          ...(serviceFQDN ? { serviceFQDN } : {}),
         });
       } catch (err) {
         log.error('Failed to sync status for pod', {
@@ -568,17 +581,22 @@ export class SandboxController {
           namespace: this.namespace,
         });
 
-        // Clean up failed/succeeded warm pool sandboxes before counting
-        const terminalSandboxes = existingSandboxes.items.filter(
-          (s) => s.status?.phase === 'Failed' || s.status?.phase === 'Succeeded'
-        );
+        // Clean up terminal warm pool sandboxes (Ready=False with non-recoverable reason)
+        const terminalSandboxes = existingSandboxes.items.filter((s) => {
+          const ready = s.status?.conditions?.find((c) => c.type === 'Ready');
+          return (
+            ready?.status === 'False' &&
+            (ready?.reason === 'SandboxExpired' || ready?.reason === 'PodCreationFailed')
+          );
+        });
         for (const terminal of terminalSandboxes) {
           const terminalName = terminal.metadata?.name;
           if (terminalName) {
             try {
               await this.client.deleteSandbox(terminalName);
+              const reason = terminal.status?.conditions?.find((c) => c.type === 'Ready')?.reason;
               log.info('Deleted terminal warm pool sandbox', {
-                data: { sandboxName: terminalName, phase: terminal.status?.phase },
+                data: { sandboxName: terminalName, reason },
               });
             } catch (delErr) {
               log.warn('Failed to delete terminal warm pool sandbox', {
@@ -589,15 +607,16 @@ export class SandboxController {
           }
         }
 
-        // Count non-terminal sandboxes (Running + Pending) to avoid creating duplicates
-        // while pods are still starting up. Only terminal (Failed/Succeeded) are excluded.
+        // Count non-terminal sandboxes to avoid creating duplicates
+        // while pods are still starting up. Only terminal sandboxes are excluded.
         const terminalNames = new Set(terminalSandboxes.map((s) => s.metadata?.name));
         const currentActive = existingSandboxes.items.filter(
           (s) => !terminalNames.has(s.metadata?.name)
         ).length;
-        const currentReady = existingSandboxes.items.filter(
-          (s) => s.status?.phase === 'Running' && !terminalNames.has(s.metadata?.name)
-        ).length;
+        const currentReady = existingSandboxes.items.filter((s) => {
+          const ready = s.status?.conditions?.find((c) => c.type === 'Ready');
+          return ready?.status === 'True' && !terminalNames.has(s.metadata?.name);
+        }).length;
 
         // Calculate deficit based on active (Running + Pending) count, not just Running
         const deficit = desiredReady - currentActive;
@@ -622,7 +641,9 @@ export class SandboxController {
             // Set sandboxTemplateRef on the spec so reconcileSandbox can resolve the template.
             // SandboxSpec doesn't include sandboxTemplateRef in v0.2.1, but the controller
             // uses it internally as a convention for template resolution.
-            (sandbox.spec as Record<string, unknown>).sandboxTemplateRef = { name: templateName };
+            (sandbox.spec as unknown as Record<string, unknown>).sandboxTemplateRef = {
+              name: templateName,
+            };
 
             try {
               await this.client.createSandbox(sandbox);
@@ -700,8 +721,8 @@ export class SandboxController {
   private async patchWarmPoolStatus(name: string, status: object): Promise<void> {
     try {
       const current = await this.customApi.getNamespacedCustomObjectStatus({
-        group: CRD_API.group,
-        version: CRD_API.version,
+        group: CRD_EXTENSIONS_API.group,
+        version: CRD_EXTENSIONS_API.version,
         namespace: this.namespace,
         plural: CRD_PLURALS.sandboxWarmPool,
         name,
@@ -709,8 +730,8 @@ export class SandboxController {
 
       const updated = { ...(current as Record<string, unknown>), status };
       await this.customApi.replaceNamespacedCustomObjectStatus({
-        group: CRD_API.group,
-        version: CRD_API.version,
+        group: CRD_EXTENSIONS_API.group,
+        version: CRD_EXTENSIONS_API.version,
         namespace: this.namespace,
         plural: CRD_PLURALS.sandboxWarmPool,
         name,

--- a/src/lib/sandbox/controllers/sandbox-controller.ts
+++ b/src/lib/sandbox/controllers/sandbox-controller.ts
@@ -284,17 +284,17 @@ export class SandboxController {
   private buildPodFromSandbox(sandbox: SandboxCRD, template?: SandboxTemplate): k8s.V1Pod {
     const sandboxName = sandbox.metadata?.name ?? '';
 
-    // Determine pod template spec: prefer template if provided, fall back to inline
-    const podTemplateSpec = template?.spec?.podTemplateSpec ?? sandbox.spec?.podTemplateSpec;
+    // Determine pod template: prefer template if provided, fall back to inline
+    const podTemplate = template?.spec?.podTemplate ?? sandbox.spec?.podTemplate;
 
     // Extract containers from the template, or build a default
     let containers: k8s.V1Container[];
     let volumes: k8s.V1Volume[] | undefined;
     let serviceAccountName: string | undefined;
 
-    if (podTemplateSpec?.spec) {
-      containers = podTemplateSpec.spec.containers?.length
-        ? podTemplateSpec.spec.containers.map((c) =>
+    if (podTemplate?.spec) {
+      containers = podTemplate.spec.containers?.length
+        ? podTemplate.spec.containers.map((c) =>
             this.ensureSecurityContext({
               ...c,
               // Ensure the container has a keep-alive command if none specified
@@ -302,8 +302,8 @@ export class SandboxController {
             })
           )
         : [this.defaultContainer()];
-      volumes = podTemplateSpec.spec.volumes;
-      serviceAccountName = podTemplateSpec.spec.serviceAccountName;
+      volumes = podTemplate.spec.volumes;
+      serviceAccountName = podTemplate.spec.serviceAccountName;
     } else {
       containers = [this.defaultContainer()];
     }
@@ -554,13 +554,13 @@ export class SandboxController {
         const poolName = pool.metadata?.name;
         if (!poolName) continue;
 
-        const templateName = pool.spec?.templateRef?.name;
+        const templateName = pool.spec?.sandboxTemplateRef?.name;
         if (!templateName) {
-          log.warn('Warm pool has no templateRef, skipping', { data: { poolName } });
+          log.warn('Warm pool has no sandboxTemplateRef, skipping', { data: { poolName } });
           continue;
         }
 
-        const desiredReady = pool.spec?.desiredReady ?? 0;
+        const desiredReady = pool.spec?.replicas ?? 0;
 
         // List existing warm sandboxes for this pool
         const existingSandboxes = await this.client.listSandboxes({
@@ -611,16 +611,21 @@ export class SandboxController {
             const randomSuffix = this.randomString(8);
             const warmSandboxName = `warm-${poolName}-${randomSuffix}`;
 
-            const builder = new SandboxBuilder(warmSandboxName)
+            const sandbox = new SandboxBuilder(warmSandboxName)
               .namespace(this.namespace)
               .labels({
                 [CRD_LABELS.warmPool]: poolName,
                 [CRD_LABELS.warmPoolState]: 'warming',
               })
-              .fromTemplate(templateName, pool.spec?.templateRef?.namespace);
+              .build();
+
+            // Set sandboxTemplateRef on the spec so reconcileSandbox can resolve the template.
+            // SandboxSpec doesn't include sandboxTemplateRef in v0.2.1, but the controller
+            // uses it internally as a convention for template resolution.
+            (sandbox.spec as Record<string, unknown>).sandboxTemplateRef = { name: templateName };
 
             try {
-              await this.client.createSandbox(builder.build());
+              await this.client.createSandbox(sandbox);
               log.info('Created warm sandbox', {
                 data: { sandboxName: warmSandboxName, poolName },
               });

--- a/src/lib/sandbox/providers/__tests__/agent-sandbox-provider.test.ts
+++ b/src/lib/sandbox/providers/__tests__/agent-sandbox-provider.test.ts
@@ -17,6 +17,7 @@ interface MockAgentSandboxClient {
   createWarmPool: ReturnType<typeof vi.fn>;
   getWarmPool: ReturnType<typeof vi.fn>;
   deleteWarmPool: ReturnType<typeof vi.fn>;
+  replaceWarmPool: ReturnType<typeof vi.fn>;
   namespace: string;
 }
 
@@ -51,6 +52,7 @@ const createMockClient = (): MockAgentSandboxClient => ({
   createWarmPool: vi.fn().mockResolvedValue({}),
   getWarmPool: vi.fn().mockRejectedValue(new Error('not found')),
   deleteWarmPool: vi.fn().mockResolvedValue(undefined),
+  replaceWarmPool: vi.fn().mockResolvedValue({}),
   namespace: 'agentpane-sandboxes',
 });
 
@@ -393,37 +395,58 @@ describe('AgentSandboxProvider', () => {
       const items = [
         // Ready=True → running
         {
-          metadata: { name: 'sandbox-0', labels: { 'agentpane.io/sandbox-id': 'id-0', 'agentpane.io/project-id': 'proj-0' } },
+          metadata: {
+            name: 'sandbox-0',
+            labels: { 'agentpane.io/sandbox-id': 'id-0', 'agentpane.io/project-id': 'proj-0' },
+          },
           spec: {},
           status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
         },
         // No conditions → creating
         {
-          metadata: { name: 'sandbox-1', labels: { 'agentpane.io/sandbox-id': 'id-1', 'agentpane.io/project-id': 'proj-1' } },
+          metadata: {
+            name: 'sandbox-1',
+            labels: { 'agentpane.io/sandbox-id': 'id-1', 'agentpane.io/project-id': 'proj-1' },
+          },
           spec: {},
           status: { replicas: 1 },
         },
         // replicas=0 → idle (paused)
         {
-          metadata: { name: 'sandbox-2', labels: { 'agentpane.io/sandbox-id': 'id-2', 'agentpane.io/project-id': 'proj-2' } },
+          metadata: {
+            name: 'sandbox-2',
+            labels: { 'agentpane.io/sandbox-id': 'id-2', 'agentpane.io/project-id': 'proj-2' },
+          },
           spec: { replicas: 0 },
           status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False' }] },
         },
         // Ready=False (generic) → error
         {
-          metadata: { name: 'sandbox-3', labels: { 'agentpane.io/sandbox-id': 'id-3', 'agentpane.io/project-id': 'proj-3' } },
+          metadata: {
+            name: 'sandbox-3',
+            labels: { 'agentpane.io/sandbox-id': 'id-3', 'agentpane.io/project-id': 'proj-3' },
+          },
           spec: {},
           status: { replicas: 1, conditions: [{ type: 'Ready', status: 'False' }] },
         },
         // Ready=False + SandboxExpired → stopped
         {
-          metadata: { name: 'sandbox-4', labels: { 'agentpane.io/sandbox-id': 'id-4', 'agentpane.io/project-id': 'proj-4' } },
+          metadata: {
+            name: 'sandbox-4',
+            labels: { 'agentpane.io/sandbox-id': 'id-4', 'agentpane.io/project-id': 'proj-4' },
+          },
           spec: {},
-          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'False', reason: 'SandboxExpired' }] },
+          status: {
+            replicas: 1,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'SandboxExpired' }],
+          },
         },
         // No status at all → creating
         {
-          metadata: { name: 'sandbox-5', labels: { 'agentpane.io/sandbox-id': 'id-5', 'agentpane.io/project-id': 'proj-5' } },
+          metadata: {
+            name: 'sandbox-5',
+            labels: { 'agentpane.io/sandbox-id': 'id-5', 'agentpane.io/project-id': 'proj-5' },
+          },
           spec: {},
         },
       ];
@@ -600,6 +623,7 @@ describe('AgentSandboxProvider', () => {
           kind: 'SandboxWarmPool',
           spec: expect.objectContaining({
             replicas: 3,
+            sandboxTemplateRef: { name: 'agentpane-default' },
           }),
         })
       );
@@ -613,19 +637,42 @@ describe('AgentSandboxProvider', () => {
       expect(mockClient.createWarmPool).not.toHaveBeenCalled();
     });
 
-    it('deletes existing warm pool and recreates when create fails (409)', async () => {
+    it('replaces existing warm pool when create fails (409)', async () => {
       // Import the mocked AlreadyExistsError so instanceof checks work in source code
+      const { AlreadyExistsError: MockedAlreadyExistsError } = await import(
+        '@agentpane/agent-sandbox-sdk'
+      );
+      mockClient.createWarmPool.mockRejectedValueOnce(
+        new MockedAlreadyExistsError('WarmPool', 'agentpane-warm-pool')
+      );
+      mockClient.replaceWarmPool.mockResolvedValueOnce({});
+
+      const provider = createProvider({ enableWarmPool: true });
+
+      await provider.initWarmPool();
+
+      expect(mockClient.replaceWarmPool).toHaveBeenCalledWith(
+        'agentpane-warm-pool',
+        expect.objectContaining({ kind: 'SandboxWarmPool' })
+      );
+      expect(mockClient.deleteWarmPool).not.toHaveBeenCalled();
+      expect(mockClient.createWarmPool).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to delete+recreate when replace also fails (409)', async () => {
       const { AlreadyExistsError: MockedAlreadyExistsError } = await import(
         '@agentpane/agent-sandbox-sdk'
       );
       mockClient.createWarmPool
         .mockRejectedValueOnce(new MockedAlreadyExistsError('WarmPool', 'agentpane-warm-pool'))
         .mockResolvedValueOnce({});
+      mockClient.replaceWarmPool.mockRejectedValueOnce(new Error('replace failed'));
 
       const provider = createProvider({ enableWarmPool: true });
 
       await provider.initWarmPool();
 
+      expect(mockClient.replaceWarmPool).toHaveBeenCalled();
       expect(mockClient.deleteWarmPool).toHaveBeenCalledWith('agentpane-warm-pool');
       expect(mockClient.createWarmPool).toHaveBeenCalledTimes(2);
     });

--- a/src/lib/sandbox/providers/__tests__/agent-sandbox-provider.test.ts
+++ b/src/lib/sandbox/providers/__tests__/agent-sandbox-provider.test.ts
@@ -26,7 +26,7 @@ const createMockClient = (): MockAgentSandboxClient => ({
   createSandbox: vi.fn().mockResolvedValue({}),
   getSandbox: vi.fn().mockResolvedValue({
     metadata: { creationTimestamp: new Date().toISOString() },
-    status: { phase: 'Running' },
+    status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
   }),
   listSandboxes: vi.fn().mockResolvedValue({ items: [] }),
   deleteSandbox: vi.fn().mockResolvedValue(undefined),
@@ -67,7 +67,10 @@ vi.mock('@agentpane/agent-sandbox-sdk', () => {
     image = vi.fn().mockReturnThis();
     resources = vi.fn().mockReturnThis();
     runtimeClass = vi.fn().mockReturnThis();
-    ttl = vi.fn().mockReturnThis();
+    shutdownTime = vi.fn().mockReturnThis();
+    shutdownPolicy = vi.fn().mockReturnThis();
+    replicas = vi.fn().mockReturnThis();
+    addVolumeClaimTemplate = vi.fn().mockReturnThis();
     agentPaneContext = vi.fn().mockReturnThis();
     build = vi.fn().mockImplementation(() => ({
       apiVersion: 'agents.x-k8s.io/v1alpha1',
@@ -277,7 +280,7 @@ describe('AgentSandboxProvider', () => {
               },
             },
             spec: {},
-            status: { phase: 'Running' },
+            status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
           },
         ],
       });
@@ -338,7 +341,7 @@ describe('AgentSandboxProvider', () => {
               creationTimestamp: '2026-01-01T00:00:00Z',
             },
             spec: {
-              podTemplateSpec: {
+              podTemplate: {
                 spec: {
                   containers: [
                     {
@@ -350,9 +353,13 @@ describe('AgentSandboxProvider', () => {
                     },
                   ],
                 },
+                metadata: {},
               },
             },
-            status: { phase: 'Running' },
+            status: {
+              replicas: 1,
+              conditions: [{ type: 'Ready', status: 'True' }],
+            },
           },
         ],
       });
@@ -379,25 +386,51 @@ describe('AgentSandboxProvider', () => {
       expect(list).toEqual([]);
     });
 
-    it('maps CRD phases to SandboxStatus correctly', async () => {
+    it('maps CRD conditions to SandboxStatus correctly', async () => {
       const provider = createProvider();
 
-      const phases = ['Running', 'Pending', 'Paused', 'Failed', 'Succeeded', undefined];
+      // v0.2.1: condition-based status detection
+      const items = [
+        // Ready=True → running
+        {
+          metadata: { name: 'sandbox-0', labels: { 'agentpane.io/sandbox-id': 'id-0', 'agentpane.io/project-id': 'proj-0' } },
+          spec: {},
+          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
+        },
+        // No conditions → creating
+        {
+          metadata: { name: 'sandbox-1', labels: { 'agentpane.io/sandbox-id': 'id-1', 'agentpane.io/project-id': 'proj-1' } },
+          spec: {},
+          status: { replicas: 1 },
+        },
+        // replicas=0 → idle (paused)
+        {
+          metadata: { name: 'sandbox-2', labels: { 'agentpane.io/sandbox-id': 'id-2', 'agentpane.io/project-id': 'proj-2' } },
+          spec: { replicas: 0 },
+          status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False' }] },
+        },
+        // Ready=False (generic) → error
+        {
+          metadata: { name: 'sandbox-3', labels: { 'agentpane.io/sandbox-id': 'id-3', 'agentpane.io/project-id': 'proj-3' } },
+          spec: {},
+          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'False' }] },
+        },
+        // Ready=False + SandboxExpired → stopped
+        {
+          metadata: { name: 'sandbox-4', labels: { 'agentpane.io/sandbox-id': 'id-4', 'agentpane.io/project-id': 'proj-4' } },
+          spec: {},
+          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'False', reason: 'SandboxExpired' }] },
+        },
+        // No status at all → creating
+        {
+          metadata: { name: 'sandbox-5', labels: { 'agentpane.io/sandbox-id': 'id-5', 'agentpane.io/project-id': 'proj-5' } },
+          spec: {},
+        },
+      ];
+
       const expected = ['running', 'creating', 'idle', 'error', 'stopped', 'creating'];
 
-      mockClient.listSandboxes.mockResolvedValue({
-        items: phases.map((phase, i) => ({
-          metadata: {
-            name: `sandbox-${i}`,
-            labels: {
-              'agentpane.io/sandbox-id': `id-${i}`,
-              'agentpane.io/project-id': `proj-${i}`,
-            },
-          },
-          spec: {},
-          status: { phase },
-        })),
-      });
+      mockClient.listSandboxes.mockResolvedValue({ items });
 
       const list = await provider.list();
       expect(list.map((s) => s.status)).toEqual(expected);
@@ -566,7 +599,7 @@ describe('AgentSandboxProvider', () => {
         expect.objectContaining({
           kind: 'SandboxWarmPool',
           spec: expect.objectContaining({
-            desiredReady: 3,
+            replicas: 3,
           }),
         })
       );
@@ -973,7 +1006,7 @@ describe('AgentSandboxInstance', () => {
       const pastDate = new Date(Date.now() - 60000).toISOString();
       mockClient.getSandbox.mockResolvedValue({
         metadata: { creationTimestamp: pastDate },
-        status: { phase: 'Running' },
+        status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
       });
 
       const metrics = await instance.getMetrics();

--- a/src/lib/sandbox/providers/__tests__/agent-sandbox-provider.test.ts
+++ b/src/lib/sandbox/providers/__tests__/agent-sandbox-provider.test.ts
@@ -449,9 +449,21 @@ describe('AgentSandboxProvider', () => {
           },
           spec: {},
         },
+        // Ready=False + PodNotReady (transient) → creating
+        {
+          metadata: {
+            name: 'sandbox-6',
+            labels: { 'agentpane.io/sandbox-id': 'id-6', 'agentpane.io/project-id': 'proj-6' },
+          },
+          spec: {},
+          status: {
+            replicas: 1,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }],
+          },
+        },
       ];
 
-      const expected = ['running', 'creating', 'idle', 'error', 'stopped', 'creating'];
+      const expected = ['running', 'creating', 'idle', 'error', 'stopped', 'creating', 'creating'];
 
       mockClient.listSandboxes.mockResolvedValue({ items });
 

--- a/src/lib/sandbox/providers/agent-sandbox-instance.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-instance.ts
@@ -384,10 +384,13 @@ export class AgentSandboxInstance implements Sandbox {
    * Also checks spec.replicas === 0 for paused (idle) sandboxes.
    * Matches AgentSandboxProvider.mapConditionsToStatus() for consistency.
    */
-  private mapConditionsToStatus(sandbox: { spec?: { replicas?: number }; status?: { conditions?: Array<{ type?: string; status?: string; reason?: string }> } }): SandboxStatus {
+  private mapConditionsToStatus(sandbox: {
+    spec?: { replicas?: number };
+    status?: { conditions?: Array<{ type?: string; status?: string; reason?: string }> };
+  }): SandboxStatus {
     if (sandbox.spec?.replicas === 0) return 'idle';
     const conditions = sandbox.status?.conditions;
-    const ready = conditions?.find(c => c.type === 'Ready');
+    const ready = conditions?.find((c) => c.type === 'Ready');
     if (!ready) return 'creating';
     if (ready.status === 'True') return 'running';
     if (ready.reason === 'SandboxExpired') return 'stopped';

--- a/src/lib/sandbox/providers/agent-sandbox-instance.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-instance.ts
@@ -361,14 +361,13 @@ export class AgentSandboxInstance implements Sandbox {
   }
 
   /**
-   * Refresh status from the actual Sandbox CRD phase.
+   * Refresh status from the actual Sandbox CRD conditions.
    * Called by the provider after constructing an instance from a cluster query.
    */
   async refreshStatus(): Promise<void> {
     try {
       const sandbox = await this.client.getSandbox(this.sandboxName);
-      const phase = sandbox?.status?.phase;
-      this._status = this.mapPhaseToStatus(phase);
+      this._status = this.mapConditionsToStatus(sandbox);
     } catch (error) {
       if (error instanceof NotFoundError) {
         this._status = 'stopped';
@@ -379,23 +378,19 @@ export class AgentSandboxInstance implements Sandbox {
   }
 
   /**
-   * Map CRD phase to SandboxStatus.
-   * Matches AgentSandboxProvider.mapCrdPhase() for consistency.
+   * Map CRD conditions to SandboxStatus.
+   *
+   * v0.2.1 CRD uses status.conditions[] instead of status.phase.
+   * Also checks spec.replicas === 0 for paused (idle) sandboxes.
+   * Matches AgentSandboxProvider.mapConditionsToStatus() for consistency.
    */
-  private mapPhaseToStatus(phase?: string): SandboxStatus {
-    switch (phase) {
-      case 'Running':
-        return 'running';
-      case 'Pending':
-        return 'creating';
-      case 'Paused':
-        return 'idle';
-      case 'Failed':
-        return 'error';
-      case 'Succeeded':
-        return 'stopped';
-      default:
-        return 'creating';
-    }
+  private mapConditionsToStatus(sandbox: { spec?: { replicas?: number }; status?: { conditions?: Array<{ type?: string; status?: string; reason?: string }> } }): SandboxStatus {
+    if (sandbox.spec?.replicas === 0) return 'idle';
+    const conditions = sandbox.status?.conditions;
+    const ready = conditions?.find(c => c.type === 'Ready');
+    if (!ready) return 'creating';
+    if (ready.status === 'True') return 'running';
+    if (ready.reason === 'SandboxExpired') return 'stopped';
+    return 'error';
   }
 }

--- a/src/lib/sandbox/providers/agent-sandbox-instance.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-instance.ts
@@ -394,6 +394,9 @@ export class AgentSandboxInstance implements Sandbox {
     if (!ready) return 'creating';
     if (ready.status === 'True') return 'running';
     if (ready.reason === 'SandboxExpired') return 'stopped';
+    // Transient reasons (PodNotReady, ContainersNotReady) indicate startup in progress
+    const transientReasons = ['PodNotReady', 'ContainersNotReady'];
+    if (transientReasons.includes(ready.reason ?? '')) return 'creating';
     return 'error';
   }
 }

--- a/src/lib/sandbox/providers/agent-sandbox-provider.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-provider.ts
@@ -167,8 +167,9 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
         builder.runtimeClass(this.runtimeClassName);
       }
 
-      // Set TTL for auto-cleanup
-      builder.ttl(config.idleTimeoutMinutes * 60);
+      // Set absolute shutdown time for auto-cleanup
+      const shutdownTime = new Date(Date.now() + config.idleTimeoutMinutes * 60 * 1000).toISOString();
+      builder.shutdownTime(shutdownTime);
 
       // Apply the CRD manifest to the cluster
       const manifest = builder.build();
@@ -335,17 +336,17 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
         id: s.metadata?.labels?.['agentpane.io/sandbox-id'] ?? '',
         codespaceId: s.metadata?.labels?.['agentpane.io/project-id'] ?? '',
         containerId: s.metadata?.name ?? '',
-        status: this.mapCrdPhase(s.status?.phase),
-        image: s.spec?.podTemplateSpec?.spec?.containers?.[0]?.image ?? this.image,
+        status: this.mapConditionsToStatus(s),
+        image: s.spec?.podTemplate?.spec?.containers?.[0]?.image ?? this.image,
         createdAt: s.metadata?.creationTimestamp?.toString() ?? new Date().toISOString(),
         lastActivityAt: new Date().toISOString(),
         memoryMb: this.parseMemoryMi(
-          s.spec?.podTemplateSpec?.spec?.containers?.[0]?.resources?.limits?.memory as
+          s.spec?.podTemplate?.spec?.containers?.[0]?.resources?.limits?.memory as
             | string
             | undefined
         ),
         cpuCores: parseFloat(
-          (s.spec?.podTemplateSpec?.spec?.containers?.[0]?.resources?.limits?.cpu as string) ?? '0'
+          (s.spec?.podTemplate?.spec?.containers?.[0]?.resources?.limits?.cpu as string) ?? '0'
         ),
       }));
     } catch (error) {
@@ -505,15 +506,15 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
     const warmPoolName = 'agentpane-warm-pool';
 
     const warmPool: SandboxWarmPool = {
-      apiVersion: 'agents.x-k8s.io/v1alpha1',
+      apiVersion: 'extensions.agents.x-k8s.io/v1alpha1',
       kind: 'SandboxWarmPool',
       metadata: {
         name: warmPoolName,
         namespace: this.namespace,
       },
       spec: {
-        desiredReady: this.warmPoolSize,
-        templateRef: {
+        replicas: this.warmPoolSize,
+        sandboxTemplateRef: {
           name: 'agentpane-default',
         },
       },
@@ -546,32 +547,30 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
   // --- Helpers ---
 
   /**
-   * Map CRD phase string to SandboxStatus type.
+   * Map CRD conditions to SandboxStatus type.
    *
-   * CRD phases: Pending, Running, Paused, Succeeded, Failed
-   * SandboxStatus: 'stopped' | 'creating' | 'running' | 'idle' | 'stopping' | 'error'
+   * v0.2.1 CRD uses status.conditions[] instead of status.phase.
+   * Also checks spec.replicas === 0 for paused (idle) sandboxes.
    */
-  private mapCrdPhase(phase?: string): SandboxStatus {
-    switch (phase) {
-      case 'Running':
-        return 'running';
-      case 'Pending':
-        return 'creating';
-      case 'Paused':
-        return 'idle';
-      case 'Failed':
-        return 'error';
-      case 'Succeeded':
-        return 'stopped';
-      default:
-        return 'creating';
-    }
+  private mapConditionsToStatus(sandbox: { spec?: { replicas?: number }; status?: { conditions?: Array<{ type?: string; status?: string; reason?: string }> } }): SandboxStatus {
+    // Check pause first (replicas === 0)
+    if (sandbox.spec?.replicas === 0) return 'idle';
+
+    const conditions = sandbox.status?.conditions;
+    const ready = conditions?.find(c => c.type === 'Ready');
+    if (!ready) return 'creating';
+    if (ready.status === 'True') return 'running';
+    if (ready.reason === 'SandboxExpired') return 'stopped';
+    return 'error';
   }
 
   private parseMemoryMi(memoryStr?: string): number {
     if (!memoryStr) return 0;
-    const match = memoryStr.match(/^(\d+)Mi$/);
-    return match?.[1] ? parseInt(match[1], 10) : 0;
+    const miMatch = memoryStr.match(/^(\d+)Mi$/);
+    if (miMatch?.[1]) return parseInt(miMatch[1], 10);
+    const giMatch = memoryStr.match(/^(\d+)Gi$/);
+    if (giMatch?.[1]) return parseInt(giMatch[1], 10) * 1024;
+    return 0;
   }
 }
 

--- a/src/lib/sandbox/providers/agent-sandbox-provider.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-provider.ts
@@ -168,7 +168,9 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
       }
 
       // Set absolute shutdown time for auto-cleanup
-      const shutdownTime = new Date(Date.now() + config.idleTimeoutMinutes * 60 * 1000).toISOString();
+      const shutdownTime = new Date(
+        Date.now() + config.idleTimeoutMinutes * 60 * 1000
+      ).toISOString();
       builder.shutdownTime(shutdownTime);
 
       // Apply the CRD manifest to the cluster
@@ -552,12 +554,15 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
    * v0.2.1 CRD uses status.conditions[] instead of status.phase.
    * Also checks spec.replicas === 0 for paused (idle) sandboxes.
    */
-  private mapConditionsToStatus(sandbox: { spec?: { replicas?: number }; status?: { conditions?: Array<{ type?: string; status?: string; reason?: string }> } }): SandboxStatus {
+  private mapConditionsToStatus(sandbox: {
+    spec?: { replicas?: number };
+    status?: { conditions?: Array<{ type?: string; status?: string; reason?: string }> };
+  }): SandboxStatus {
     // Check pause first (replicas === 0)
     if (sandbox.spec?.replicas === 0) return 'idle';
 
     const conditions = sandbox.status?.conditions;
-    const ready = conditions?.find(c => c.type === 'Ready');
+    const ready = conditions?.find((c) => c.type === 'Ready');
     if (!ready) return 'creating';
     if (ready.status === 'True') return 'running';
     if (ready.reason === 'SandboxExpired') return 'stopped';

--- a/src/lib/sandbox/providers/agent-sandbox-provider.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-provider.ts
@@ -566,6 +566,9 @@ export class AgentSandboxProvider implements EventEmittingSandboxProvider {
     if (!ready) return 'creating';
     if (ready.status === 'True') return 'running';
     if (ready.reason === 'SandboxExpired') return 'stopped';
+    // Transient reasons (PodNotReady, ContainersNotReady) indicate startup in progress
+    const transientReasons = ['PodNotReady', 'ContainersNotReady'];
+    if (transientReasons.includes(ready.reason ?? '')) return 'creating';
     return 'error';
   }
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -166,7 +166,7 @@ export interface SandboxProviderHealth {
     message?: string;
     details?: Record<string, unknown>;
   }>;
-  listSandboxes?(): Promise<Array<{ name: string; phase: string }>>;
+  listSandboxes?(): Promise<Array<{ name: string; status: string }>>;
 }
 
 export interface RouterDependencies {

--- a/src/server/routes/sandbox-status.ts
+++ b/src/server/routes/sandbox-status.ts
@@ -39,7 +39,7 @@ interface SandboxProviderHealth {
     message?: string;
     details?: Record<string, unknown>;
   }>;
-  listSandboxes?(): Promise<Array<{ name: string; phase: string }>>;
+  listSandboxes?(): Promise<Array<{ name: string; status: string }>>;
   get?(codespaceId: string): Promise<unknown>;
   create?(config: {
     codespaceId: string;
@@ -179,7 +179,7 @@ async function countPods(
     const sandboxes = await provider.listSandboxes();
     return {
       total: sandboxes.length,
-      running: sandboxes.filter((s) => s.phase === 'Running').length,
+      running: sandboxes.filter((s) => s.status === 'running').length,
     };
   } catch (err) {
     log.warn(context ?? 'K8s listSandboxes failed', {

--- a/tests/e2e/k8s/agent-sandbox-e2e.test.ts
+++ b/tests/e2e/k8s/agent-sandbox-e2e.test.ts
@@ -685,12 +685,11 @@ describe.skipIf(!ENABLED)('Sandbox Template', () => {
   it('should create a sandbox from a template and inherit spec', async () => {
     templateName = generateTestName('e2e-tpl-inherit');
 
-    // Create template with specific resources
+    // Create template with specific resources and pod template metadata
     const template = new SandboxTemplateBuilder(templateName)
       .namespace(namespace)
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
-      .runtimeClass('gvisor') // Template sets gvisor
       .labels({ 'agentpane.io/e2e-test': 'true' })
       .build();
 
@@ -755,7 +754,299 @@ describe.skipIf(!ENABLED)('Sandbox Template', () => {
 });
 
 // ============================================================================
-// 8. Provider Integration
+// 8. v0.2.1 CRD Features
+// ============================================================================
+
+describe.skipIf(!ENABLED)('v0.2.1 CRD Features', () => {
+  let templateName: string;
+  let claimName: string;
+  let warmPoolName: string;
+
+  afterEach(async () => {
+    if (claimName) {
+      try {
+        await client.deleteClaim(claimName, namespace);
+      } catch {
+        // Already deleted
+      }
+      claimName = '';
+    }
+    if (warmPoolName) {
+      try {
+        await client.deleteWarmPool(warmPoolName, namespace);
+      } catch {
+        // Already deleted
+      }
+      warmPoolName = '';
+    }
+    if (templateName) {
+      try {
+        await client.deleteTemplate(templateName, namespace);
+      } catch {
+        // Already deleted
+      }
+      templateName = '';
+    }
+  });
+
+  it('should create a template with networkPolicyManagement=Managed', async () => {
+    templateName = generateTestName('e2e-tpl-netpol');
+
+    const template = new SandboxTemplateBuilder(templateName)
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .networkPolicyManagement('Managed')
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    const created = await client.createTemplate(template, namespace);
+    expect(created.metadata?.name).toBe(templateName);
+    expect(created.spec?.networkPolicyManagement).toBe('Managed');
+  });
+
+  it('should create a template with networkPolicyManagement=Unmanaged', async () => {
+    templateName = generateTestName('e2e-tpl-unmanaged');
+
+    const template = new SandboxTemplateBuilder(templateName)
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .networkPolicyManagement('Unmanaged')
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    const created = await client.createTemplate(template, namespace);
+    expect(created.metadata?.name).toBe(templateName);
+    expect(created.spec?.networkPolicyManagement).toBe('Unmanaged');
+  });
+
+  it('should detect sandbox readiness via Ready condition (not phase)', async () => {
+    const sandboxName = generateTestName('e2e-cond-ready');
+
+    const sandbox = new SandboxBuilder(sandboxName)
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .shutdownTime(new Date(Date.now() + 300_000).toISOString())
+      .build();
+
+    await client.createSandbox(sandbox, namespace);
+
+    const ready = await client.waitForReady(sandboxName, { timeoutMs: 120_000 });
+
+    // v0.2.1: No status.phase field — readiness is determined by conditions
+    expect(ready.status?.conditions).toBeDefined();
+    expect(Array.isArray(ready.status?.conditions)).toBe(true);
+
+    const readyCond = ready.status?.conditions?.find((c: any) => c.type === 'Ready');
+    expect(readyCond).toBeDefined();
+    expect(readyCond?.status).toBe('True');
+
+    // Verify phase is NOT present (v0.2.1 removed it)
+    expect((ready.status as any)?.phase).toBeUndefined();
+
+    // Cleanup
+    await client.deleteSandbox(sandboxName, namespace);
+  }, 130_000);
+
+  it('should create a SandboxClaim with lifecycle shutdownTime', async () => {
+    templateName = generateTestName('e2e-tpl-lc');
+    warmPoolName = generateTestName('e2e-pool-lc');
+
+    const template = new SandboxTemplateBuilder(templateName)
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    await client.createTemplate(template, namespace);
+
+    const pool = new SandboxWarmPoolBuilder(warmPoolName)
+      .namespace(namespace)
+      .replicas(1)
+      .sandboxTemplateRef(templateName)
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    await client.createWarmPool(pool, namespace);
+
+    // Wait for pool to have a ready sandbox
+    await waitForCondition(
+      async () => {
+        const fetched = await client.getWarmPool(warmPoolName, namespace);
+        return (fetched.status?.readyReplicas ?? 0) > 0;
+      },
+      120_000,
+      3_000
+    );
+
+    // Create claim with lifecycle
+    claimName = generateTestName('e2e-claim-lc');
+    const shutdownTime = new Date(Date.now() + 600_000).toISOString();
+
+    const claim = new SandboxClaimBuilder(claimName)
+      .namespace(namespace)
+      .templateRef(templateName)
+      .lifecycle({ shutdownTime })
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    const created = await client.createClaim(claim, namespace);
+    expect(created.metadata?.name).toBe(claimName);
+    expect(created.spec?.lifecycle?.shutdownTime).toBe(shutdownTime);
+
+    // Wait for claim to be bound
+    await waitForCondition(
+      async () => {
+        const fetched = await client.getClaim(claimName, namespace);
+        return !!fetched.status?.sandbox?.Name;
+      },
+      60_000,
+      2_000
+    );
+
+    const bound = await client.getClaim(claimName, namespace);
+    expect(bound.status?.sandbox?.Name).toBeDefined();
+  }, 200_000);
+
+  it('should create a SandboxClaim with lifecycle shutdownPolicy', async () => {
+    templateName = generateTestName('e2e-tpl-sp');
+    warmPoolName = generateTestName('e2e-pool-sp');
+
+    const template = new SandboxTemplateBuilder(templateName)
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    await client.createTemplate(template, namespace);
+
+    const pool = new SandboxWarmPoolBuilder(warmPoolName)
+      .namespace(namespace)
+      .replicas(1)
+      .sandboxTemplateRef(templateName)
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    await client.createWarmPool(pool, namespace);
+
+    await waitForCondition(
+      async () => {
+        const fetched = await client.getWarmPool(warmPoolName, namespace);
+        return (fetched.status?.readyReplicas ?? 0) > 0;
+      },
+      120_000,
+      3_000
+    );
+
+    claimName = generateTestName('e2e-claim-sp');
+
+    const claim = new SandboxClaimBuilder(claimName)
+      .namespace(namespace)
+      .templateRef(templateName)
+      .lifecycle({ shutdownPolicy: 'Delete' })
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    const created = await client.createClaim(claim, namespace);
+    expect(created.metadata?.name).toBe(claimName);
+    expect(created.spec?.lifecycle?.shutdownPolicy).toBe('Delete');
+  }, 200_000);
+
+  it('should use extensions API group for SandboxTemplate', async () => {
+    templateName = generateTestName('e2e-tpl-api');
+
+    const template = new SandboxTemplateBuilder(templateName)
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .labels({ 'agentpane.io/e2e-test': 'true' })
+      .build();
+
+    // Verify the builder sets the correct extensions API version
+    expect(template.apiVersion).toBe('extensions.agents.x-k8s.io/v1alpha1');
+
+    const created = await client.createTemplate(template, namespace);
+    expect(created.metadata?.name).toBe(templateName);
+  });
+
+  it('should use extensions API group for SandboxClaim', () => {
+    const claim = new SandboxClaimBuilder('test-api-check')
+      .namespace(namespace)
+      .templateRef('some-template')
+      .build();
+
+    expect(claim.apiVersion).toBe('extensions.agents.x-k8s.io/v1alpha1');
+  });
+
+  it('should use extensions API group for SandboxWarmPool', () => {
+    const pool = new SandboxWarmPoolBuilder('test-api-check')
+      .namespace(namespace)
+      .replicas(1)
+      .sandboxTemplateRef('some-template')
+      .build();
+
+    expect(pool.apiVersion).toBe('extensions.agents.x-k8s.io/v1alpha1');
+  });
+
+  it('should use core API group for Sandbox', () => {
+    const sandbox = new SandboxBuilder('test-api-check')
+      .namespace(namespace)
+      .image(getTestImage())
+      .build();
+
+    expect(sandbox.apiVersion).toBe('agents.x-k8s.io/v1alpha1');
+  });
+
+  it('should build sandbox with podTemplate (not podTemplateSpec)', () => {
+    const sandbox = new SandboxBuilder('test-pod-template')
+      .namespace(namespace)
+      .image(getTestImage())
+      .resources({ memory: '256Mi', cpu: '250m' })
+      .shutdownTime(new Date(Date.now() + 300_000).toISOString())
+      .build();
+
+    // v0.2.1: spec uses podTemplate (with spec + metadata), not podTemplateSpec
+    expect(sandbox.spec?.podTemplate).toBeDefined();
+    expect(sandbox.spec?.podTemplate?.spec).toBeDefined();
+    expect(sandbox.spec?.podTemplate?.metadata).toBeDefined();
+    expect((sandbox.spec as any)?.podTemplateSpec).toBeUndefined();
+  });
+
+  it('should build warm pool with replicas and sandboxTemplateRef (not desiredReady/templateRef)', () => {
+    const pool = new SandboxWarmPoolBuilder('test-warmpool-fields')
+      .namespace(namespace)
+      .replicas(3)
+      .sandboxTemplateRef('my-template')
+      .build();
+
+    // v0.2.1: replicas (not desiredReady), sandboxTemplateRef (not templateRef)
+    expect(pool.spec?.replicas).toBe(3);
+    expect(pool.spec?.sandboxTemplateRef).toEqual({ name: 'my-template' });
+    expect((pool.spec as any)?.desiredReady).toBeUndefined();
+    expect((pool.spec as any)?.templateRef).toBeUndefined();
+  });
+
+  it('should build SandboxClaim without warmPoolRef', () => {
+    const claim = new SandboxClaimBuilder('test-claim-fields')
+      .namespace(namespace)
+      .templateRef('my-template')
+      .lifecycle({ shutdownTime: new Date(Date.now() + 300_000).toISOString() })
+      .build();
+
+    // v0.2.1: warmPoolRef removed, lifecycle added
+    expect(claim.spec?.sandboxTemplateRef).toEqual({ name: 'my-template' });
+    expect(claim.spec?.lifecycle).toBeDefined();
+    expect((claim.spec as any)?.warmPoolRef).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// 9. Provider Integration
 // ============================================================================
 
 describe.skipIf(!ENABLED)('Provider Integration', () => {
@@ -944,7 +1235,7 @@ describe.skipIf(!ENABLED)('Provider Integration', () => {
 });
 
 // ============================================================================
-// 9. Cleanup
+// 10. Cleanup
 // ============================================================================
 
 describe.skipIf(!ENABLED)('Cleanup', () => {

--- a/tests/e2e/k8s/agent-sandbox-e2e.test.ts
+++ b/tests/e2e/k8s/agent-sandbox-e2e.test.ts
@@ -112,7 +112,7 @@ describe.skipIf(!ENABLED)('Sandbox Lifecycle', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(300)
+      .shutdownTime(new Date(Date.now() + 300_000).toISOString())
       .build();
 
     const created = await client.createSandbox(sandbox, namespace);
@@ -123,7 +123,8 @@ describe.skipIf(!ENABLED)('Sandbox Lifecycle', () => {
       timeoutMs: 120_000,
     });
 
-    expect(ready.status?.phase).toBe('Running');
+    const readyCond = ready.status?.conditions?.find((c: any) => c.type === 'Ready');
+    expect(readyCond?.status).toBe('True');
   }, 130_000);
 
   it('should list the created sandbox', async () => {
@@ -134,7 +135,7 @@ describe.skipIf(!ENABLED)('Sandbox Lifecycle', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(300)
+      .shutdownTime(new Date(Date.now() + 300_000).toISOString())
       .build();
 
     await client.createSandbox(sandbox, namespace);
@@ -157,7 +158,7 @@ describe.skipIf(!ENABLED)('Sandbox Lifecycle', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(300)
+      .shutdownTime(new Date(Date.now() + 300_000).toISOString())
       .build();
 
     await client.createSandbox(sandbox, namespace);
@@ -165,7 +166,8 @@ describe.skipIf(!ENABLED)('Sandbox Lifecycle', () => {
 
     const fetched = await client.getSandbox(sandboxName, namespace);
     expect(fetched.metadata?.name).toBe(sandboxName);
-    expect(fetched.status?.phase).toBe('Running');
+    const readyCond = fetched.status?.conditions?.find((c: any) => c.type === 'Ready');
+    expect(readyCond?.status).toBe('True');
   }, 130_000);
 
   it('should delete a sandbox and confirm removal', async () => {
@@ -176,7 +178,7 @@ describe.skipIf(!ENABLED)('Sandbox Lifecycle', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(300)
+      .shutdownTime(new Date(Date.now() + 300_000).toISOString())
       .build();
 
     await client.createSandbox(sandbox, namespace);
@@ -217,7 +219,7 @@ describe.skipIf(!ENABLED)('Exec in Sandbox', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(600)
+      .shutdownTime(new Date(Date.now() + 600_000).toISOString())
       .build();
 
     await client.createSandbox(sandbox, namespace);
@@ -306,7 +308,7 @@ describe.skipIf(!ENABLED)('Streaming Exec', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(600)
+      .shutdownTime(new Date(Date.now() + 600_000).toISOString())
       .build();
 
     await client.createSandbox(sandbox, namespace);
@@ -393,7 +395,7 @@ describe.skipIf(!ENABLED)('tmux Sessions', () => {
       .image(getTestImage())
       .resources({ memory: '256Mi', cpu: '250m' })
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(600)
+      .shutdownTime(new Date(Date.now() + 600_000).toISOString())
       .build();
 
     await client.createSandbox(sandbox, namespace);
@@ -518,7 +520,7 @@ describe.skipIf(!ENABLED)('Warm Pool', () => {
     const pool = new SandboxWarmPoolBuilder(warmPoolName)
       .namespace(namespace)
       .replicas(1)
-      .templateRef(templateName)
+      .sandboxTemplateRef(templateName)
       .labels({ 'agentpane.io/e2e-test': 'true' })
       .build();
 
@@ -543,7 +545,7 @@ describe.skipIf(!ENABLED)('Warm Pool', () => {
     const pool = new SandboxWarmPoolBuilder(warmPoolName)
       .namespace(namespace)
       .replicas(1)
-      .templateRef(templateName)
+      .sandboxTemplateRef(templateName)
       .labels({ 'agentpane.io/e2e-test': 'true' })
       .build();
 
@@ -579,7 +581,7 @@ describe.skipIf(!ENABLED)('Warm Pool', () => {
     const pool = new SandboxWarmPoolBuilder(warmPoolName)
       .namespace(namespace)
       .replicas(1)
-      .templateRef(templateName)
+      .sandboxTemplateRef(templateName)
       .labels({ 'agentpane.io/e2e-test': 'true' })
       .build();
 
@@ -600,26 +602,24 @@ describe.skipIf(!ENABLED)('Warm Pool', () => {
     const claim = new SandboxClaimBuilder(claimName)
       .namespace(namespace)
       .templateRef(templateName)
-      .warmPoolRef(warmPoolName)
       .labels({ 'agentpane.io/e2e-test': 'true' })
       .build();
 
     const created = await client.createClaim(claim, namespace);
     expect(created.metadata?.name).toBe(claimName);
 
-    // Wait for claim to be bound
+    // Wait for claim to be bound (sandbox.Name populated)
     await waitForCondition(
       async () => {
         const fetched = await client.getClaim(claimName, namespace);
-        return fetched.status?.phase === 'Bound';
+        return !!fetched.status?.sandbox?.Name;
       },
       60_000,
       2_000
     );
 
     const bound = await client.getClaim(claimName, namespace);
-    expect(bound.status?.phase).toBe('Bound');
-    expect(bound.status?.sandboxRef?.name).toBeDefined();
+    expect(bound.status?.sandbox?.Name).toBeDefined();
 
     // Cleanup claim
     await client.deleteClaim(claimName, namespace);
@@ -696,25 +696,39 @@ describe.skipIf(!ENABLED)('Sandbox Template', () => {
 
     await client.createTemplate(template, namespace);
 
-    // Create sandbox from template
-    sandboxName = generateTestName('e2e-from-tpl');
+    // Create sandbox from template via SandboxClaim
+    const claimName = generateTestName('e2e-claim-tpl');
 
-    const sandbox = new SandboxBuilder(sandboxName)
+    const claim = new SandboxClaimBuilder(claimName)
       .namespace(namespace)
-      .fromTemplate(templateName)
+      .templateRef(templateName)
       .labels({ 'agentpane.io/e2e-test': 'true' })
-      .ttl(300)
       .build();
 
-    const created = await client.createSandbox(sandbox, namespace);
-    expect(created.metadata?.name).toBe(sandboxName);
-    expect(created.spec?.sandboxTemplateRef?.name).toBe(templateName);
+    const created = await client.createClaim(claim, namespace);
+    expect(created.metadata?.name).toBe(claimName);
 
-    // Wait for Ready (controller resolves the template)
-    await client.waitForReady(sandboxName, { timeoutMs: 120_000 });
+    // Wait for claim to be bound (sandbox.Name populated)
+    await waitForCondition(
+      async () => {
+        const fetched = await client.getClaim(claimName, namespace);
+        return !!fetched.status?.sandbox?.Name;
+      },
+      120_000,
+      3_000
+    );
 
+    const bound = await client.getClaim(claimName, namespace);
+    sandboxName = bound.status?.sandbox?.Name ?? '';
+    expect(sandboxName).toBeTruthy();
+
+    // Verify the sandbox is running
     const running = await client.getSandbox(sandboxName, namespace);
-    expect(running.status?.phase).toBe('Running');
+    const readyCond = running.status?.conditions?.find((c: any) => c.type === 'Ready');
+    expect(readyCond?.status).toBe('True');
+
+    // Cleanup claim
+    await client.deleteClaim(claimName, namespace);
   }, 130_000);
 
   it('should delete a template', async () => {

--- a/tests/lib/sandbox/sandbox-controller.test.ts
+++ b/tests/lib/sandbox/sandbox-controller.test.ts
@@ -69,7 +69,7 @@ function makeSandbox(name: string, overrides: Partial<Sandbox> = {}): Sandbox {
 
 function makeWarmPool(
   name: string,
-  desiredReady: number,
+  replicas: number,
   templateName: string,
   overrides: Partial<SandboxWarmPool> = {}
 ): SandboxWarmPool {
@@ -78,8 +78,8 @@ function makeWarmPool(
     kind: 'SandboxWarmPool',
     metadata: { name, namespace: 'test-ns' },
     spec: {
-      desiredReady,
-      templateRef: { name: templateName },
+      replicas,
+      sandboxTemplateRef: { name: templateName },
     },
     ...overrides,
   } as SandboxWarmPool;
@@ -461,7 +461,7 @@ describe('SandboxController', () => {
         kind: 'SandboxTemplate',
         metadata: { name: 'my-template' },
         spec: {
-          podTemplateSpec: {
+          podTemplate: {
             spec: {
               containers: [
                 { name: 'custom', image: 'custom-image:latest', command: ['sleep', 'infinity'] },
@@ -797,9 +797,9 @@ describe('SandboxController', () => {
       ctrl.stop();
     });
 
-    it('skips warm pool with no templateRef', async () => {
+    it('skips warm pool with no sandboxTemplateRef', async () => {
       const pool = makeWarmPool('pool-no-tpl', 2, 'any-template');
-      (pool.spec as any).templateRef = undefined;
+      (pool.spec as any).sandboxTemplateRef = undefined;
 
       mockClient.listWarmPools.mockResolvedValue({ items: [pool] });
 

--- a/tests/lib/sandbox/sandbox-controller.test.ts
+++ b/tests/lib/sandbox/sandbox-controller.test.ts
@@ -748,8 +748,8 @@ describe('SandboxController', () => {
 
     it('does not create sandboxes when pool is satisfied', async () => {
       const existingSandboxes = [
-        makeSandbox('warm-pool-1-a', { status: { phase: 'Running' } } as any),
-        makeSandbox('warm-pool-1-b', { status: { phase: 'Running' } } as any),
+        makeSandbox('warm-pool-1-a', { status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] } } as any),
+        makeSandbox('warm-pool-1-b', { status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] } } as any),
       ];
 
       mockClient.listWarmPools.mockResolvedValue({
@@ -766,7 +766,7 @@ describe('SandboxController', () => {
     });
 
     it('cleans up terminal warm pool sandboxes', async () => {
-      const existingSandboxes = [makeSandbox('warm-fail', { status: { phase: 'Failed' } } as any)];
+      const existingSandboxes = [makeSandbox('warm-fail', { status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False', reason: 'PodCreationFailed' }] } } as any)];
 
       mockClient.listWarmPools.mockResolvedValue({
         items: [makeWarmPool('pool-1', 1, 'template-1')],
@@ -813,7 +813,7 @@ describe('SandboxController', () => {
 
     it('updates warm pool status with ready count', async () => {
       const existingSandboxes = [
-        makeSandbox('warm-running', { status: { phase: 'Running' } } as any),
+        makeSandbox('warm-running', { status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] } } as any),
       ];
 
       mockClient.listWarmPools.mockResolvedValue({
@@ -834,10 +834,58 @@ describe('SandboxController', () => {
       ctrl.stop();
     });
 
+    it('cleans up expired warm pool sandboxes (SandboxExpired reason)', async () => {
+      const existingSandboxes = [
+        makeSandbox('warm-expired', {
+          status: {
+            replicas: 0,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'SandboxExpired' }],
+          },
+        } as any),
+      ];
+
+      mockClient.listWarmPools.mockResolvedValue({
+        items: [makeWarmPool('pool-1', 1, 'template-1')],
+      });
+      mockClient.listSandboxes.mockResolvedValue({ items: existingSandboxes });
+      mockClient.deleteSandbox.mockResolvedValue(undefined);
+      mockClient.createSandbox.mockResolvedValue({});
+
+      const ctrl = new SandboxController(mockClient as any, 'test-ns');
+      await ctrl.start();
+
+      expect(mockClient.deleteSandbox).toHaveBeenCalledWith('warm-expired');
+
+      ctrl.stop();
+    });
+
+    it('does not clean up sandboxes with non-terminal Ready=False reason', async () => {
+      const existingSandboxes = [
+        makeSandbox('warm-creating', {
+          status: {
+            replicas: 1,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'ContainerCreating' }],
+          },
+        } as any),
+      ];
+
+      mockClient.listWarmPools.mockResolvedValue({
+        items: [makeWarmPool('pool-1', 1, 'template-1')],
+      });
+      mockClient.listSandboxes.mockResolvedValue({ items: existingSandboxes });
+
+      const ctrl = new SandboxController(mockClient as any, 'test-ns');
+      await ctrl.start();
+
+      expect(mockClient.deleteSandbox).not.toHaveBeenCalled();
+
+      ctrl.stop();
+    });
+
     it('counts Pending sandboxes as active to avoid over-provisioning', async () => {
       const existingSandboxes = [
-        makeSandbox('warm-pending-a', { status: { phase: 'Pending' } } as any),
-        makeSandbox('warm-pending-b', { status: { phase: 'Pending' } } as any),
+        makeSandbox('warm-pending-a', { status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }] } } as any),
+        makeSandbox('warm-pending-b', { status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }] } } as any),
       ];
 
       mockClient.listWarmPools.mockResolvedValue({

--- a/tests/lib/sandbox/sandbox-controller.test.ts
+++ b/tests/lib/sandbox/sandbox-controller.test.ts
@@ -748,8 +748,12 @@ describe('SandboxController', () => {
 
     it('does not create sandboxes when pool is satisfied', async () => {
       const existingSandboxes = [
-        makeSandbox('warm-pool-1-a', { status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] } } as any),
-        makeSandbox('warm-pool-1-b', { status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] } } as any),
+        makeSandbox('warm-pool-1-a', {
+          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
+        } as any),
+        makeSandbox('warm-pool-1-b', {
+          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
+        } as any),
       ];
 
       mockClient.listWarmPools.mockResolvedValue({
@@ -766,7 +770,14 @@ describe('SandboxController', () => {
     });
 
     it('cleans up terminal warm pool sandboxes', async () => {
-      const existingSandboxes = [makeSandbox('warm-fail', { status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False', reason: 'PodCreationFailed' }] } } as any)];
+      const existingSandboxes = [
+        makeSandbox('warm-fail', {
+          status: {
+            replicas: 0,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'PodCreationFailed' }],
+          },
+        } as any),
+      ];
 
       mockClient.listWarmPools.mockResolvedValue({
         items: [makeWarmPool('pool-1', 1, 'template-1')],
@@ -813,7 +824,9 @@ describe('SandboxController', () => {
 
     it('updates warm pool status with ready count', async () => {
       const existingSandboxes = [
-        makeSandbox('warm-running', { status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] } } as any),
+        makeSandbox('warm-running', {
+          status: { replicas: 1, conditions: [{ type: 'Ready', status: 'True' }] },
+        } as any),
       ];
 
       mockClient.listWarmPools.mockResolvedValue({
@@ -884,8 +897,18 @@ describe('SandboxController', () => {
 
     it('counts Pending sandboxes as active to avoid over-provisioning', async () => {
       const existingSandboxes = [
-        makeSandbox('warm-pending-a', { status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }] } } as any),
-        makeSandbox('warm-pending-b', { status: { replicas: 0, conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }] } } as any),
+        makeSandbox('warm-pending-a', {
+          status: {
+            replicas: 0,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }],
+          },
+        } as any),
+        makeSandbox('warm-pending-b', {
+          status: {
+            replicas: 0,
+            conditions: [{ type: 'Ready', status: 'False', reason: 'PodNotReady' }],
+          },
+        } as any),
       ];
 
       mockClient.listWarmPools.mockResolvedValue({

--- a/tests/routes/sandbox-status.test.ts
+++ b/tests/routes/sandbox-status.test.ts
@@ -126,8 +126,8 @@ describe('GET /sandbox/status/:codespaceId - K8s auto-heal guard', () => {
   it('does NOT trigger auto-heal when listSandboxes returns running pods', async () => {
     const k8sProvider = createMockK8sProvider({
       listSandboxes: vi.fn().mockResolvedValue([
-        { name: 'sandbox-1', phase: 'Running' },
-        { name: 'sandbox-2', phase: 'Running' },
+        { name: 'sandbox-1', status: 'running' },
+        { name: 'sandbox-2', status: 'running' },
       ]),
     });
 
@@ -207,7 +207,7 @@ describe('GET /sandbox/status/:codespaceId - K8s auto-heal guard', () => {
         // First call: no pods (triggers auto-heal)
         // Second call: pod created by auto-heal
         if (listCallCount === 1) return Promise.resolve([]);
-        return Promise.resolve([{ name: 'sandbox-default', phase: 'Running' }]);
+        return Promise.resolve([{ name: 'sandbox-default', status: 'running' }]);
       }),
     });
 
@@ -595,9 +595,9 @@ describe('GET /sandbox/status/:codespaceId - K8s health details', () => {
     const mockDb = createMockDb();
     const k8sProvider = createMockK8sProvider({
       listSandboxes: vi.fn().mockResolvedValue([
-        { name: 'sandbox-1', phase: 'Running' },
-        { name: 'sandbox-2', phase: 'Pending' },
-        { name: 'sandbox-3', phase: 'Running' },
+        { name: 'sandbox-1', status: 'running' },
+        { name: 'sandbox-2', status: 'creating' },
+        { name: 'sandbox-3', status: 'running' },
       ]),
     });
 


### PR DESCRIPTION
## Summary
This PR updates the Agent Sandbox SDK and controllers to align with the v0.2.1 API specification, which introduces a major shift from phase-based to condition-based status reporting and reorganizes the CRD API groups.

## Key Changes

### API Group Reorganization
- **Sandbox** remains in `agents.x-k8s.io/v1alpha1` (core group)
- **SandboxTemplate**, **SandboxClaim**, **SandboxWarmPool** moved to `extensions.agents.x-k8s.io/v1alpha1`
- Updated all builders, client CRUD operations, and constants to use the correct API groups

### Status Model Migration
- Replaced phase-based status (`phase: 'Running' | 'Failed' | etc.`) with condition-based status
- `SandboxStatus` now uses `conditions: V1Condition[]` array with `type: 'Ready'` and `type: 'PodReady'`
- Added `replicas` field to status (0 = paused/not ready, 1 = running)
- Removed `podName`, `podIP`, `phase` fields from status schema
- Updated `waitForReady()` to check for `Ready=True` condition instead of `phase='Running'`

### Sandbox Spec Restructuring
- Replaced `podTemplateSpec` with `podTemplate` (includes required `metadata` field)
- Replaced `volumeClaims` with `volumeClaimTemplates` (PVC template format)
- Moved `runtimeClassName` from spec to `podTemplate.spec.runtimeClassName`
- Replaced `ttlSecondsAfterFinished` with `shutdownTime` (absolute ISO timestamp) and `shutdownPolicy` ('Delete' | 'Retain')
- Removed `networkPolicy` and `runtimeClassName` from top-level spec
- Removed `sandboxTemplateRef` from public SandboxSpec (kept as internal convention for warm pool reconciler)

### SandboxClaim Updates
- `SandboxTemplateRef` now name-only (no namespace field)
- Removed `warmPoolRef` from spec
- Status changed from `phase: 'Bound'` to `sandbox: { Name: string }` (capital-N to match upstream JSON)
- Added `Lifecycle` type for `shutdownTime` and `shutdownPolicy` fields

### SandboxWarmPool Updates
- Renamed `desiredReady` to `replicas`
- Renamed `templateRef` to `sandboxTemplateRef`

### Builder API Changes
- `SandboxBuilder.ttl(seconds)` → `shutdownTime(isoString)` and `shutdownPolicy(policy)`
- `SandboxBuilder.fromTemplate()` removed (use SandboxClaim instead)
- `SandboxBuilder.runtimeClass()` now sets `podTemplate.spec.runtimeClassName`
- `SandboxBuilder.addVolumeClaim()` → `addVolumeClaimTemplate()`
- `SandboxTemplateBuilder.podTemplateSpec()` → `podTemplate()`
- `SandboxWarmPoolBuilder.templateRef()` → `sandboxTemplateRef()`
- `SandboxWarmPoolBuilder.desiredReady()` → `replicas()`

### Provider Implementation Updates
- Updated `AgentSandboxProvider` to use `shutdownTime` (absolute timestamp) instead of TTL
- Changed status mapping from `mapCrdPhase()` to `mapConditionsToStatus()`
- Updated e2e tests to check for `Ready=True` condition instead of `phase='Running'`
- Updated warm pool reconciliation to use new field names

### Schema Updates
- Added `podMetadataSchema`, `podTemplateSchema`, `persistentVolumeClaimTemplateSchema`
- Added `shutdownPolicySchema`, `lifecycleSchema`, `claimSandboxStatusSchema`
- Removed `sandboxNetworkRuleSchema`, `sandboxVolumeClaimSchema`
- Updated all spec/status schemas to match v0.2.1 structure

## Notable Implementation Details

https://claude.ai/code/session_019uaqAVedoME8SQtZKPr7Do
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
