### PR TITLE
fix(ci): drop node_modules cache restore-key fallback

### DIFF
--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -26,8 +26,6 @@ runs:
       with:
         path: node_modules
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
-        restore-keys: |
-          node-modules-${{ runner.os }}-
 
     - name: Restore Bun packages cache
       uses: actions/cache@v5
@@ -36,3 +34,8 @@ runs:
         key: bun-packages-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
         restore-keys: |
           bun-packages-${{ runner.os }}-
+
+    - name: Install dependencies (cache miss fallback)
+      if: steps.cache-modules.outputs.cache-hit != 'true'
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Bun version to install
     required: false
     default: '1.3.10'
+  cache-version:
+    description: Cache version token; bump to invalidate stale caches
+    required: false
+    default: v2
 
 outputs:
   cache-hit:
@@ -25,15 +29,15 @@ runs:
       uses: actions/cache@v5
       with:
         path: node_modules
-        key: node-modules-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
+        key: node-modules-${{ inputs.cache-version }}-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
 
     - name: Restore Bun packages cache
       uses: actions/cache@v5
       with:
         path: ~/.bun/install/cache
-        key: bun-packages-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
+        key: bun-packages-${{ inputs.cache-version }}-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
         restore-keys: |
-          bun-packages-${{ runner.os }}-
+          bun-packages-${{ inputs.cache-version }}-${{ runner.os }}-
 
     - name: Install dependencies (cache miss fallback)
       if: steps.cache-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   BUN_VERSION: '1.3.10'
+  # Bump to invalidate stale node_modules / bun package caches.
+  CACHE_VERSION: v2
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -30,15 +32,15 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
+          key: node-modules-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
 
       - name: Cache Bun packages
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: bun-packages-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
+          key: bun-packages-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
           restore-keys: |
-            bun-packages-${{ runner.os }}-
+            bun-packages-${{ env.CACHE_VERSION }}-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/bun.lock', '**/package.json') }}
-          restore-keys: |
-            node-modules-${{ runner.os }}-
 
       - name: Cache Bun packages
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
Fixes recurring \`z.function(...).returns is not a function\` build failures on main after dependency updates.

## Root cause
\`actions/cache@v5\` with \`restore-keys: node-modules-Linux-\` fell back to a stale \`node_modules/\` from a previous lockfile hash. When the install job then ran \`bun install --frozen-lockfile\` on top of the partial restore, bun reported success without re-linking missing nested deps (e.g. \`zod@3.25.76\` nested under \`@tanstack/router-plugin/node_modules/zod\`). The downstream build job restored the same poisoned cache and \`vite.config.ts\` failed when \`@tanstack/router-plugin\` tried \`z.function(...).returns(...)\` — an API removed in zod 4.

Seen on CI run [24643155383](https://github.com/agentdevsl/agentpane/actions/runs/24643155383) after #160 merged, and on PR #155 ([run 24643200548](https://github.com/agentdevsl/agentpane/actions/runs/24643200548)).

## Changes
- Drop \`restore-keys\` for \`node_modules\` cache in \`.github/workflows/ci.yml\` and \`.github/actions/setup-bun-env/action.yml\`. A cache miss now forces a fresh install, not a stale restore.
- Keep \`restore-keys\` on the Bun download cache (\`~/.bun/install/cache\`) — that only accelerates downloads, it isn't consumed directly.
- Add explicit \`bun install --frozen-lockfile\` step inside \`setup-bun-env\` composite when \`cache-hit != 'true'\`, so downstream jobs (\`test\`, \`build\`, \`integration-test\`) self-heal if the shared \`install\` job's cache isn't yet exact-available.

## Test plan
- [ ] CI passes on this PR
- [ ] On merge, push-to-main CI run is green (no \`z.function(...).returns\` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
