### PR TITLE
docs(arch-review): April 2026 full architecture review

### DIFF
--- a/specs/arch_review_april/01-service-architecture.md
+++ b/specs/arch_review_april/01-service-architecture.md
@@ -1,0 +1,127 @@
+# Service Architecture
+
+## Summary
+The service layer is reasonably well-organised: the recent facade split for `AgentService` (CRUD / Execution / Queue) and `ContainerAgentService` (state / worktree / exec / plan-approval / agentcore bridge) and the proper dependency ordering in `service-container.ts` have eliminated the old "stub-then-patch" TaskService pattern. However, four architectural habits now dominate the code and deserve attention: (1) heavy use of in-memory `Map` state with no reconciliation path on crash/restart, (2) late-binding optional setters on `TaskService`, (3) a monolithic `TaskCreationService` (~2,600 LOC) that skipped the facade treatment, and (4) a 6-phase bootstrap whose background sandbox retry and API-key resolution have subtle "server up but broken" failure modes.
+
+## Map
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| Bootstrap orchestration | `src/server/bootstrap/server-bootstrap.ts`, `src/server/bootstrap/phases/*.ts`, `src/server/bootstrap/sandbox/*.ts` | 11-step pipeline: config -> db -> recovery -> services -> api key -> router -> serve -> schedulers -> sandbox (background) |
+| Service container (DI) | `src/server/bootstrap/service-container.ts`, `src/server/bootstrap/types.ts` | Factory function builds all 30+ services in dependency order; a flat `ServiceContainer` interface is passed to routes |
+| Shutdown | `src/server/bootstrap/shutdown.ts` | LIFO cleanup registry with 30s force-exit guard |
+| Facade services | `src/services/agent.service.ts`, `src/services/session.service.ts`, `src/services/container-agent.service.ts`, `src/services/container-agent/container-agent.service.ts` | Delegate to focused sub-services under `src/services/{agent,session,container-agent}/` |
+| Non-facade large services | `src/services/task.service.ts` (907 LOC), `src/services/codespace.service.ts` (663 LOC), `src/services/task-creation.service.ts` (2,623 LOC) | Still monolithic |
+| In-memory state holders | `src/services/container-agent/sandbox-state.ts`, `src/services/agent/agent-execution.service.ts`, `src/services/task-creation.service.ts`, `src/services/terraform-compose.service.ts`, `src/services/cli-monitor/cli-monitor.service.ts`, `src/services/{terraform,template}-sync-scheduler.ts` | Maps/sets keyed by taskId/sessionId/registryId with various TTL strategies |
+| Recovery | `src/server/bootstrap/phases/recovery.ts`, `src/services/container-agent/plan-approval.service.ts:188` | Resets stale agents/tasks and recovers pending plans from DB on boot |
+
+## What's working
+- Facade pattern for `AgentService` and `ContainerAgentService` delivered clean sub-service boundaries (CRUD / execution / queue; state / worktree / exec / plan / agentcore) without breaking callers.
+- `service-container.ts` is comment-documented with the dependency graph and constructs services in-order so constructor params enforce ordering at compile time.
+- Graceful shutdown uses LIFO with a 30s force-exit safety net (`shutdown.ts:30-51`) and individual cleanups are wrapped in try/catch so one failure cannot block the rest.
+- Recovery phase (`phases/recovery.ts`) resets `starting|planning|running` agents, orphaned tasks, and stale worktree refs on every boot — a rare and valuable property.
+- Pending plans are persisted to the `tasks` table and recovered via `PlanApprovalService.getPendingPlan` (`plan-approval.service.ts:188-220`), so approval survives a restart.
+- `CommandRunner` is already a typed interface (`worktree.service.ts:120-122`) with a sandbox-variant factory — testability boundary is in place.
+
+## Findings
+
+### F01-01: In-memory running-agent state has no DB reconciliation on restart
+- **Priority**: P1
+- **Observation**: `SandboxStateManager` (`src/services/container-agent/sandbox-state.ts:19-28`) holds `runningAgents`, `runningAgentCoreAgents`, `pendingPlans`, and `startingAgents` in process memory. Recovery (`src/server/bootstrap/phases/recovery.ts:36-85`) resets agents to `idle` and tasks to `backlog` at boot — but there is no reconciliation against live containers: if the host restarts while Docker/K8s containers are still running (or are being drained), the DB forgets them and a subsequent restart of the same task can collide with live containers on the same codespace. `pendingPlans` does recover from DB (`plan-approval.service.ts:188-220`), but `runningAgents` does not.
+- **Risk**: Duplicate agents on the same task after a crash, silent capacity leaks (reserved slots without tracking), orphaned containers consuming resources.
+- **Recommendation**: Add a reconciliation step to the recovery phase that lists live sandboxes via each provider and either adopts them into `SandboxStateManager` or explicitly destroys them. Document the chosen policy (adopt vs destroy) per provider.
+- **Effort**: M
+- **Links**: [`specs/release_plan/05-error-resilience.md`](../release_plan/05-error-resilience.md), [`specs/release_plan/06-database-integrity.md`](../release_plan/06-database-integrity.md)
+
+### F01-02: Late-binding optional setters on TaskService bypass type-level init guarantees
+- **Priority**: P2
+- **Observation**: `TaskService` exposes `setContainerAgentService()` and `setAgentExecutionService()` (`src/services/task.service.ts:122-132`) called from two very different bootstrap locations — `service-container.ts:157` (synchronous, always) and `sandbox/sandbox-init.ts:139` (async background, may never fire if the provider init times out and retries fail). `approvePlan` (`task.service.ts:194-236`) then branches on which field is set, returning `NO_EXECUTION_SERVICE` (503) if neither is wired — a runtime failure mode that the type system cannot catch.
+- **Risk**: Silent "feature missing" errors at runtime when sandbox init fails; brittle to refactors; tests that stub only one trigger miss code paths.
+- **Recommendation**: Collapse into a single required dependency `TaskOrchestrator` interface passed at construction, or move plan-approval out of TaskService into a dedicated orchestrator that owns the decision.
+- **Effort**: M
+- **Links**: N/A
+
+### F01-03: Sandbox provider initialization is fire-and-forget with no readiness gate for dependents
+- **Priority**: P1
+- **Observation**: `initSandboxProvider` runs as a background promise after `Bun.serve` starts (`server-bootstrap.ts:211-217`). Task/agent routes that require `containerAgentService` become usable only after sandbox init resolves. There is no readiness probe and no 503 gate — if init times out or retries back off for minutes (exponential backoff up to 5 min in non-dev, `sandbox-init.ts:185`), `taskService.setContainerAgentService` is never called and every task-move yields the `NO_EXECUTION_SERVICE` error from F01-02.
+- **Risk**: "Server healthy but nothing works" silent failure; confusing UX; load balancers route traffic to an incomplete instance.
+- **Recommendation**: Expose a `/ready` (vs `/health`) endpoint gated on `sandboxState.provider !== null`. Have route handlers that require the sandbox return a consistent typed error rather than relying on an optional setter.
+- **Effort**: S
+- **Links**: [`specs/release_plan/03-observability.md`](../release_plan/03-observability.md), [`specs/release_plan/04-release-deployment.md`](../release_plan/04-release-deployment.md)
+
+### F01-04: CommandRunner is constructed inline in the service container, limiting test isolation
+- **Priority**: P2
+- **Observation**: `createBunCommandRunner` is defined in-file at `src/server/bootstrap/service-container.ts:58-79` and wired into both `WorktreeService` and `CodespaceService` (and via those, TaskService). There is no way to swap it at bootstrap — every call to `createServiceContainer` brings a real `Bun.spawn` runner. Tests substitute via direct constructor calls to `WorktreeService`, but any integration-style test of the full container inherits real shell execution.
+- **Risk**: Slow/flaky integration tests; accidental shell execution in unit contexts; hard to enforce the `validateShellCommand` policy (`worktree.service.ts:128-133`) from a single choke point.
+- **Recommendation**: Accept `CommandRunner` as an injected parameter to `createServiceContainer` (default to the Bun runner). Consider moving `validateShellCommand` into the runner itself so every concrete runner enforces it.
+- **Effort**: S
+- **Links**: [`specs/release_plan/02-security-hardening.md`](../release_plan/02-security-hardening.md)
+
+### F01-05: Bootstrap phase failures have inconsistent exit behaviour
+- **Priority**: P1
+- **Observation**: Phase failure handling is uneven: `initializeDatabase` calls `process.exit(1)` on missing `DATABASE_URL` (`phases/database.ts:43`); `resolveApiKey` only exits in production and warns in dev (`phases/api-key-resolution.ts:36-42`); `runRecovery` swallows errors and returns `{errors}` which bootstrap logs but does not act on (`server-bootstrap.ts:54-58`); `startSchedulers` logs "Failed to start scheduler" and continues (`phases/schedulers.ts:51-57`); sandbox init is best-effort with retry. No single place encodes "which phases are fatal".
+- **Risk**: Server boots with unusable subsystems (e.g., scheduler down, recovery silently skipped) and no operator signal.
+- **Recommendation**: Introduce an explicit per-phase `{fatal: boolean}` declaration or a `BootstrapContext.reportPhaseResult()` helper. Have recovery errors bubble to a fail-fast decision configurable by env.
+- **Effort**: S
+- **Links**: [`specs/release_plan/03-observability.md`](../release_plan/03-observability.md)
+
+### F01-06: Two overlapping "running agents" maps create consistency hazards
+- **Priority**: P2
+- **Observation**: `SandboxStateManager` tracks `runningAgents` and `runningAgentCoreAgents` as separate maps (`sandbox-state.ts:19-22`), while `AgentExecutionService` maintains its own `runningAgents: Map<string, AbortController>` plus `agentStartTimes`, `preToolHooks`, `postToolHooks`, `agentInsightIds` (`agent-execution.service.ts:80-85`). The two sides represent the same logical fact ("agent is running") keyed by different IDs (taskId vs agentId) and updated by different services. There is no invariant that they agree.
+- **Risk**: UI or API returning "running" from one side while the other side has already cleaned up; orphan sweep double-stops.
+- **Recommendation**: Consolidate running-agent truth in a single owner (likely `SandboxStateManager` renamed and promoted) and have AgentExecutionService register AbortControllers there. Define an invariant test that the two views never disagree.
+- **Effort**: M
+- **Links**: F01-01
+
+### F01-07: TaskCreationService is a 2,623-line monolith that escaped the facade refactor
+- **Priority**: P2
+- **Observation**: `src/services/task-creation.service.ts` at 2,623 lines owns SDK session management, question/answer state, token batching, idle cleanup, DB history, and SSE callback plumbing — all under one class with one Map of sessions (`task-creation.service.ts:193-218`). Comparable services (Agent, Session, ContainerAgent) have been split; this one has not.
+- **Risk**: High cognitive load, difficult to test in isolation, regression risk when modifying one responsibility.
+- **Recommendation**: Apply the same facade pattern used for Agent/Session: split into `TaskCreationSessionStore`, `TaskCreationSdkBridge`, `TaskCreationQuestionFlow`, and a thin `TaskCreationService` facade.
+- **Effort**: L
+- **Links**: N/A
+
+### F01-08: ServiceContainer is a 30-field record; routes receive the whole graph
+- **Priority**: P3
+- **Observation**: `ServiceContainer` (`src/server/bootstrap/types.ts:63-93`) carries 30 service fields. `createAppRouter` is given the whole container plus three `getXxxProvider()` closures (`server-bootstrap.ts:110-116`). Each route module can reach any service, including `commandRunner` — there is no sub-scope or facet type per route group.
+- **Risk**: Encourages cross-boundary calls, makes it easy to introduce hidden coupling between unrelated route modules.
+- **Recommendation**: Narrow the router signatures so each route group receives only the services it needs (e.g., `TaskRouterDeps`, `CodespaceRouterDeps`). Type-check unused fields away.
+- **Effort**: M
+- **Links**: N/A
+
+### F01-09: Lazy GC in TerraformComposeService leaks sessions when idle
+- **Priority**: P2
+- **Observation**: `TerraformComposeService.cleanupSessions()` (`terraform-compose.service.ts:85-100`) only runs when a new session is created (called at line 122). Other services use scheduled `setInterval` cleanup (e.g., `TaskCreationService:214`, `SandboxStateManager:34`, `SessionPresenceService:232`). If the compose UI is unused for a period, stale SDK sessions and durable streams remain in memory indefinitely until a new compose begins.
+- **Risk**: Memory growth under intermittent use; durable streams not cleaned.
+- **Recommendation**: Either start a cleanup interval in the constructor and register it with shutdown, or document explicitly that compose sessions are bounded by `MAX_SESSIONS` eviction only.
+- **Effort**: S
+- **Links**: [`specs/events_review/README.md`](../events_review/README.md)
+
+### F01-10: Interval timers bypass the shutdown registry in several services
+- **Priority**: P2
+- **Observation**: Many services start `setInterval` timers during construction but only some register cleanup with the `GracefulShutdown`. Registered: session presence (via `sessionService.destroy`), schedulers, agent orphan sweep, task-creation cleanup. Not registered: `SandboxStateManager.planCleanupInterval` (`sandbox-state.ts:34`) — it exposes `dispose()` but nothing calls it during shutdown; the containerAgentService dispose path does cover it indirectly, but only when a containerAgentService was created. If sandbox init never finishes, nothing ever calls `SandboxStateManager.dispose()`. Similarly the `AgentRetryQueue` interval (`agent-retry-queue.ts:121`) has no visible shutdown registration in bootstrap.
+- **Risk**: Tests leaking timers; process hangs on shutdown waiting for unref'd intervals; inconsistent cleanup invariants.
+- **Recommendation**: Make "every `setInterval` in services/* has a matching shutdown.register" a lint or review rule. Audit and register all outstanding timers.
+- **Effort**: S
+- **Links**: N/A
+
+### F01-11: Memory and Dream services are constructed eagerly but initialized asynchronously post-construction
+- **Priority**: P3
+- **Observation**: `MemoryService` is constructed in the service container (`service-container.ts:134`) but then `memoryService.initialize()` is called in phase 4.5 (`server-bootstrap.ts:67`) — a pattern that re-introduces the two-phase-init problem the `WorktreeService`/`TaskService` refactor was designed to eliminate. `DreamService` depends on `memoryService.getStore()` at construction time (`service-container.ts:139-144`), which works only because the store is available pre-initialize, but this is an undocumented invariant.
+- **Risk**: Future refactors may cause the store to be null until `initialize()` runs; easy to reintroduce the stub-then-patch pattern.
+- **Recommendation**: Either make `MemoryService` fully usable after construction (move async work into a lazy init on first call) or introduce a `MemoryServiceFactory.create()` async factory that returns a ready instance.
+- **Effort**: S
+- **Links**: N/A
+
+### F01-12: Plan approval branching conflates two execution modes silently
+- **Priority**: P2
+- **Observation**: `TaskService.approvePlan` (`task.service.ts:194-236`) silently selects between container-mode and host-mode based on which optional trigger is wired. The container path (`containerAgentService.approvePlan`) and the host path (`agentExecutionService.resume`) have materially different semantics — different prompt composition, different session resume behaviour, different error shapes. Callers (the `/tasks/:id/approve-plan` route) cannot see which mode will run and there is no observable indicator.
+- **Risk**: Confusing incident debugging; divergent test coverage; feature drift between modes.
+- **Recommendation**: Return the execution mode in the response, or route host-mode through a dedicated endpoint. Ensure functional tests cover both paths end-to-end and assert `phase: 'execute'` + `sdkSessionId` propagation per the project CLAUDE.md rule.
+- **Effort**: S
+- **Links**: project `CLAUDE.md` — "Functional Tests: Real Service Transitions"
+
+## Open questions
+- What is the intended restart policy for containers that outlive the server? Adopt, reap, or ignore? (affects F01-01, F01-06)
+- Is there an operational SLA for "sandbox provider unreachable"? The 300s max backoff means prolonged degradation can be invisible (F01-03, F01-05).
+- Should `ServiceContainer` evolve into per-request scoped sub-containers for future multi-tenant isolation, or is a single global container sufficient long-term? (F01-08)
+- Are per-service singletons the right choice for `TerraformComposeService` and `CliMonitorService` at scale, or do they need horizontal partitioning? (F01-09)

--- a/specs/arch_review_april/01-service-architecture.md
+++ b/specs/arch_review_april/01-service-architecture.md
@@ -1,12 +1,12 @@
 # Service Architecture
 
 ## Summary
-The service layer is reasonably well-organised: the recent facade split for `AgentService` (CRUD / Execution / Queue) and `ContainerAgentService` (state / worktree / exec / plan-approval / agentcore bridge) and the proper dependency ordering in `service-container.ts` have eliminated the old "stub-then-patch" TaskService pattern. However, four architectural habits now dominate the code and deserve attention: (1) heavy use of in-memory `Map` state with no reconciliation path on crash/restart, (2) late-binding optional setters on `TaskService`, (3) a monolithic `TaskCreationService` (~2,600 LOC) that skipped the facade treatment, and (4) a 6-phase bootstrap whose background sandbox retry and API-key resolution have subtle "server up but broken" failure modes.
+The service layer is reasonably well-organised: the recent facade split for `AgentService` (CRUD / Execution / Queue) and `ContainerAgentService` (state / worktree / exec / plan-approval / agentcore bridge) and the proper dependency ordering in `service-container.ts` have eliminated the old "stub-then-patch" TaskService pattern. However, four architectural habits now dominate the code and deserve attention: (1) heavy use of in-memory `Map` state with no reconciliation path on crash/restart, (2) late-binding optional setters on `TaskService`, (3) a monolithic `TaskCreationService` (~2,600 LOC) that skipped the facade treatment, and (4) a 9-step bootstrap whose background sandbox retry and API-key resolution have subtle "server up but broken" failure modes.
 
 ## Map
 | Layer | Files | Purpose |
 |-------|-------|---------|
-| Bootstrap orchestration | `src/server/bootstrap/server-bootstrap.ts`, `src/server/bootstrap/phases/*.ts`, `src/server/bootstrap/sandbox/*.ts` | 11-step pipeline: config -> db -> recovery -> services -> api key -> router -> serve -> schedulers -> sandbox (background) |
+| Bootstrap orchestration | `src/server/bootstrap/server-bootstrap.ts`, `src/server/bootstrap/phases/*.ts`, `src/server/bootstrap/sandbox/*.ts` | 9-step pipeline: config -> db -> recovery -> services -> api key -> router -> serve -> schedulers -> sandbox (background) |
 | Service container (DI) | `src/server/bootstrap/service-container.ts`, `src/server/bootstrap/types.ts` | Factory function builds all 30+ services in dependency order; a flat `ServiceContainer` interface is passed to routes |
 | Shutdown | `src/server/bootstrap/shutdown.ts` | LIFO cleanup registry with 30s force-exit guard |
 | Facade services | `src/services/agent.service.ts`, `src/services/session.service.ts`, `src/services/container-agent.service.ts`, `src/services/container-agent/container-agent.service.ts` | Delegate to focused sub-services under `src/services/{agent,session,container-agent}/` |

--- a/specs/arch_review_april/02-data-layer.md
+++ b/specs/arch_review_april/02-data-layer.md
@@ -1,0 +1,142 @@
+# Data Layer
+
+## Summary
+
+AgentPane runs a dual-backend Drizzle ORM stack: SQLite (default, via `bun:sqlite`) and PostgreSQL (via `postgres-js`), with 42 tables defined twice under `src/db/schema/sqlite/` and `src/db/schema/postgres/`. The SQLite path is the primary data source and is well-hardened (WAL, `busy_timeout=5000`, `foreign_keys=ON`, trigger-based enum validation, FK-safe rebuild migrations). The PostgreSQL path is a second-class citizen — a single mega catch-up migration (`0004_schema_catchup.sql`) closes the gap with the 31 SQLite inline migrations, but operational maturity (connection pool config, drift tests, backup, health-check raw SQL, transaction usage) trails the SQLite side. The custom SQLite migration runner is pragmatic (idempotent ALTER TABLE, per-migration transactions) but sits outside Drizzle Kit, meaning two parallel, divergent migration chains must be maintained. JSON columns are well-typed via Drizzle's `$type<>()` generics, but rely on application discipline — several services `JSON.parse(setting.value) as X` without validation. Schema-drift tests cover only 2 of 42 tables.
+
+## Map
+| Area | Files | Purpose |
+| --- | --- | --- |
+| Schema definitions (dual) | `src/db/schema/sqlite/*.ts` (44 modules) · `src/db/schema/postgres/*.ts` (44 modules) · `src/db/schema/shared/` | Drizzle tables, one-per-entity, kept in parallel |
+| Database bootstrap | `src/server/bootstrap/phases/database.ts` · `src/lib/bootstrap/phases/sqlite.ts` · `src/db/client.ts` | WAL/pragmas, drizzle wiring, PG client init |
+| SQLite migrations (inline) | `src/lib/bootstrap/migrations/index.ts` (31 versions) · `runner.ts` · `v19-project-folders.ts` · `src/lib/bootstrap/phases/schema.ts` | Ordered SQL migrations with `schema_migrations` tracking |
+| Drizzle-kit migrations | `src/db/migrations/` (14 SQL + meta) · `src/db/migrations-pg/` (6 SQL + `0004_schema_catchup.sql` 590 lines) | Generator output; PG uses these at runtime |
+| Drizzle configs | `drizzle.config.ts` (SQLite) · `drizzle.config.pg.ts` (Postgres) | Kit generator targets |
+| Drift tests | `tests/integration/agents-schema-drift.test.ts` · `session-schema-drift.test.ts` (2 files) | Runtime column comparison |
+| Raw SQL hotspots | `src/server/routes/health.ts:99-114` · `src/lib/bootstrap/migrations/runner.ts:40-60` · `schema.ts:326,873` | `db.execute(sql…)`, `db.exec`, `INSERT OR IGNORE` |
+| Unsafe casts | `src/services/container-agent/plan-approval.service.ts:197,474,485` · `container-exec.service.ts:1186` | `as unknown as TaskPlanRow` |
+| Transactions | 16 usages across services (task, codespace, teams, RBAC, settings, terraform) | Multi-step atomic mutations |
+
+## What's working
+- SQLite pragmas are consistent across every entrypoint: `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON` (`src/db/client.ts:76-78`, `src/lib/bootstrap/phases/sqlite.ts:42-44`, `src/server/bootstrap/phases/database.ts:62-64`).
+- Migration runner wraps each migration in BEGIN/COMMIT with rollback on failure (`runner.ts:89-102`).
+- FK-safe rebuild pattern: migrations 29 and 30 `UPDATE ... SET col = NULL WHERE col NOT IN (SELECT id FROM parent)` before table rebuild, matching CLAUDE.md guidance.
+- Trigger-based enum validation (v25) covers `tasks.column`, `agents.status`, `worktrees.status`, `agents.type`, `tasks.priority` for INSERT + UPDATE.
+- JSON columns use Drizzle's `$type<>()` generic (~35 call sites under `src/db/schema/sqlite/`) — types flow cleanly to services.
+- Transaction discipline: 16 services/routes use `db.transaction()` for multi-step mutations (tasks, teams, RBAC, settings, invitations, terraform).
+- PostgreSQL JSON columns use `jsonb` (35 occurrences across 20 files) for indexable JSON, not `json`.
+
+## Findings
+
+### F02-01: PostgreSQL migration chain lives in one 590-line mega-migration
+- **Priority**: P1
+- **Observation**: `src/db/migrations-pg/` contains just 6 files; `0004_schema_catchup.sql` (590 lines, `BEGIN; ... COMMIT;`) fuses the equivalent of SQLite migrations v4–v25. SQLite has 31 inline migrations (`src/lib/bootstrap/migrations/index.ts:46-364`). `0001_overconfident_raza.sql` and `0002_amused_talon.sql` are 1–2 lines; `0003_nomad_columns.sql` is 5 lines. There is no per-change migration for PG post-v25.
+- **Risk**: Incremental PG schema evolution is effectively impossible; any new column must be appended to a growing catch-up file or create a new top-level file, inviting drift with the SQLite-first workflow.
+- **Recommendation**: Adopt a one-migration-per-change Postgres policy going forward. Split `0004_schema_catchup.sql` into logical sections if future changes need to reference intermediate states. Add a CI check that every SQLite `MIGRATIONS` entry added since the baseline has a corresponding PG migration.
+- **Effort**: M
+- **Links**: prior finding in `specs/release_plan/06-database-integrity.md` §"Critical: PostgreSQL Migration Gap" — largely addressed by `0004_schema_catchup`, but operational process gap remains.
+
+### F02-02: Schema-drift tests cover 2 of 42 tables
+- **Priority**: P1
+- **Observation**: Only `tests/integration/agents-schema-drift.test.ts` and `tests/integration/session-schema-drift.test.ts` exist. CLAUDE.md promotes drift tests as the regression barrier: "Run `npx vitest run tests/integration/*schema-drift*` before pushing." 40 tables have no runtime column-comparison guard, including high-churn ones (`tasks`, `codespaces`, `sandboxInstances`, `sandboxConfigs`, `planSessions`, `memoryInsights`, `skillExecutions`, `eventLog`, `templates`).
+- **Risk**: Silent drift between Drizzle schema and the actual SQLite/Postgres columns causes runtime NULL-column reads and mysterious Drizzle query failures only under specific code paths.
+- **Recommendation**: Auto-generate a drift test per table from the schema index (`src/db/schema/sqlite/index.ts`). Prioritize the 10 highest-churn tables first. Fold the generator into `tests/integration/` so new tables get coverage automatically.
+- **Effort**: M
+- **Links**: `release_plan/06-database-integrity.md` §"Schema Drift Detection" — the existing `scripts/check-schema-drift.ts` only compares filenames, not columns.
+
+### F02-03: Raw SQL in `/api/health` violates "Never bypass Drizzle" rule
+- **Priority**: P2
+- **Observation**: `src/server/routes/health.ts:99-114` executes `db.execute(sql`SELECT version() as v`)` with `as unknown as PostgresDatabase` and `(db as SqliteDatabase).all<{ v: string }>(sql`SELECT sqlite_version() as v`)`. This is a read-only version probe, but the pattern normalises bypassing the typed ORM in request paths.
+- **Risk**: Low data-integrity risk (read-only), but the cast pattern and raw tagged-template SQL leak dialect assumptions into a route that should be dialect-agnostic. It also sets precedent for future raw SQL.
+- **Recommendation**: Move dialect detection to `src/server/bootstrap/phases/database.ts` — probe version once at startup, store on the returned `DatabaseResult`, and consume via typed accessor. Remove the casts and the `DB_MODE` env read from the route.
+- **Effort**: S
+- **Links**: CLAUDE.md memory: "Never bypass Drizzle with raw SQL for database operations."
+
+### F02-04: `as unknown as TaskPlanRow` indicates schema/query shape mismatch
+- **Priority**: P2
+- **Observation**: Four sites force-cast Drizzle query results: `src/services/container-agent/plan-approval.service.ts:197,474,485` and `src/services/container-agent/container-exec.service.ts:1186`. `TaskPlanRow` is defined in `src/services/container-agent/types.ts:101-108` as a hand-rolled subset of `tasks` columns. The casts exist because `db.query.tasks.findFirst()` returns the full Drizzle-inferred type, and the service wants a narrower row.
+- **Risk**: Casts defeat type safety when schema changes — a renamed column won't surface as a compile error in plan-approval logic. Two of the four casts are the same query issued back-to-back (lines 474 and 485 both hit `tasks` where `id = taskId`).
+- **Recommendation**: Replace `TaskPlanRow` with `typeof tasks.$inferSelect` (or a `Pick<>` of it). Merge the duplicate queries in `rejectPlan` into one. Drop the casts.
+- **Effort**: S
+
+### F02-05: PostgreSQL client has no pool/timeout tuning
+- **Priority**: P1
+- **Observation**: `src/server/bootstrap/phases/database.ts:46` calls `postgres(connectionString)` with zero options. `postgres-js` defaults are `max: 10`, `idle_timeout: 0` (no idle close), `connect_timeout: 30s`, `max_lifetime: null`. No prepared-statement cap, no application_name, no SSL enforcement.
+- **Risk**: Under production load the 10-connection default caps throughput; `idle_timeout: 0` keeps handles open indefinitely across PG restart failovers; no `connection.application_name` makes `pg_stat_activity` triage blind; no SSL toggle means a misconfigured `DATABASE_URL` can silently talk cleartext.
+- **Recommendation**: Pass `{ max, idle_timeout, max_lifetime, connect_timeout, connection: { application_name: 'agentpane' }, ssl: config.pgSsl }` from `ServerConfig`. Surface pool-depth as an env var. Mirror in the K8s Helm chart defaults.
+- **Effort**: S
+- **Links**: `release_plan/07-performance-scalability.md` §"Connection Management".
+
+### F02-06: SQLite `synchronous` and `cache_size` pragmas never set
+- **Priority**: P2
+- **Observation**: Grep for `synchronous`, `cache_size`, `mmap_size` in `src/db/` returns nothing. Only `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON` are applied (`src/db/client.ts:76-78`). With WAL, `synchronous` defaults to `FULL` which is conservative; for server workloads `NORMAL` is typical and 2–3x faster on write-heavy paths like `session_events`.
+- **Risk**: Write throughput on event insertion (high-frequency path per Durable Streams architecture) is slower than necessary; no protection against page cache exhaustion under bursty agent output.
+- **Recommendation**: Add `synchronous=NORMAL` (WAL-safe on crash, only risks trailing commits), `cache_size=-64000` (64 MB), `temp_store=MEMORY`, `mmap_size=134217728` (128 MB). Make each configurable via env for conservative deployments.
+- **Effort**: S
+- **Links**: `release_plan/07-performance-scalability.md` §"Current Architecture".
+
+### F02-07: Migration runner swallows every "duplicate column" exception
+- **Priority**: P2
+- **Observation**: `src/lib/bootstrap/migrations/runner.ts:41-47, 53-60` catches exceptions and ignores anything whose message contains `'duplicate column'`. This runs for both multi-statement blocks (via `db.exec`) and individual ALTER statements. A failing ALTER on a different column would still throw, but the string-match is fragile — if better-sqlite3 or bun:sqlite wording changes, real errors get masked or real errors get raised in the idempotent path.
+- **Risk**: Migration idempotency depends on an error-message substring; a quiet upgrade to the SQLite binding could either skip required migrations or break re-runs.
+- **Recommendation**: Switch to pre-checks — query `PRAGMA table_info(x)` before ALTER and skip if the column exists. Drop the string-match catch. For `db.exec` blocks, decompose into individual statements where idempotency matters.
+- **Effort**: M
+
+### F02-08: `INSERT OR IGNORE` in table-rebuild migrations can mask row loss
+- **Priority**: P2
+- **Observation**: Migrations v29 (`agents`) and v30 (`sessions`) in `src/lib/bootstrap/migrations/index.ts:311,344` do `INSERT OR IGNORE INTO agents_new SELECT ... FROM agents`. While v29/v30 now correctly NULL orphaned FKs before the rebuild (lines 295-296, 328-329), `INSERT OR IGNORE` can still swallow PRIMARY KEY collisions, NOT NULL violations, and CHECK failures silently. No row-count parity assertion.
+- **Risk**: A bug that produces duplicate IDs or violates a new NOT NULL constraint would silently drop rows during rebuild. Users discover missing agents/sessions only at query time.
+- **Recommendation**: Drop `OR IGNORE` — the upstream UPDATEs already handle the known FK case. Add a `SELECT COUNT(*)` parity check: rollback if `agents_new` count differs from the pre-drop `agents` count minus known filtered rows.
+- **Effort**: S
+- **Links**: CLAUDE.md "Migration safety — `INSERT OR IGNORE` does NOT suppress FK violations in SQLite."
+
+### F02-09: JSON settings parsed as `T` without schema validation
+- **Priority**: P2
+- **Observation**: `src/services/settings.service.ts:43,70,289`, `src/services/task.service.ts:549`, `src/services/terraform-registry.service.ts:292`, `src/services/github-app.service.ts:63`, `src/server/routes/sandbox-status.ts:75`, `src/server/bootstrap/sandbox/sandbox-init.ts:47,64` all do `JSON.parse(row.value) as T`. This is for the `settings` table which stores values as TEXT, not `{ mode: 'json' }`. Parse errors throw uncaught; shape mismatches are silent.
+- **Risk**: A tampered or stale settings row causes a runtime type error deep in a service, or silently supplies wrong-shaped config to the sandbox/terraform bootstrap. No audit log of malformed settings.
+- **Recommendation**: Introduce a small `parseSetting<T>(key, schema)` helper using Zod. Replace all 10+ raw `JSON.parse` sites. Log+default on validation failure. Consider migrating the `settings.value` column to `text({ mode: 'json' })` so Drizzle handles parse and the schema captures the types centrally.
+- **Effort**: M
+
+### F02-10: JSON column conventions diverge between SQLite and Postgres
+- **Priority**: P2
+- **Observation**: SQLite schemas use `text('col', { mode: 'json' })` (~35 sites); Postgres schemas use `jsonb(...)` (35 occurrences across 20 files). Drizzle handles (un)marshalling differently — SQLite stringifies on write, PG sends native JSON. Mixed reads via `db.query.x.findFirst()` return already-parsed objects in both; but raw `db.execute(sql...)` in health.ts or future raw SQL would return string in SQLite and object in PG. There's no typed helper to guarantee this invariant.
+- **Risk**: Any future raw SQL touching JSON columns will silently diverge between backends. PG `jsonb` can't represent `undefined`; SQLite stringify can. Round-trip tests don't exist.
+- **Recommendation**: Add a single shared type export per JSON column (`src/db/schema/shared/json-types.ts`) referenced by both backend schemas. Add a dual-backend round-trip test for every JSON column (auto-generated from the schema index).
+- **Effort**: M
+
+### F02-11: Task-delete and many multi-step writes skip transactions
+- **Priority**: P2
+- **Observation**: Grep for `db.transaction` returns 16 files; `src/services/task.service.ts` uses it for `create()` and `moveColumn()`, but `Task.delete` is a single `db.delete(tasks)` (no transaction, relies on cascade). `CodespaceService.delete` does `worktreeService.prune()` then `db.delete(codespaces)` without a transaction — if prune succeeds and delete fails, worktrees are orphaned on disk.
+- **Risk**: Partial failures leak external resources (worktree dirs on disk, session records, sandbox containers) that the cascade-delete never sees.
+- **Recommendation**: Wrap delete chains in `db.transaction`. For external resources (worktree dirs, containers), adopt an outbox pattern: record deletion intent in a DB row inside the transaction, then reconcile from a sweeper. Prior review already flagged this.
+- **Effort**: M
+- **Links**: `release_plan/06-database-integrity.md` §"Gap: Non-Transactional Multi-Step Operations".
+
+### F02-12: Two parallel migration chains — inline runner vs Drizzle Kit
+- **Priority**: P2
+- **Observation**: `src/db/migrations/` contains 14 Drizzle-kit generated SQLite migrations (v0000–v0014); these are never applied at runtime. Runtime uses `src/lib/bootstrap/migrations/index.ts` (31 versions) with a custom runner. The two chains are unrelated — Drizzle-kit output is likely vestigial. Risk of a developer running `drizzle-kit migrate` against a prod SQLite DB and corrupting the version tracker (`schema_migrations` vs Drizzle's `__drizzle_migrations`).
+- **Risk**: Confusion; a mis-step in ops could apply the wrong chain and brick a DB. The 14 orphaned files keep diverging from the live schema.
+- **Recommendation**: Pick one system. Either (a) delete `src/db/migrations/` and document that SQLite runtime uses `migrations/index.ts`, or (b) migrate the inline runner to Drizzle-kit and regenerate from current schema. Matching the PG approach (Drizzle-kit) would simplify.
+- **Effort**: L
+
+### F02-13: PostgreSQL path has no runtime migration-safety tests
+- **Priority**: P1
+- **Observation**: The PG bootstrap (`src/server/bootstrap/phases/database.ts:49-52`) calls `migratePg(db, { migrationsFolder: './src/db/migrations-pg' })` but `tests/integration/` has zero `*-postgres-*.test.ts` or `*-pg-*.test.ts` files (drift tests are SQLite-only via `bun:sqlite` imports). `0004_schema_catchup.sql` is a 590-line BEGIN/COMMIT block — any SQL error aborts the whole catch-up.
+- **Risk**: First real PG production deployment is the first time the chain runs against a non-empty DB. No regression guard.
+- **Recommendation**: Add a CI job that spins up Postgres via testcontainers, runs migrations, then runs drift tests against the PG schema. Decompose `0004_schema_catchup.sql` into logical savepoints to scope failures.
+- **Effort**: M
+- **Links**: `release_plan/06-database-integrity.md` §"Critical: PostgreSQL Migration Gap".
+
+### F02-14: No session-event retention enforcement for non-session stream IDs
+- **Priority**: P2
+- **Observation**: The `session_events` table stores events for all stream types — bare session IDs, `plan:{id}`, `sandbox:{id}`, `terraform:{jobId}`, `cli-monitor`. CLAUDE.md notes `sessionId` has no FK constraint. `EventCleanupService` prunes by age (30 days) but per prior review is a blunt instrument. Terraform compose events are labelled "ephemeral" in CLAUDE.md but still land in `session_events` when routed through `session.service`.
+- **Risk**: Orphan event rows accumulate indefinitely if a stream ID's cleanup owner (e.g., `codespace.service.ts`) misses a branch. The lack of FK means no DB-level integrity — only application discipline.
+- **Recommendation**: Add a `streamKind` enum column to `session_events` (`session` | `plan` | `sandbox` | `terraform` | `cli-monitor`). Retention policies per kind. Add a reconcile job that logs rows whose `streamId` has no corresponding owner. Cross-reference with the events-review theme file.
+- **Effort**: M
+
+## Open questions
+- Is the Drizzle-kit `src/db/migrations/` SQLite output intentional (for reference/docs) or dead code? Safe to delete?
+- Has the single PG `0004_schema_catchup.sql` actually been run end-to-end against a production-shaped PG instance, or only against a fresh DB in CI?
+- Are there any plans for a multi-writer deployment? WAL helps readers but single-writer lock-contention will be the scaling wall, making the PG path strategically important.
+- Who owns writing drift tests for new tables — should this be enforced in PR template / CODEOWNERS?
+- What is the policy for casting Drizzle row types? If team prefers hand-rolled row interfaces, the schema-drift tests should also assert the hand-rolled type matches `$inferSelect`.

--- a/specs/arch_review_april/03-agent-execution.md
+++ b/specs/arch_review_april/03-agent-execution.md
@@ -1,0 +1,201 @@
+# Agent Execution Subsystem — Architecture Review (April 2026)
+
+## Summary
+
+AgentPane runs Claude agents through two nearly-parallel pipelines: a **host-mode** path (`AgentExecutionService` → `runAgentPlanning`/`runAgentExecution`) that embeds the Claude Agent SDK directly in the Bun process, and a **container-mode** path (`ContainerAgentService` → `ContainerExecService` → `agent-runner` in Docker/K8s/Nomad) that shells out to a separate package via JSON-over-stdout. A third path for **AWS Bedrock AgentCore** is fully scaffolded but is no longer reachable from bootstrap after migration `0011_drop_agentcore_columns.sql`. The two live paths have drifted substantially in behaviour (plan/execution transitions, error bubbling, plan-option propagation, session resume, hook support). A single planning → approval → execution state machine exists in the spec but is realised differently on each side, and several `ExitPlanMode` affordances (`launchSwarm`, `teammateCount`, `allowedPrompts`) are carried through the data pipe but never executed by either runtime. Plan TTL and orphan sweeps are in place, but both have fragile single-timer designs that will silently stop running on a single throw.
+
+## Map
+
+| Layer | File | Role |
+|-------|------|------|
+| Facade | `src/services/agent.service.ts:50` | Composes CRUD/Execution/Queue services; wires orphan sweep |
+| Host-mode lifecycle | `src/services/agent/agent-execution.service.ts:74` | `start`/`stop`/`pause`/`resume`; in-memory `runningAgents`, `agentStartTimes`, `preToolHooks`, `postToolHooks` |
+| Host-mode SDK loop | `src/lib/agents/stream-handler.ts:431,866` | `runAgentPlanning` / `runAgentExecution` — direct Claude SDK session, topology, chunk batching |
+| SDK env helper | `src/lib/agents/agent-sdk-utils.ts:48` | `buildSdkEnv` — strips `CLAUDECODE`, DB creds, secrets before spawning subprocess |
+| Container facade | `src/services/container-agent/container-agent.service.ts:46` | Routes `startAgent` to container-exec or AgentCore bridge; owns reconcile |
+| Container state | `src/services/container-agent/sandbox-state.ts:17` | `runningAgents`, `runningAgentCoreAgents`, `pendingPlans`, `startingAgents`; plan TTL interval |
+| Container exec path | `src/services/container-agent/container-exec.service.ts` | Docker/K8s/Nomad lifecycle, env propagation, stdout bridge wiring |
+| Plan approval | `src/services/container-agent/plan-approval.service.ts:26` | `handlePlanReady`/`approvePlan`/`rejectPlan`, skill-chain swap, sandbox-change detection |
+| Container → DS bridge | `src/lib/agents/container-bridge.ts` | Parses JSON-lines from container stdout, maps to durable-stream events |
+| AgentCore → DS bridge | `src/lib/agents/agentcore-bridge.ts` | Mirror of container-bridge for AWS AgentCore SSE invocations (dead from bootstrap) |
+| Agent runner | `agent-runner/src/index.ts`, `agent-runner/src/agentcore-handler.ts` | Child-process entry points; reads OAuth into `~/.claude/.credentials.json`; resumes SDK session on plan approval |
+| Recovery | `src/server/bootstrap/phases/recovery.ts` | Boot-time reset of `starting/planning/running` agents to `idle`; orphan task rollback; worktree-ref clearing |
+| Orphan sweep | `src/services/agent/agent-execution.service.ts:1347` | 10-minute `setInterval` aborting agents past `getAgentMaxRuntimeMs` (default 4 h) |
+| Hooks (wired only to host path) | `src/lib/agents/hooks/*` | Whitelist/streaming/audit PreToolUse / PostToolUse — constructed but never installed in SDK session |
+
+## What's working
+
+- **Clean lifecycle decomposition.** `AgentService` is a thin facade; CRUD, Execution, Queue are separated and test-friendly.
+- **Transactional `start`.** `src/services/agent/agent-execution.service.ts:391` wraps the task-column / agent-status / agent-run insert in a single Drizzle transaction and compensates (worktree + session deletion) on failure.
+- **Recovery on boot.** `resetStaleAgents`/`recoverOrphanedTasks`/`cleanOrphanedWorktrees` fire before services are wired, preventing phantom "running" UI state.
+- **Host-mode runtime timeout.** Both planning and execution install `setTimeout(maxRuntimeMs)` that aborts the SDK stream and emits a structured `agent:stopped{reason:'timeout'}` event (`stream-handler.ts:447,877`). External abort signals also fan in.
+- **Topology tracking.** `handleTopologySystemMessage` maps SDK `task_id` to a generated `nodeId`, emits `topology:agent_spawned/progress/completed`, and on error flushes any in-flight nodes to `status:'failed'` (`stream-handler.ts:1304`).
+- **Idempotency guards on plan approval.** `handlePlanReady` checks `hasPendingPlan` and also CAS-updates the task with `where(column='in_progress')` (`plan-approval.service.ts:55,117`); `rejectPlan` CAS-updates with `where(lastAgentStatus='planning')` (`plan-approval.service.ts:502`).
+- **Plan persistence + recovery across restart.** Plan text, `sdkSessionId`, and `planningSandboxId` are written to `tasks.plan`/`tasks.planOptions` and re-hydrated by `getPendingPlan` (`plan-approval.service.ts:195`).
+- **Sandbox-change detection on approval.** `planData.sandboxId` is compared against the current codespace sandbox; on mismatch the `sdkSessionId` is discarded so the resumed agent-runner falls back to a fresh session with full plan text (`plan-approval.service.ts:366`).
+- **Env sanitisation.** `buildSdkEnv` (`agent-sdk-utils.ts:48`) blocks `CLAUDECODE`, `DATABASE_URL`, `DB_*`, `ENCRYPTION_KEY`, `SESSION_SECRET`, `GITHUB_APP_PRIVATE_KEY` before subprocess launch — a real footgun for SDK-in-process runs.
+- **agent-runner hardening.** `resolveWorkspacePath`/`resolveStopFilePath` (`agent-runner/src/index.ts:351,362`) enforce that `AGENT_CWD` stays inside `/workspace` and `AGENT_STOP_FILE` inside `/workspace` or `/tmp`; `uncaughtException`/`unhandledRejection` handlers best-effort emit an `error` event and sync-exit.
+
+## Findings
+
+### F1 — AgentCore path is dead code but still present in two packages
+
+**Priority:** P1
+**Observation:** `ContainerAgentService.setAgentCoreProvider` (`container-agent.service.ts:153`) is invoked only from tests; nothing in `server-bootstrap.ts` or `sandbox-init.ts` calls it. Migration `src/db/migrations/0011_drop_agentcore_columns.sql` removed the storage that previously drove configuration. Meanwhile the entire AgentCore stack is still shipped: `src/lib/agents/agentcore-bridge.ts`, `src/services/container-agent/agentcore-bridge.service.ts`, `src/lib/sandbox/providers/agentcore-sandbox-*.ts`, and `agent-runner/src/agentcore-handler.ts` (577 LOC) all compile into the build. `agent-runner/package.json:16` still ships `bedrock-agentcore@^0.2.2` as a runtime dep.
+**Risk:** Dual runtimes to test and maintain for a feature users cannot enable. Fresh changes to plan-approval, skill-chaining, team-mode, event shapes must be mirrored to the AgentCore branch by contributors who cannot exercise it. `'agentcore'` enum member (`src/db/schema/shared/enums.ts:62`) keeps the concept "real" to type-checks while there is no boot path.
+**Recommendation:** Either (a) archive AgentCore behind a feature flag and delete the bridge/handler/provider from the default build; or (b) restore a configuration surface (settings table + UI) and add at least one functional test that starts an AgentCore agent end-to-end. Document the decision in `specs/diagrams/02-agent-execution-flow.md`.
+**Effort:** M (1–2 d) to excise; L to restore parity.
+**Links:** `specs/application/state-machines/agent-lifecycle.md`, `specs/sandbox/` (provider matrix).
+
+### F2 — Tool-use hooks are registered but never installed in the SDK session
+
+**Priority:** P1
+**Observation:** `AgentExecutionService` maintains `preToolHooks` and `postToolHooks` maps (`agent-execution.service.ts:82-83`), exposes `registerPreToolUseHook`/`registerPostToolUseHook` (`agent-execution.service.ts:1328,1337`), and deletes the entries on six cleanup paths. `src/lib/agents/hooks/index.ts` constructs a `createAgentHooks({ PreToolUse: [whitelist, streaming], PostToolUse: [audit, streaming] })`. `stream-handler.ts` contains **zero** references to either map — `runAgentPlanning`/`runAgentExecution` only wire a local `canUseTool` callback and never accept hooks through `StreamHandlerOptions`.
+**Risk:** Silent security regression. The tool-whitelist hook, audit hook, and streaming hook are not enforcing or recording anything for host-mode runs. `allowedTools` passed via config is honoured by the SDK's own permission layer, but any richer logic added to `createToolWhitelistHook` (e.g. deny-list, per-skill allow lists, path scoping) is inert. No caller notices because the hook registration API returns `void`.
+**Recommendation:** Either thread the hook arrays through `StreamHandlerOptions` into `canUseTool` (run PreToolUse before `{behavior:'allow'}`, PostToolUse on `tool:result`), or remove the dead registration API. Add a unit test that asserts a registered PreToolUse hook is invoked when a tool fires in planning/execution.
+**Effort:** M.
+**Links:** `specs/application/security/` (tool permission model), `specs/events_review/` (event ordering).
+
+### F3 — Plan-option fields (`launchSwarm`, `teammateCount`) are carried end-to-end but never acted on
+
+**Priority:** P1
+**Observation:** `ExitPlanModeOptions` (`stream-handler.ts:92`) declares `launchSwarm` and `teammateCount`; `PlanReadyData`/`PlanData`/`AgentCorePlanReadyData` propagate them (`container-bridge.ts:51`, `agentcore-bridge.ts:38`, `container-agent/types.ts:93`, `plan-approval.service.ts:95`, `durable-streams.service.ts:219`). Plan approval logs them but passes only `prompt`, `phase`, `sdkSessionId` to `startAgentFn` (`plan-approval.service.ts:330`). `runAgentExecution` never reads these fields. Nothing in `container-exec.service.ts` spawns multiple `agent-runner` processes. Meanwhile `.claude/CLAUDE.md` "Team Mode" section states this is a live feature.
+**Risk:** Documentation fiction; agents that call `ExitPlanMode({ launchSwarm: true })` get no parallelism, users see single-agent execution. CLAUDE.md misleads future contributors. The SDK's own subagent spawning (`task_started` system messages) is what actually provides concurrency — it does not depend on these fields.
+**Recommendation:** Either delete the fields from the type chain and update CLAUDE.md to describe the actual SDK-driven topology, or implement a worktree-per-teammate fan-out in `PlanApprovalService.approvePlan`. Given the existing SDK subagent support, deletion is cheaper.
+**Effort:** S (delete) / XL (implement).
+**Links:** `.claude/CLAUDE.md` "Team Mode" section; `specs/application/state-machines/agent-lifecycle.md`.
+
+### F4 — `allowedPrompts` are captured but never added to the execution `allowedTools`
+
+**Priority:** P2
+**Observation:** Host-mode `runAgentPlanning` captures `exitPlanModeOptions.allowedPrompts` into `planOptions` (`stream-handler.ts:799`) and publishes them on `agent:plan_ready`. On approval, `executeAgentExecution` (`agent-execution.service.ts:1111`) passes only `agent.config.allowedTools` to `runAgentExecution`. The `allowedPrompts` array — a per-plan whitelist of pre-approved Bash invocations — is not merged into the SDK permission layer. Container mode has the same gap: `container-exec.service.ts` emits `AGENT_ALLOWED_TOOLS` but `allowedPrompts` are never serialised.
+**Risk:** The plan author's contract ("these bash commands are safe to run without per-invocation prompts") is ignored; agents will still hit interactive Bash prompts. Users see "plan approved" then the agent stalls waiting for a permission approval that never comes.
+**Recommendation:** In both paths, derive a Bash-prompt allow list from `planOptions.allowedPrompts` and feed it into the SDK permission layer (SDK v0.2.113 exposes `canUseTool` — compare `input` prompt against the list). Add a functional test asserting a pre-approved Bash command executes without prompting.
+**Effort:** M.
+**Links:** `specs/application/security/` (tool permission model).
+
+### F5 — Host-mode cannot resume an SDK session across plan approval
+
+**Priority:** P1
+**Observation:** The container-runner supports `AGENT_SDK_SESSION_ID` and calls `unstable_v2_resumeSession` so the execution phase inherits the planning conversation (`agent-runner/src/index.ts:914`). Host-mode `runAgentExecution` has no analogue — it calls `unstable_v2_createSession` unconditionally with a freshly-built "Execute the following approved plan: …" prompt (`agent-execution.service.ts:932`, `stream-handler.ts:947`). There is no `sdkSessionId` plumbing in `StreamHandlerOptions`.
+**Risk:** Host mode pays full context cost (plan restatement) and loses the planning-phase reasoning/tool-use history. Behaviour is semantically different from container mode, invalidating shared functional tests. The CLAUDE.md "Functional Tests" rule that plan approval must pass `sdkSessionId` describes container-mode only.
+**Recommendation:** Either thread `sdkSessionId` into host-mode (capture it from the SDK `init` message the same way agent-runner does, persist it on the agent row or task plan options, resume on approval) or document host-mode as a compatibility layer with explicit behavioural differences.
+**Effort:** M.
+**Links:** `specs/application/state-machines/agent-lifecycle.md` (plan → execute edge).
+
+### F6 — `rejectPlan` has no host-mode fallback
+
+**Priority:** P1
+**Observation:** `TaskService.approvePlan` (`task.service.ts:196-236`) has both a container path and a host-mode path (`agentExecutionService.resume`). `TaskService.rejectPlan` (`task.service.ts:242-250`) short-circuits with `CONTAINER_AGENT_SERVICE_UNAVAILABLE` status 503 when the container service is not wired.
+**Risk:** In a deployment running host-mode agents (no Docker/K8s), users hit an un-rejectable plan. Tasks sit in `waiting_approval` forever and the worktree leaks. The state machine's `plan → backlog` edge is unreachable.
+**Recommendation:** Add a host-mode reject path that (a) updates `task.column='backlog'`, clears `plan`/`planOptions`/`lastAgentStatus`, and (b) calls `agentExecutionService.stop(agentId)` or sets agent back to idle and removes the worktree via `worktreeService.remove`. Mirror the atomic CAS (`where lastAgentStatus='planning'`) from container mode.
+**Effort:** S.
+**Links:** `specs/application/state-machines/agent-lifecycle.md`, `specs/application/state-machines/task-workflow.md`.
+
+### F7 — Orphan sweep timer silently dies if any one iteration throws
+
+**Priority:** P2
+**Observation:** `startOrphanSweep` (`agent-execution.service.ts:1347`) uses `setInterval` with a synchronous callback. `sweepOrphanedAgents` does fire-and-forget `void getAgentMaxRuntimeMs(this.db).then(...).catch(...)` and the DB update is `.catch(...)`, but if a synchronous throw ever escapes the loop (e.g. future refactor introduces a bug in the `for…of` iteration or a logger throw), the timer keeps firing but every subsequent iteration sees stale state. Worse, there is no test ensuring the sweep still runs after a first exception.
+**Risk:** Long-tail leak: one bad interval → sweeps stop forever → agents that crash without cleanup stay "running" until server restart. Discoverable only through UI stuck-state reports.
+**Recommendation:** Wrap the body in `try/catch` that logs but does not rethrow. Add a health metric (`agent.orphan_sweep.last_run_at`) and a test that throws inside the loop and verifies the next tick still executes. Consider replacing the field-based interval with a `setTimeout`-chain that is explicitly rescheduled after each iteration.
+**Effort:** S.
+**Links:** `specs/events_review/` (observability of background work).
+
+### F8 — Plan-TTL cleanup has the same single-timer fragility and no metric
+
+**Priority:** P2
+**Observation:** `SandboxStateManager` constructs a `setInterval(cleanupExpiredPlans, PLAN_CLEANUP_INTERVAL_MS)` in its constructor (`sandbox-state.ts:34`). `cleanupExpiredPlans` (`sandbox-state.ts:176`) is synchronous and only touches a Map, but the same pattern as F7 applies. TTL is 60 min with a 5 min sweep; no DB-level expiry — expired plans persist in `tasks.plan`/`tasks.planOptions` because cleanup only removes the in-memory cache. On server restart, `getPendingPlan` (`plan-approval.service.ts:188`) re-hydrates plans with no TTL check, so a 10-day-old plan is still approvable.
+**Risk:** In-memory expiry is a UX convenience, not an actual policy. Stale plans can be approved and re-execute against a long-changed codebase.
+**Recommendation:** Either enforce TTL on re-hydration (reject `getPendingPlan` if `task.updatedAt` older than 1 h and `column='waiting_approval'`) or persist a `planExpiresAt` column and surface it in the UI. Add the same `try/catch` guard as F7.
+**Effort:** S.
+**Links:** `specs/application/state-machines/agent-lifecycle.md` (plan validity window).
+
+### F9 — Recovery phase and orphan sweep can race with incoming requests
+
+**Priority:** P2
+**Observation:** `runRecovery` (`server-bootstrap.ts:53`) sets all `starting/planning/running` agents to idle before services are constructed. `ContainerAgentService.reconcile` (`container-agent.service.ts:175`) is similar but is **never called** from bootstrap — it's a dead method. After recovery finishes, Bun.serve binds (`server-bootstrap.ts:119`) and HTTP requests can arrive before the later `services.agentService.startOrphanSweep()` executes and before `initSandboxProvider` completes — so the first minute of uptime runs without orphan protection.
+**Risk:** An agent-start that crashes mid-setup during the bootstrap window leaves a phantom running agent until the next 10-minute sweep. `reconcile` being unreachable means in-memory maps and DB can diverge after container-agent.service restart if ever bolted onto the bootstrap path.
+**Recommendation:** Call `containerAgentService.reconcile()` right after `runRecovery` (or during Phase 4 after services construction, before `Bun.serve`). Document that recovery happens under a startup "maintenance" banner. Consider rejecting task-move to `in_progress` until orphan sweep has run at least once.
+**Effort:** S.
+**Links:** `specs/application/state-machines/agent-lifecycle.md`, `specs/diagrams/01-system-architecture.md`.
+
+### F10 — Two separate lockfiles in `agent-runner/` (npm and bun)
+
+**Priority:** P2
+**Observation:** `agent-runner/` ships both `bun.lock` and `package-lock.json`. CLAUDE.md explicitly states "CI uses `--frozen-lockfile` and will fail if the lockfile is stale. The lockfile is `agent-runner/bun.lock` (not `bun.lockb`)." `package-lock.json` is never referenced by scripts but sits in the repo.
+**Risk:** Contributor drift — running `npm install` inside `agent-runner/` will update the wrong file, pass local build, fail CI. Dependency resolution discrepancies between bun and npm can yield different transitive versions for the shipped Docker image.
+**Recommendation:** Delete `agent-runner/package-lock.json`; add a pre-commit guard that asserts only `bun.lock` exists in `agent-runner/`.
+**Effort:** XS.
+**Links:** CLAUDE.md "agent-runner Lockfile" section.
+
+### F11 — `agent-runner` mints fake OAuth `expiresAt` and a null `refreshToken`
+
+**Priority:** P1
+**Observation:** `writeCredentialsFile` (`agent-runner/src/index.ts:303`) writes `expiresAt: Date.now() + 86_400_000` and `refreshToken: null` regardless of the actual token lifetime. The host supplies only `CLAUDE_OAUTH_TOKEN`; there is no mechanism to refresh a rotated token mid-run. Multiple agents per host share the same container-user credentials file (`~/.claude/.credentials.json`) under the node user.
+**Risk:** A token revoked externally still appears "valid for 24 h" to the SDK; actual 401s surface as opaque "assistant errors" mid-stream. Concurrent agents racing on the credentials file (two container starts within the same per-project container) can interleave writes — the 0o600 file is not atomic on overwrite. No mechanism to refresh a short-lived token (future OAuth PKCE rotation).
+**Recommendation:** (a) carry real `expiresAt` from the host token registry and emit a pre-run validation event when the token is expired/near-expiry; (b) write the credentials file under a unique `HOME` per agent-runner (set `HOME=/tmp/agents/<taskId>` at container start) to isolate writers; (c) if refresh tokens ever become available, plumb them in.
+**Effort:** M.
+**Links:** CLAUDE.md "Authentication Configuration"; `specs/application/security/`.
+
+### F12 — Two stream handlers evolved in parallel and drifted
+
+**Priority:** P2
+**Observation:** `src/lib/agents/stream-handler.ts` and `agent-runner/src/index.ts` both implement almost the same loop: `canUseTool` tool tracking, `tool_use_summary` fan-out, `rate_limit_event`, `tool_progress`, `compact_boundary`, topology `task_started/progress/notification`, `ExitPlanMode` capture. The in-file comment at `stream-handler.ts:422` acknowledges this ("AE-010: Deferred - functions share ~70% code"). There is a shared `src/lib/agents/event-type-map.ts` and `agent-runner/src/shared-session.ts`, but they cover only event-type mapping and credential/file-change helpers — not the message-loop dispatch.
+**Risk:** Bug fixes and new SDK features (e.g. upcoming `tool_use_summary` payload changes) must be applied in two places. The current SDK pin is `^0.2.113` in agent-runner vs `^0.2.76` originally assumed in CLAUDE.md (tech-stack table still says `0.2.76`) — version skew between the host facade and the container.
+**Recommendation:** Extract a shared dispatcher (pure function taking a message and callbacks for each event class) into `packages/agent-sdk-loop` that both host and agent-runner consume. Pin a single `@anthropic-ai/claude-agent-sdk` version across root and agent-runner; update CLAUDE.md tech-stack table.
+**Effort:** L.
+**Links:** `specs/events_review/` (single-source event mapping).
+
+### F13 — Model resolution ignores `task.modelOverride` on the execution phase
+
+**Priority:** P2
+**Observation:** In `AgentExecutionService.start` (`agent-execution.service.ts:478`) `taskModelOverride` is cast from `task as typeof task & { modelOverride?: string | null }` — the schema cast suggests the column exists but typed tasks don't expose it (schema drift with tests per CLAUDE.md "Tests: Keep in Sync"). In `executeAgentExecution` (`agent-execution.service.ts:1064`) the same cast is applied to a much thinner `{ id, worktreeId }` task object, so `taskModelOverride` is **always `undefined`** on the execution phase — the override is silently dropped after plan approval.
+**Risk:** Task-scoped model overrides only work for the planning phase, execution silently reverts to agent/project/global default. Users setting an Opus override for a critical plan will see their execution run on Sonnet.
+**Recommendation:** Pass the full task row (or at minimum `{ id, worktreeId, modelOverride }`) into `executeAgentExecution`, and lift `modelOverride` into the typed schema so the cast is no longer needed. Add a functional test: task.modelOverride='opus-x' → planning + execution both see the same resolved model.
+**Effort:** S.
+**Links:** `specs/application/database/schema.md`.
+
+### F14 — `executeAgentExecution` catches too broadly; agent stays "starting" on sub-failures
+
+**Priority:** P2
+**Observation:** The outer try in `executeAgentExecution` (`agent-execution.service.ts:1019`) wraps the agent lookup, worktree lookup, codespace lookup, model resolution, `agentRuns` insert, memory-session start, and the SDK loop. On any early throw (e.g. codespace deleted mid-run), `runId` is still the synthetic one from `createId()` at line 1014, so the `agentRuns` row may never be inserted before the catch tries to update by `runId` → no-op. The agent is set to `error` and maps cleared, but **no task column update happens** — the task is stuck at `in_progress` until recovery on next restart.
+**Risk:** Silent task orphaning without a corresponding `agent:error` propagation to the task state. Error message reaches the UI session but the Kanban board still shows "in progress" with no agent.
+**Recommendation:** Narrow the try-block per CLAUDE.md "Try/catch scope" guidance. Track whether `agentRuns.id` was obtained and update the task column to `waiting_approval` (with failure status) on catch, mirroring the planning-error path. Add a functional test: simulate a codespace-lookup throw during execution and assert task ends in a terminal column with a logged error.
+**Effort:** M.
+**Links:** CLAUDE.md "Error bubbling"; `specs/events_review/`.
+
+### F15 — `agent.config.maxTurns` default (50) is hard-coded in three places; `ExitPlanMode` forced into allowed tools inside the container only
+
+**Priority:** P3
+**Observation:** Hard-coded `50` appears at `agent-execution.service.ts:551,1116,1247` and `agent-runner/src/index.ts:192`. `essentialPlanningTools = ['ExitPlanMode']` is injected into `allowedTools` only inside agent-runner (`index.ts:515`); host-mode `runAgentPlanning` does not enforce the same — if a caller forgets to include `ExitPlanMode`, host-mode planning can never exit plan mode and will time out on the 4 h runtime cap.
+**Risk:** Silent incompatibility between paths; hard-to-diagnose planning stalls on host mode. Defaults drift.
+**Recommendation:** Centralise defaults in `src/lib/agents/constants.ts` (maxTurns, essentialPlanningTools, default model). Apply the same `essentialPlanningTools` injection in `stream-handler.ts:runAgentPlanning` before the `unstable_v2_createSession` call.
+**Effort:** S.
+**Links:** `specs/application/configuration/`.
+
+### F16 — Planning path moves task to `waiting_approval` on `turn_limit`/`paused`, execution path mirrors — but host-mode planning also emits `agent:completed` on completion (not `agent:plan_ready`)
+
+**Priority:** P3
+**Observation:** Compare `stream-handler.ts:688` ("result.status === 'completed'" in the planning outer handler `executeAgentAsync`) — which maps task to `waiting_approval` — with the SDK-level `result` handler at `stream-handler.ts:765-802` that always returns `status: 'planning'` after a `result` message, regardless of whether `ExitPlanMode` was called. The executeAgentAsync switch then has both a `result.status === 'completed'` branch and a `result.status === 'planning'` branch; the `completed` branch is dead for the planning phase because `runAgentPlanning` never returns `'completed'`.
+**Risk:** Minor code-reading trap; the `completed` branch in `executeAgentAsync` is dead but reads as live; future refactors could make it live accidentally with wrong task transitions.
+**Recommendation:** Either delete the `completed`/`error` branches from `executeAgentAsync` (they are unreachable for `runAgentPlanning`), or tighten the return type of `runAgentPlanning` to `'planning' | 'paused' | 'error'`.
+**Effort:** XS.
+**Links:** `specs/application/state-machines/agent-lifecycle.md`.
+
+### F17 — Host mode never publishes `agent:started` on planning (only `agent:planning`); container mode emits both `agent:started` and `agent:plan_ready`
+
+**Priority:** P3
+**Observation:** `runAgentPlanning` (`stream-handler.ts:459`) publishes `type: 'agent:planning'` at entry and then only `agent:plan_ready` at finish. `runAgentExecution` publishes `agent:started`. Container agent-runner emits `agent:started` for both phases (`agent-runner/src/index.ts:407`). The event-map (`src/lib/agents/event-type-map.ts`) and UI (`specs/events_review/`) assume `agent:started` fires at least once per run.
+**Risk:** UI subscribers that key on `agent:started` to reset per-run state miss the planning phase in host-mode. Event ordering invariants documented in `specs/events_review/` may not hold uniformly.
+**Recommendation:** Emit `agent:started{phase:'planning'}` from `runAgentPlanning` before the SDK session create, matching `runAgentExecution`. Keep `agent:planning` as an additional breadcrumb or retire it.
+**Effort:** XS.
+**Links:** `specs/events_review/`.
+
+## Open questions
+
+1. **Is AgentCore coming back?** If the intent is to reintroduce it post-migration-0011, the config surface needs re-specifying. Otherwise the ~1.5 kLOC across `agentcore-*` plus the `bedrock-agentcore` runtime dep is pure overhead (F1).
+2. **Should host mode be deprecated?** Container mode has gained features (SDK session resume, stop-file cancellation, `AGENT_HAS_SKILL` bypass-mode, stderr error capture) that host mode lacks. If the long-term target is container-only, several findings (F5, F6, F12, F17) dissolve. If both remain first-class, they need a shared dispatcher and a parity test matrix.
+3. **What is the canonical plan TTL?** 60 min in memory, no DB expiry — the product intent is unclear (F8).
+4. **Are tool hooks a planned feature or abandoned?** The scaffolding is invasive (`createAgentHooks`, two maps on the service, six cleanup call sites). If hooks are staying, F2 is a bug. If not, delete the infrastructure.
+5. **Team mode commitment.** CLAUDE.md documents `launchSwarm`/`teammateCount` as a live mechanism. The code treats them as data-only breadcrumbs. Which is the target? (F3).
+6. **Credential isolation per-agent.** When multiple per-project containers each run one agent, the OAuth write is contained; when the "Shared Container" mode is used with two concurrent tasks, they share `/home/node/.claude/.credentials.json`. Is concurrent-run-in-shared-container a supported topology? (F11).

--- a/specs/arch_review_april/04-sandbox-providers.md
+++ b/specs/arch_review_april/04-sandbox-providers.md
@@ -1,0 +1,150 @@
+# Arch Review — Sandbox Providers
+
+Theme: Docker, Kubernetes (Agent Sandbox CRD), and Nomad drivers; provider parity; create/run/destroy lifecycle; crash-cleanup; stream-ID consistency for `sandbox:*` events; config validation; health and liveness checks. Also covers the lingering AgentCore/Bedrock fourth path, the sandbox image supply chain, and credential injection into containers.
+
+Cross-references: `specs/sandbox/architecture/overview.md`, `specs/sandbox/architecture/isolation-layers.md`, `specs/sandbox/security/environment-variables.md`, `specs/sandbox/security/path-boundary.md`, `specs/diagrams/` (sandbox sequence), `specs/roadmap/phase2-sandbox-plugins.md` (future plan context only).
+
+---
+
+## P0 — Security / data loss
+
+### P0-01 Container-escape blast radius hinges on one undocumented Docker image tag (`srlynch1/agent-sandbox:latest`) with no signature pinning, no scanning, and no reproducible build
+
+`src/lib/sandbox/types.ts` (line 91) sets `SANDBOX_DEFAULTS.image` to `srlynch1/agent-sandbox:latest` — a mutable, username-scoped Docker Hub tag — and `src/services/sandbox-config.service.ts` allows any codespace to override the image string. `docker/Dockerfile.agent-sandbox` builds `FROM ${BASE_IMAGE}` with `BASE_IMAGE=srlynch1/terraform-ai-tools:latest` (two layers of mutable `:latest` tags), installs `@anthropic-ai/claude-code` unpinned via `npm install -g`, apt-installs `ripgrep`/`fd-find`/`tree` without version pinning, and ships with a sudo NOPASSWD rule for `chown`. Every sandbox (Docker, K8s, Nomad) pulls this same image. Nothing in the provider layer verifies image digest, signature (cosign/sigstore), or checksum of the agent-runner tarball before executing arbitrary tool calls from a planning model inside it. The Docker provider does use `CapDrop: ['ALL']` + `no-new-privileges` + a narrow `CapAdd` list (`docker-provider.ts:571-574`), which is good — but those hardening flags only matter if the image itself is trustworthy. If a malicious image is pushed to the `srlynch1/*` namespace (compromised account, typo-squat, pull-through cache poisoning) the compromise lands in every tenant's sandbox with network egress enabled (`NetworkMode: 'bridge'` default) and the OAuth credentials file injected on first exec.
+
+Direction: (1) pin `SANDBOX_DEFAULTS.image` to a digest (`srlynch1/agent-sandbox@sha256:...`), and require digest pinning for any tenant override. (2) Run Trivy/Grype in CI on `docker/Dockerfile.agent-sandbox` builds and fail the build on HIGH/CRITICAL findings. (3) Sign images with cosign keyless and verify on pull in the provider (`isImageAvailable` can also check the signature). (4) Remove the NOPASSWD sudo rule from `docker/entrypoint.sh` once the workspace-chown path has a root-owned alternative (K8s initContainer pattern is already the right shape — apply it to Docker too). (5) Document who owns the `srlynch1/*` namespace and what rotation policy it has — this is a single-person Docker Hub account footprint for what is effectively the tenant isolation boundary. Link to `specs/sandbox/security/environment-variables.md` and to the supply-chain section of `01-security-and-auth.md`.
+
+---
+
+## P1 — Silent failure / scaling wall
+
+### P1-01 The `SandboxProvider` interface is not actually uniform — AgentCore is a fourth execution path that doesn't implement it, and the three CRD-style providers diverge on key contracts
+
+`sandbox-provider.ts:124-167` defines `SandboxProvider` with `create/get/getById/list/pullImage/isImageAvailable/healthCheck/cleanup`. `DockerProvider`, `AgentSandboxProvider`, and `NomadSandboxProvider` all implement `EventEmittingSandboxProvider`, but:
+- `AgentCoreSandboxProvider` deliberately does NOT implement the interface (`agentcore-sandbox-provider.ts:10-12` comment: "does NOT implement the full SandboxProvider interface"). It has a different `create(codespaceId, sandboxId)` signature, synchronous return, no `EventEmittingSandboxProvider`, no `cleanup(options)` shape, and no `list(): Promise<SandboxInfo[]>` (returns `AgentCoreRuntimeInfo[]`). The orchestrator (`container-agent.service.ts:146-166`) branches on `isAgentCoreProvider()` at every call site. Every feature added to the three "real" providers has to be double-implemented or ignored for AgentCore.
+- `NomadSandboxInstance.execAsRoot()` throws (`nomad-sandbox-instance.ts:111-116`); `AgentSandboxInstance.execAsRoot()` silently falls back to non-root exec with a `log.warn` (`agent-sandbox-instance.ts:72-78`); `DockerSandbox.execAsRoot()` actually runs as root. Three different semantics for the same method — calling code cannot rely on the contract.
+- Error shapes differ: Docker throws `SandboxErrors.*`, K8s throws `K8sErrors.*`, Nomad throws `NomadErrors.*`. Upstream handlers in `src/services/sandbox.service.ts` and `container-exec.service.ts` cannot do structured error handling without sniffing the discriminated union.
+- `NomadSandboxProvider.list()` throws on failure (`nomad-sandbox-provider.ts:422-428`); `AgentSandboxProvider.list()` swallows and returns `[]` (`agent-sandbox-provider.ts:354-359`); `DockerProvider.list()` calls `validateContainers()` first and always returns an array. A UI component that expects consistent behaviour will silently show "no sandboxes" under K8s but surface errors under Nomad.
+
+Direction: promote the interface to a real contract. Pick one behaviour for each method (recommend: `list()` returns `{ ok, data }` or throws a typed `ProviderError`; `execAsRoot()` either works or throws a single `RootExecNotSupported` error). Collapse error types to a single `SandboxProviderError` discriminated union, or make all three provider-specific errors extend a common base the service layer can pattern-match on. For AgentCore: either write a thin adapter that satisfies `SandboxProvider` (exec can be a no-op that throws `EXEC_NOT_SUPPORTED`) or remove AgentCore entirely (see P1-02).
+
+### P1-02 AgentCore is half-deleted — migration 0011 dropped the DB columns but ~1200 LOC of provider/instance/bridge/errors code remains reachable, and the health path uses a dynamic-import AWS SDK that is never declared as a dependency
+
+Migrations `0010_add_agentcore_columns.sql` and `0011_drop_agentcore_columns.sql` indicate AgentCore was removed from the schema. But `createAgentCoreProvider()` is still invoked from `container-agent.service.ts:154` via `setAgentCoreProvider(config)`, `agentcore-sandbox-instance.ts` still ships a hand-rolled AWS SigV4 signer (`agentcore-sandbox-instance.ts:57-156`), and `agentcore-sandbox-provider.ts:247-337` dynamically imports `@aws-sdk/client-sts` at health-check time via a string module name specifically so TypeScript won't resolve it statically. That package is not declared in `package.json` (grep confirms only the `sts` reference is a dynamic import with `webpackIgnore`). Result: health-check will throw at runtime in any deployment that didn't happen to have `@aws-sdk/client-sts` installed transitively. The hand-rolled SigV4 signer is explicitly flagged `SC-038` as "DEFERRED" in the code — meaning the team knows it's a maintenance liability. Meanwhile every new feature (stream-ID consistency, recovery, health-check shape) has to be considered against this fourth path too, and the tests mock it (`container-agent.service.test.ts:82`), so nobody notices when it drifts.
+
+Direction: either (a) remove AgentCore completely — delete the provider/instance/bridge/tests/errors, drop the migrations comment trail, and simplify `container-agent.service.ts` to a single path; or (b) commit to it and add `@aws-sdk/client-sts` + `@aws-sdk/client-bedrock-agentcore` as real dependencies, replace the hand-rolled signer, and bring AgentCore under the `SandboxProvider` interface. Given the rest of the codebase targets Docker/K8s/Nomad, option (a) is the lower-risk move. Link to `specs/archive/` once removed.
+
+### P1-03 Provider cleanup of orphans only exists for Docker — Kubernetes pods/PVCs and Nomad jobs have no startup-sweep, so a crash leaves cluster-side resources running forever
+
+`DockerProvider.recover()` (`docker-provider.ts:432-527`) scans for `agentpane-*` containers, removes stopped/stale-image ones, re-registers running ones into the in-memory map. It's wired in at `src/server/bootstrap/sandbox/docker-init.ts:31`. Nothing equivalent exists for K8s or Nomad:
+- `AgentSandboxProvider` has `validateSandboxes()` but only iterates `this.sandboxes` (the in-memory map); on a fresh process the map is empty, so orphaned `Sandbox` CRDs from a previous instance sit in the cluster consuming resources until their `shutdownTime` expires. `agentpane.io/sandbox-id` labels make them findable but no startup code does the sweep.
+- `NomadSandboxProvider` has the same `validateSandboxes()` pattern and the same gap. Orphaned Nomad jobs stay alive indefinitely because `shutdownTime` is not set on Nomad jobs (only on K8s CRDs via `builder.shutdownTime()`).
+- `AgentCoreSandboxProvider.cleanup()` only walks the in-memory `instances` map — same issue.
+
+A server crash mid-create in K8s is the worst case: `client.createSandbox()` succeeded, `waitForReady()` threw, the provider emitted `sandbox:error` and the CRD is still in the cluster with no in-memory handle. The rescheduled agent on the next server boot creates a *second* CRD (`POD_ALREADY_EXISTS` guard only checks memory, see P1-04), doubling resource consumption until both expire.
+
+Direction: add `recover()` to all three providers. For K8s: on bootstrap, list `Sandbox` CRDs in the namespace with `labelSelector: 'agentpane.io/sandbox-id'`, cross-reference with `sandboxInstances` table, and either re-register (if DB knows about them) or delete (if DB has no record or status is `stopped`). For Nomad: list jobs with `NOMAD_JOB_PREFIX`, same cross-reference. Wire each into the bootstrap phase alongside `docker-init.ts`. Add an integration test that simulates a mid-create crash and verifies the next boot cleans up. Link to `specs/operations/monitoring.md`.
+
+### P1-04 `POD_ALREADY_EXISTS` / `JOB_ALREADY_EXISTS` guards check only in-memory state, so a server restart with a still-running K8s/Nomad sandbox creates a duplicate
+
+`AgentSandboxProvider.create()` (`agent-sandbox-provider.ts:125-137`) and `NomadSandboxProvider.create()` (`nomad-sandbox-provider.ts:130-143`) both check `this.codespaceToSandbox.get(config.codespaceId)` and `this.creatingCodespaces.has(...)`. Both maps are in-memory only. After a process restart the maps are empty, so the next `create` for that codespace succeeds and provisions a second pod/job even though the first is still running. `DockerProvider` has the same bug in `create()` but `recover()` re-populates the maps before the first `create` call, masking it. K8s and Nomad have no equivalent bootstrap step. Per-codespace dedup breaks on restart.
+
+Direction: fix as part of P1-03. The cluster listing in `recover()` must populate `codespaceToSandbox` before the service starts accepting `create()` calls, AND the guard should additionally probe the cluster on a cache miss (not only the in-memory map) so that two parallel replicas of the API server don't both create a sandbox for the same codespace. The DB `sandboxInstances` table is also authoritative — add a unique index on `(codespaceId, status='running')` to push dedup down to the DB as a last-resort guard.
+
+### P1-05 Credentials injection writes the OAuth token via a shell exec that embeds it in the command string — base64 helps, but a compromised/hostile image can still capture it from argv
+
+`credentials-injector.ts:71-87` injects OAuth credentials by base64-encoding the JSON and running `sh -c 'echo "<b64>" | base64 -d > /home/node/.claude/.credentials.json'` inside the sandbox. The base64 step removes shell-injection risk from the *credential contents*, but the full command (including the base64 blob) appears in the container's process table and audit logs. An adversary with a foothold in the sandbox (or a malicious base image — see P0-01) can `ps -ef` / `cat /proc/*/cmdline` on the injector exec and recover the token. The injector also runs BEFORE the agent-runner starts, so even a transient shell hijack inside the container gets a window to exfiltrate. Additionally `CLAUDE_OAUTH_TOKEN` is passed as a container env var in `container-exec.service.ts:767` — readable by every process in the sandbox via `/proc/1/environ`.
+
+Direction: stream the token via stdin rather than argv (`sh -c 'cat > /path' <<<"$encoded"` via exec stdin, which is not visible in `/proc`). Better: use `docker cp` / K8s `cp` / Nomad file template equivalent to place the file without a shell. Drop `CLAUDE_OAUTH_TOKEN` from the env-var path once the credentials file is the SDK's primary source (CLAUDE.md already says the API blocks env-var OAuth). Cross-link to `01-security-and-auth.md` and `specs/sandbox/security/environment-variables.md`.
+
+### P1-06 No network policy, egress filtering, or east-west isolation on any provider
+
+`DockerProvider` uses `NetworkMode: 'bridge'` by default (`docker-provider.ts:568`) — every sandbox can reach every other sandbox on the host bridge and can egress to any internet endpoint. `AgentSandboxProvider` builds a CRD via `SandboxBuilder` with no `NetworkPolicy` (grep for `NetworkPolicy|egress` returns zero matches in `src/lib/sandbox`). `NomadSandboxProvider` sets no network stanza at all. A prompt-injection attack that makes the planning agent emit a `curl` to `$INTERNAL_SERVICE` will succeed. Two tenants' sandboxes on the same host or cluster can reach each other's ports.
+
+Direction: at minimum, default `networkMode: 'none'` for the `execute` phase of agent runs (the plan phase rarely needs network). For K8s: generate a default-deny `NetworkPolicy` alongside the `Sandbox` CRD, explicitly allowlisting Anthropic API, npm registry, and GitHub. For Nomad: use Consul Connect or a `network { mode = "none" }` block. Make network-egress an opt-in config per-codespace. Cross-link to `specs/sandbox/security/secure-fs.md` (which currently focuses on FS, not network) and consider expanding that spec to cover network.
+
+### P1-07 Resource limits are not validated per-tenant — `sandboxConfigSchema` caps at 32 GB memory / 16 CPU cores globally but nothing enforces a per-tenant ceiling
+
+`types.ts:104-115` caps `memoryMb ≤ 32768` and `cpuCores ≤ 16` in the Zod schema. These are per-sandbox maxima, not per-tenant or per-team totals. A codespace can set `memoryMb: 32768, cpuCores: 16` and — combined with no quota enforcement at the K8s namespace or Nomad namespace level in the provider code — a single tenant can consume the entire cluster. `CodespaceSandboxConfig` has no `maxMemoryMbPerTenant` field. There is also no disk-quota enforcement in any provider; `SandboxMetrics.diskUsageMb` returns 0 in all three implementations (`docker-provider.ts:249`, `nomad-sandbox-instance.ts:415`, `agent-sandbox-instance.ts:331`).
+
+Direction: introduce a per-team/per-codespace resource ceiling in the admin settings, validated in `SandboxConfigService` before the provider call. For K8s: generate a `ResourceQuota` per-namespace and document the expected team-to-namespace mapping. For Nomad: use Nomad `Quota` specifications. For Docker: enforce at the service layer since Docker has no native quota system. Track disk usage at least for warning thresholds — the `diskUsageMb: 0` returns are silently misleading ops dashboards.
+
+---
+
+## P2 — Maintainability / consistency / type-safety
+
+### P2-01 Three near-identical tmux implementations across `DockerSandbox`, `AgentSandboxInstance`, `NomadSandboxInstance`
+
+`docker-provider.ts:120-217` has `createTmuxSession/listTmuxSessions/killTmuxSession/sendKeysToTmux/captureTmuxPane`. `agent-sandbox-instance.ts:210-313` has the same five methods, copy-pasted with different error types. `nomad-sandbox-instance.ts:268-397` has the same five methods again with extra `assertRunning()` guards. The code comment at `docker-provider.ts:117-119` (`SC-037`) already tracks this as known duplication. Any fix to tmux parsing (session names with `:`, idle detection, window counting) needs three edits and three sets of tests. `src/lib/sandbox/tmux-manager.ts` already exists at the service layer — promote it to wrap any `Sandbox`-shaped exec target so the three instance classes can share it.
+
+Direction: extract a `TmuxHelper` mixin / free-function set that takes a `Sandbox` and implements the five methods via `sandbox.exec()`. Make `DockerSandbox`/`AgentSandboxInstance`/`NomadSandboxInstance` delegate. Use provider-specific error codes by passing an error factory in. Retire `SC-037`.
+
+### P2-02 `shellEscape` is implemented three times with subtle differences and `execStream` env-injection logic differs between Nomad (`lastIndexOf('exec ')`) and K8s (`indexOf('exec ')`)
+
+`docker-provider.ts:267-270`, `agent-sandbox-instance.ts:100-102`, `nomad-sandbox-instance.ts:137-139` each define `shellEscape`. Identical implementation in all three — dead-obvious candidate for a shared util. More subtle: `agent-sandbox-instance.ts:154` uses `indexOf('exec ')` to locate the injection point for env vars while `nomad-sandbox-instance.ts:182` uses `lastIndexOf('exec ')` with a code comment saying "avoid matching 'exec' in path names". The K8s version is wrong for any path that contains `exec` (e.g. `/opt/foo-exec-bar/tool`). This is a latent bug waiting for a customer with a weird path.
+
+Direction: move `shellEscape` and `buildExecShellCommand(cmd, args, cwd, env)` into `src/lib/sandbox/utils/shell.ts`. Have both Nomad and K8s call it. Write a test with `cwd: '/opt/foo-exec-bar'` to lock in the `lastIndexOf` behaviour.
+
+### P2-03 `SandboxProviderEvent` is defined but `DockerProvider` emits more event types than the type allows, and the K8s/Nomad providers never emit `sandbox:idle` or `sandbox:stopping`
+
+`sandbox-provider.ts:172-180` defines eight event variants. `DockerProvider.emit` calls only `sandbox:creating`, `sandbox:created`, `sandbox:started`, `sandbox:error` (`docker-provider.ts:541-610`). `AgentSandboxProvider` and `NomadSandboxProvider` emit the same four subset. Nothing emits `sandbox:idle`, `sandbox:stopping`, `sandbox:stopped` — those are published via the durable stream in `sandbox.service.ts:269` / `sandbox.service.ts:300`, not via the provider event bus. Listeners subscribing to the provider `on()` channel for idle signals will silently miss every event. The type claims support; the runtime doesn't deliver.
+
+Direction: either narrow the `SandboxProviderEvent` union to the four events that are actually emitted, or make every provider also emit the lifecycle events when `stop()`/idle detection runs. Recommendation: route all provider lifecycle events through the bus (single source of truth), and have `sandbox.service.ts` subscribe to it for durable-stream republish, rather than publishing twice.
+
+### P2-04 `sandboxId` slicing in CRD/job name construction truncates to 8 chars, creating collision risk across a large tenant set
+
+`agent-sandbox-provider.ts:141` and `nomad-sandbox-provider.ts:146` both build the resource name as `agentpane-${codespaceId.slice(0,20)}-${sandboxId.slice(0,8)}`. cuid2 IDs have ~36 alphabet size; 8 chars = `36^8 ≈ 2.8e12` combinations — adequate for a single tenant but per-codespace the effective space is much smaller because only sandboxes for the same 20-char-prefix codespace collide. Two sandboxes created back-to-back for the same codespace (which shouldn't happen due to the mutex, but can happen if the mutex is bypassed — see P1-04) have a non-trivial collision chance. Docker doesn't slice (`docker-provider.ts:559` also uses 8 chars — same risk).
+
+Direction: use 12+ chars of the sandbox ID suffix, or use the full ID and rely on DNS-1123's 63-char limit being handled by hashing the codespace prefix instead. Add a uniqueness check on the generated name before `createSandbox`/`registerJob` — if it exists, regenerate.
+
+### P2-05 `validateContainers`/`validateSandboxes` silently remove entries — no event, no DB reconciliation
+
+All three providers evict sandboxes from the in-memory cache when their refresh/inspect call returns 404 or errors (`docker-provider.ts:680-686`, `agent-sandbox-provider.ts:240-248`, `nomad-sandbox-provider.ts:274-283`). None of them update `sandboxInstances` in the DB or emit an event. Downstream the DB still says `status: 'running'`, the API returns stale data, and the UI shows a sandbox that doesn't exist. The idle-checker in `sandbox.service.ts:455-484` is separately reading from the DB and will try to `stop()` a sandbox that the provider has already evicted, triggering `CONTAINER_NOT_FOUND`.
+
+Direction: whenever a provider evicts from the in-memory cache, it must (a) emit a `sandbox:stopped`/`sandbox:error` provider event and (b) have the service layer update the DB row to match. Add a test that creates a sandbox, deletes the underlying container out-of-band, calls `list()`, and asserts DB row status transitioned.
+
+### P2-06 `SandboxStateManager` coexists with per-provider in-memory maps — three sources of truth for "is this sandbox running"
+
+`SandboxStateManager` (`src/services/container-agent/sandbox-state.ts`) tracks `runningAgents` by `taskId`. Each provider tracks `sandboxes` and `codespaceToSandbox` internally. The DB `sandboxInstances` table tracks sandbox lifecycle. These three can — and do — disagree (see P2-05, P1-04). The service layer mostly uses the state manager for the task-level view and the provider map for the sandbox-level view, but `container-exec.service.ts:216` reads from both paths.
+
+Direction: make `SandboxStateManager` the single source of truth for in-memory sandbox→codespace mapping; remove `codespaceToSandbox` from each provider; make providers stateless dispatchers that consult the state manager on `get()`. Or commit to provider-owned state and have `SandboxStateManager` only track agent execution (its original responsibility). Pick one; document the pick in `specs/sandbox/architecture/overview.md`.
+
+### P2-07 Health checks don't probe sandbox liveness, only provider connectivity
+
+`DockerProvider.healthCheck()` pings the Docker daemon. `AgentSandboxProvider.healthCheck()` calls `client.healthCheck()` (cluster + CRD registered). `NomadSandboxProvider.healthCheck()` checks cluster leader. None of them run a readiness probe on the sandbox pods/containers themselves. If a sandbox is stuck (OOMKilled and restarting, stuck in `CrashLoopBackoff`, tmux server dead, Claude CLI missing) no health endpoint surfaces it. The CRD K8s path relies on the controller's `Ready` condition, which is closer to right — but `mapConditionsToStatus` (`agent-sandbox-provider.ts:557-572`) maps transient `PodNotReady` back to `creating`, hiding a stuck pod from the UI.
+
+Direction: add a per-sandbox liveness probe: `sandbox.exec('true')` (or an HTTP probe against the agent-runner if it exposes one) invoked on a timer and exposed through `sandbox.service.ts.getMetrics()`. Track consecutive failures and transition to `error` after N. For K8s: distinguish `creating` (first 30s since creation timestamp) from `stuck` (`PodNotReady` for > 60s).
+
+### P2-08 `pullImage` / `isImageAvailable` are no-ops on K8s and Nomad (they trust the runtime) — means a bad image reference in config fails late, during pod schedule, with poor UX
+
+`agent-sandbox-provider.ts:362-373`: `pullImage` and `isImageAvailable` just verify the string is non-empty. `nomad-sandbox-provider.ts:431-442`: same. If a tenant configures `image: 'nonexistent/typo:tag'`, the failure arrives via `waitForReady` timeout 120s later as `POD_CREATION_FAILED` with no indication that the root cause is a missing image. The user gets "sandbox creation failed" with no actionable signal.
+
+Direction: make `isImageAvailable` actually check the image is pullable on K8s (e.g. create a short-lived `ImagePullJob` Pod with `imagePullPolicy: Always`, or query a registry catalog API). For Nomad: hit the Docker registry HEAD endpoint using the configured registry credentials. At minimum, detect `ImagePullBackOff` / `ErrImagePull` events from the pod and surface them through the provider error instead of a generic timeout.
+
+---
+
+## P3 — Polish / docs
+
+### P3-01 `sandboxConfigSchema` allows `networkMode: 'bridge' | 'none'` but the K8s and Nomad providers ignore the field entirely
+
+The Zod schema (`types.ts:114`) accepts `networkMode`. Only `DockerProvider.create()` (line 568) reads it. K8s and Nomad silently ignore it. Tenants who set `networkMode: 'none'` expecting isolation get it on Docker and don't get it on K8s/Nomad. Either drop the field from the non-Docker code paths explicitly, or implement equivalents (NetworkPolicy for K8s — see P1-06).
+
+### P3-02 `specs/sandbox/README.md` claims "18 files" but only three subdirectories exist (`architecture/`, `security/`, plus `container/`, `sdk-integration/`, `terminal/`, `worktree/`). Each subdirectory has 2-3 markdown files. The CLAUDE.md line "Deep sandbox spec: `specs/sandbox/` (18 files)" is approximately correct but the spec does not cover the Nomad provider at all. `specs/sandbox/architecture/overview.md` and `isolation-layers.md` predate the Nomad provider landing. Add a `specs/sandbox/providers/` directory with one page per provider (docker, k8s, nomad) and a parity matrix.
+
+### P3-03 `runtimeClassName: 'gvisor' | 'kata' | 'none'` is exposed in K8s provider options but no spec or docs discuss when to use which, what the trade-offs are, or whether gVisor is tested. Add a note in `specs/sandbox/architecture/isolation-layers.md` covering the runtime-class decision matrix.
+
+### P3-04 `agent-sandbox-sdk` and `nomad-sandbox-sdk` under `packages/` are versioned independently but not published — the import is via workspace reference. Document the versioning/release story: do they pin 1:1 with the app, or do they target external K8s/Nomad cluster versions? Add to `packages/*/README.md` (if absent). This matters for the `@kubernetes/client-node 1.4.0` / K8s API version compatibility window.
+
+### P3-05 The `SandboxMetrics` interface (`types.ts:39-47`) promises CPU %, memory MB, disk MB, network bytes, uptime. K8s and Nomad return zero for everything except `uptime` (`agent-sandbox-instance.ts:327-335`, `nomad-sandbox-instance.ts:411-419`). The UI's sandbox-indicator panel renders these zeros as "0 MB used" which is materially misleading. Either wire them up via `metrics-server` (K8s) / `nomad alloc status -stats` (Nomad), or mark them `| null` in the type and render "unavailable" in the UI.
+
+---
+
+## Summary
+
+- **Findings**: 18 total
+- **P0**: 1 (container image supply chain)
+- **P1**: 7 (provider-parity drift, AgentCore zombie, missing cleanup for K8s/Nomad, restart-dup bug, credential-in-argv, no network policy, no resource quotas)
+- **P2**: 8 (tmux duplication, shellEscape triplication, unused event types, short sandbox-ID slicing, silent cache eviction, three-way state duplication, shallow health checks, no-op `isImageAvailable` on K8s/Nomad)
+- **P3**: 5 (docs + ignored `networkMode` field on non-Docker providers)
+
+Roadmap context: `specs/roadmap/phase2-sandbox-plugins.md` anticipates additional providers. Any plugin work should first stabilise the `SandboxProvider` contract surfaced in P1-01 — adding a fifth provider on top of today's three-plus-one divergence would compound the maintenance cost.

--- a/specs/arch_review_april/04-sandbox-providers.md
+++ b/specs/arch_review_april/04-sandbox-providers.md
@@ -141,7 +141,7 @@ The Zod schema (`types.ts:114`) accepts `networkMode`. Only `DockerProvider.crea
 
 ## Summary
 
-- **Findings**: 18 total
+- **Findings**: 21 total
 - **P0**: 1 (container image supply chain)
 - **P1**: 7 (provider-parity drift, AgentCore zombie, missing cleanup for K8s/Nomad, restart-dup bug, credential-in-argv, no network policy, no resource quotas)
 - **P2**: 8 (tmux duplication, shellEscape triplication, unused event types, short sandbox-ID slicing, silent cache eviction, three-way state duplication, shallow health checks, no-op `isImageAvailable` on K8s/Nomad)

--- a/specs/arch_review_april/05-event-streaming.md
+++ b/specs/arch_review_april/05-event-streaming.md
@@ -10,7 +10,7 @@ The system has materially improved since the March 2026 `specs/events_review/` p
 
 What remains is the architectural tail: the 50-connection SSE cap is still hard-coded, presence/counters/retention are still split across `EventBus`, `CliMonitorService`, and Caddy-managed SSE, the dual-write is still best-effort (no outbox), there is no client-side gap detection on reconnect, the `MAX_CHUNKS=5000` client cap still drops history silently, Caddy SSE endpoints still have no authentication beyond network trust, and SQLite remains the single writer for every event. Stream-ID conventions are documented in `CLAUDE.md` but not enforced in code — a bare CUID published to `DurableStreamsService` for what should be a plan stream will land in `session_events` as a session event and never reach the plan SSE path. And the `droppedEventCount` counter on `PlanModeService` swallows publish failures silently, with no surfaced metric, no alert, and no export to an admin endpoint.
 
-This file consolidates the 19 work items from `specs/events_review/roadmap.md`, restates those still valid with their current disposition, and adds findings for issues that surfaced after that pass.
+This file consolidates 24 prior items from `specs/events_review/` (12 from `README.md` §§2–3, 9 from `hybrid-architecture.md`, 3 from `roadmap.md`), restates those still valid with their current disposition, and adds 6 new findings for issues that surfaced after that pass. See the "What this supersedes" table below for full dispositions.
 
 ## Map
 

--- a/specs/arch_review_april/05-event-streaming.md
+++ b/specs/arch_review_april/05-event-streaming.md
@@ -1,0 +1,255 @@
+# Arch Review — 05: Event Streaming
+
+Theme: durable streams, Caddy SSE backend, stream-ID conventions, retention, SSE scale, single-writer SQLite bottleneck, event publishing patterns, session events table.
+
+## Summary
+
+Event streaming is the nerve of AgentPane. Every agent turn, token, tool call, sandbox transition, plan interaction, Terraform compose, and topology update is produced by a backend service, persisted to `session_events` in SQLite, and fanned out to browsers via Caddy's `durable_streams` plugin (or `DurableStreamTestServer` on :3002 in dev). The shape is a two-lane dual-write: SQLite provides durability and offset-ordered replay; Caddy/LMDB provides sub-second live delivery.
+
+The system has materially improved since the March 2026 `specs/events_review/` pass. The P0 trio — dropping `accumulated` from chunk payloads, scheduled retention cleanup in `EventCleanupService`, and `ChunkBatcher` batching SQLite writes while streaming individual tokens to SSE — has been delivered. Atomic offset assignment now uses a single `INSERT...SELECT` with bounded retry, LRU eviction keeps the Caddy producer pool bounded at 200 with a 5-minute idle sweep, and shared client subscriptions de-duplicate SSE connections per session with a 60s orphan audit. Envelope metadata (OC-005) is now enforced end-to-end.
+
+What remains is the architectural tail: the 50-connection SSE cap is still hard-coded, presence/counters/retention are still split across `EventBus`, `CliMonitorService`, and Caddy-managed SSE, the dual-write is still best-effort (no outbox), there is no client-side gap detection on reconnect, the `MAX_CHUNKS=5000` client cap still drops history silently, Caddy SSE endpoints still have no authentication beyond network trust, and SQLite remains the single writer for every event. Stream-ID conventions are documented in `CLAUDE.md` but not enforced in code — a bare CUID published to `DurableStreamsService` for what should be a plan stream will land in `session_events` as a session event and never reach the plan SSE path. And the `droppedEventCount` counter on `PlanModeService` swallows publish failures silently, with no surfaced metric, no alert, and no export to an admin endpoint.
+
+This file consolidates the 19 work items from `specs/events_review/roadmap.md`, restates those still valid with their current disposition, and adds findings for issues that surfaced after that pass.
+
+## Map
+
+Producer → persist → distribute → consume:
+
+- `src/services/durable-streams.service.ts` — typed `publish<T>` + `publishSessionEvent`; channel routing via `getChannelForType`; metadata enforcement via `requirePayloadStreamMetadata`; terraform ephemeral branch (skip DB). 1005 lines.
+- `src/services/session/session-stream.service.ts` — REST query surface (offset/limit), session-event persistence for the session channel, explicit cleanup API for session deletion.
+- `src/lib/streams/caddy-producer.ts` — `CaddyDurableStreamsServer` with `IdempotentProducer` (5ms linger, 1 MB batch, 5 in-flight), LRU pool (MAX_PRODUCERS=200, 5-min idle, 60s sweep), stream-ID → URL routing.
+- `src/lib/streams/client.ts` — `DurableStreamsClient`, shared subscription multiplexer, reconnect loop (exponential backoff capped at 30s, 8 attempts), Zod validation per event type.
+- `src/lib/streams/envelope.ts` — OC-005 structured envelope + opaque cursor normalization; `STREAM_PROTOCOL_MIGRATION_GATE` enforcement.
+- `src/lib/agents/stream-handler.ts` — Claude SDK → `publish` bridge; `ChunkBatcher` for tokens; plan/execution phase handlers.
+- `src/lib/agents/chunk-batcher.ts` — delta accumulator: immediate SSE, batched DB persistence.
+- `src/services/event-cleanup.service.ts` — 24h retention job (60d sessionEvents, 90d eventLog defaults, batch 1000), integrity-check-gated SQLite backups.
+- `src/lib/events/event-bus.ts` — in-process SSE listeners for `/api/events`; `MAX_SSE_CONNECTIONS=50`.
+- `src/server/routes/cli-monitor.ts` — separate SSE endpoint, separate `MAX_SSE_CONNECTIONS=50` counter.
+- `src/app/hooks/use-session.ts` — `MAX_CHUNKS=5000` cap, silent slice on overflow.
+- `src/db/schema/sqlite/session-events.ts` — 4 indexes (session, (session, offset) unique, created_at, (session, type)); sessionId has no FK.
+- `Caddyfile` — `@streams path /v1/stream /v1/stream/*` handler; auth handled upstream by API server, not by Caddy itself.
+- Packages: `@durable-streams/client@^0.2.3`, `@durable-streams/server@^0.3.1`, `@durable-streams/state@^0.2.5`.
+
+Stream-ID prefixes (documented in `CLAUDE.md`, routed by `streamIdToPath` in `caddy-producer.ts`): bare CUID → sessions; `plan:` → plans; `sandbox:` → sandboxes; `terraform:` → ephemeral terraform; `cli-monitor` → singleton.
+
+## What's working
+
+- **Atomic offset assignment (DB-008).** `persistToDb` uses a single `INSERT...SELECT` with `COALESCE(MAX(offset), -1) + 1` and a 3-attempt bounded retry on unique-constraint collision. No read-then-write race window.
+- **Chunk batching (P0-3).** `ChunkBatcher` wires immediate SSE delivery for tokens with batched DB persistence, and flushes before turn-boundary events to preserve ordering.
+- **Retention scheduler (P0-2).** `EventCleanupService` batch-deletes with `LIMIT 1000` to avoid long-held locks, reads retention days from `SettingsService` at runtime, and runs a WAL-checkpointed SQLite backup with integrity-check gating on the same cadence.
+- **LRU producer pool (P1-6 / RS-001).** 200-entry cap with 5-minute idle sweep; timer is `unref`-ed so it never blocks process exit.
+- **Shared subscription multiplexing (RS-010).** Client-side `subscribeToSession` fans out a single underlying SSE connection to many subscribers, tears down on last unsubscribe, and audits orphans every 60s.
+- **Envelope gating (OC-005d).** `requirePayloadStreamMetadata` now fails publish if metadata is missing or targets a conflicting stream — caught the kind of cross-stream leak that F14 in the previous review worried about.
+- **Ephemeral Terraform streams.** `isEphemeral` branch skips SQLite entirely and surfaces Caddy failures as first-class errors for that path, so operators don't accumulate 18M rows of compose-noise.
+- **Sandbox ID consistency.** Provider accepts `config.id` so `sandbox:{id}` is the same identifier in DB, stream, and provider map (fix from commit f8d5947b).
+- **Structured logging + masking.** All stream publish sites go through the `createLogger` path with sensitive-data masking (e6335667) — good floor for later observability work.
+
+## Findings
+
+### F05-01 — No code enforcement of stream-ID conventions
+
+- **Priority:** P1
+- **Observation:** `CLAUDE.md` lines 413–427 document prefixes (`plan:`, `sandbox:`, `terraform:`, bare CUID, `cli-monitor`), but `DurableStreamsService.publish` accepts any non-empty string as `streamId`. Routing is decided downstream in `streamIdToPath` (`src/lib/streams/caddy-producer.ts:12-22`) via prefix string matching, and `getChannelForType` (`durable-streams.service.ts:530-539`) switches on the event type — not the stream ID. A plan-typed event published to a bare CUID would persist to `session_events` and be delivered at `/v1/stream/sessions/{id}`, not `/v1/stream/plans/{id}`. Nothing warns.
+- **Risk:** Events silently land on the wrong channel. Debugging "why doesn't the plan panel see its own events" becomes a string-matching archaeology exercise. Migrations that change an entity's naming (project→codespace, task→skill) create stream-ID drift that is invisible until a user hits the missing stream in the UI.
+- **Recommendation:** Introduce a tagged type `StreamId = PlanStreamId | SandboxStreamId | SessionStreamId | TerraformStreamId | typeof CLI_MONITOR_STREAM_ID` with constructors (`planStreamId(id)`, `sandboxStreamId(id)`) that prepend the prefix. Make `publish` and `createStream` take the tagged type. Cross-check at the publish site: a `plan:*` event type requires a `PlanStreamId`; a `sandbox:*` type requires `SandboxStreamId`. Reject mismatches with `STREAM_PROTOCOL_MISMATCH` (the error code already exists for envelope mismatches). No runtime cost — pure compile-time plus a cheap prefix check.
+- **Effort:** S (1 day) — narrow type plus site updates; bulk of call sites already compose the prefix inline.
+- **Links:** `CLAUDE.md:413-427`; `src/services/durable-streams.service.ts:422-482`, `src/lib/streams/caddy-producer.ts:12-22`; partially anticipated by `specs/events_review/README.md` §3.2 Phase 2.4 (schema normalization).
+
+### F05-02 — `droppedEventCount` is invisible beyond a getter
+
+- **Priority:** P1
+- **Observation:** `PlanModeService.droppedEventCount` increments on 13 publish-in-catch sites (`src/services/plan-mode.service.ts:67, 194, 206, 263, 386, 403, 453, 532, 545, 570, 600, 667, 679`). `getMetrics()` exposes it, but nothing calls `getMetrics()`: no admin endpoint, no log emission, no alerting threshold, no resetting, no per-session breakdown. A plan-mode deployment that silently loses every streaming event still returns healthy.
+- **Risk:** Silent failure class — exactly what the events-review pass called out — persisting in the one service the pass said had the counter. A user whose plan stream is broken sees a spinner; operators see clean logs.
+- **Recommendation:** (1) Emit a `log.warn` at each increment with the stream type and error code so the structured logger picks it up. (2) Add `GET /api/admin/metrics/plan-mode` returning `{ droppedEventCount, perType, perSession }`. (3) If the counter exceeds a threshold (say 100 over 5 min) emit a `plan:stream_degraded` event to the plan stream itself so the UI can show a banner. (4) Consider converting these catches to the outbox pattern proposed in F05-05 — most of them exist because the Caddy publish is best-effort.
+- **Effort:** S (half day) for logging + endpoint; folds into F05-05.
+- **Links:** `src/services/plan-mode.service.ts:67-116`, increment sites throughout the file.
+
+### F05-03 — SSE connection cap still 50 with two separate counters
+
+- **Priority:** P1
+- **Observation:** `MAX_SSE_CONNECTIONS = 50` appears in `src/lib/events/event-bus.ts:24` for the `/api/events` endpoint and is declared separately (same value) in `src/server/routes/cli-monitor.ts:175`. Caddy-managed SSE streams are not counted at all. The `event-bus.ts` TODO (line 12) explicitly flags the split. Team mode spawning 5 subagents with a user viewing 10 sessions already approaches the cap for the `/api/events` route alone, and 429s arrive as `TOO_MANY_CONNECTIONS` with no polling fallback.
+- **Risk:** Scaling wall at ≈2x current usage. With team mode (launchSwarm) + browser tabs + CLI-monitor + session panels, a single heavy user can exhaust the cap. No graceful degradation.
+- **Recommendation:** Implement P1-3 per the roadmap: single `EventRouter` with a `Map<route, count>`, lift default to 200, make it an admin setting, enforce per-user quotas (~20), and return a polling-mode response at 80% capacity instead of 429. Pair with F05-08 (unified event bus) — they touch the same code.
+- **Effort:** S (1 day) for the cap bump + graceful degradation alone; M for unified bus.
+- **Links:** `src/lib/events/event-bus.ts:24`, `src/server/routes/cli-monitor.ts:175`, `src/server/routes/events.ts:1069`; `specs/events_review/roadmap.md` P1-3.
+
+### F05-04 — `MAX_CHUNKS=5000` silently drops history on the client
+
+- **Priority:** P1
+- **Observation:** `src/app/hooks/use-session.ts:148` slices to `MAX_CHUNKS=5000` with no user-visible signal. A long agent session (a realistic swarm run past ~1,000 turns) silently loses the earliest chunks from the UI, with no banner, no "load earlier" control, and no state flag.
+- **Risk:** User-visible but mis-attributed data loss — the user concludes "AgentPane forgot the start of the conversation," when in fact the REST endpoint `/api/sessions/:id/events?offset=0&limit=...` still has it.
+- **Recommendation:** Implement P1-4: set a `truncated: boolean` + `truncatedAt: offset` on the returned state. Render a "Showing last 5,000 events — load earlier" banner. Back the "load earlier" button with the existing REST endpoint. Deduplicate by offset on merge.
+- **Effort:** S (2-4 h).
+- **Links:** `src/app/hooks/use-session.ts:148, 205`; `specs/events_review/roadmap.md` P1-4.
+
+### F05-05 — Dual-write still best-effort; no transactional outbox
+
+- **Priority:** P1
+- **Observation:** `DurableStreamsService.publish` persists to SQLite first, then publishes to Caddy; a Caddy failure logs at `debug` and returns `ok(offset)` (`durable-streams.service.ts:713-717`). `publishSessionEvent` has the same shape (`:985-992`). If Caddy is mid-restart, connected SSE clients miss the event until they reconnect and replay from offset — but the reconnect loop in `DurableStreamsClient` uses the last *cursor*, not the last *DB offset*, so the chance of a silent gap exists (see F05-06). There is no outbox to decouple durability from delivery; re-publish to Caddy after a transient failure does not happen.
+- **Risk:** Events durable in DB but missing from live SSE until client reconnects; no visibility into how often it happens; no retry path. Under a Caddy crash loop, the API server keeps ack-ing `ok` to callers while the browser goes quiet.
+- **Recommendation:** Implement P1-1 (transactional outbox): new `event_outbox` table (status, attempts, nextAttemptAt, payload, streamId, type), `DurableStreamsService.publish` writes only to SQLite within the business transaction, a 50ms `OutboxRelayService` polls and publishes to Caddy with exponential backoff. Removes the best-effort catch in `durable-streams.service.ts:713`. Pair with F05-02 — most `droppedEventCount` increments disappear because the relay guarantees eventual delivery.
+- **Effort:** M (1-2 days).
+- **Links:** `src/services/durable-streams.service.ts:697-717, 985-992`; `specs/events_review/roadmap.md` P1-1.
+
+### F05-06 — No client-side gap detection on reconnect
+
+- **Priority:** P1
+- **Observation:** `DurableStreamsClient` resumes from `lastCursor` via `offset: lastCursor ?? '-1'` (`client.ts:850`). The `StreamResponse` layer replays from that cursor on reconnect, but the hook never checks whether the first event *after* reconnect matches `lastCursor + 1`. GC pauses on the browser tab, sleeping the laptop, or a Caddy restart that lost in-flight LMDB entries all produce invisible gaps. `useTaskActivity` fetches historical data on mount; `useSession` does not.
+- **Risk:** Client state diverges from server state after any non-trivial disconnect. The UI looks fine, but is missing tool results or chunk deltas between the last pre-disconnect and first post-reconnect offsets.
+- **Recommendation:** Implement P2-5: on `onReconnect`, compare `getLastOffset()` with the next event's offset. If gap > 1, fetch missing events from the REST endpoint `/api/sessions/:id/events?offset=last&limit=gap` and merge by offset (dedup). Trivial once offsets are durable.
+- **Effort:** S-M (3 days).
+- **Links:** `src/lib/streams/client.ts:840-874, 994-999`; `specs/events_review/roadmap.md` P2-5.
+
+### F05-07 — Caddy SSE endpoints still unauthenticated
+
+- **Priority:** P1
+- **Observation:** `Caddyfile` `@streams path /v1/stream /v1/stream/*` does not require auth. The inline comment (lines 15–30) documents that the deployment is expected to restrict the Caddy port to the internal network and that the API server terminates auth. There is no `forward_auth` block, no basicauth, no JWT validation. The browser session cookie is not checked by Caddy.
+- **Risk:** In any deployment where Caddy's stream port is reachable from outside the trusted network — default dev, mis-configured prod, developer laptops bridged onto a public Wi-Fi, or a reverse-proxy mis-route — any client can subscribe to any stream ID they can guess, including CUIDs derived from URL leakage or log scraping. This is a security finding, not a scaling one.
+- **Recommendation:** Implement P2-3 Option A immediately (network isolation documented in deploy), Option B as follow-up: enable `forward_auth` against `POST /api/auth/verify-stream` that returns 200 if the session cookie maps to a user with access to the stream ID (scope check). Stream IDs carry enough structure (`plan:` → team, `sandbox:` → codespace, bare CUID → session) to make this a bounded lookup.
+- **Effort:** M (3-5 days including the scope resolver).
+- **Links:** `Caddyfile:15-30, 31-33`; `specs/events_review/roadmap.md` P2-3 (RS-019).
+
+### F05-08 — Three parallel SSE subsystems, three connection counters
+
+- **Priority:** P2
+- **Observation:** `EventBus` (`src/lib/events/event-bus.ts`) handles `/api/events` with its own listener Set and counter. `CliMonitorService` maintains its own `localSubscribers` and counter. Caddy handles `/v1/stream/*` with no API-level counter at all. The file's own TODO (line 11-13) flags the duplication. Event naming conventions drift between the two: `StreamEventMap` keys (colon-delimited `category:action`) don't match the `event-bus` payloads.
+- **Risk:** Capacity planning is impossible — no single number says "this server is at X% of its SSE capacity." Cleanup bugs duplicate across three cleanup paths. Future events need to decide which system to publish into, and the answer depends on historical accident. Observability is gappy.
+- **Recommendation:** Implement P1-2: unified `EventRouter` with channel-based pub/sub, a single `Map<route, count>` counter, one cleanup surface. `EventBus.publishEventToStream` and `CliMonitorService.localSubscribers` become subscribers of the router. Caddy delivery stays as-is for durable streams but publishes to the router for counting. No change to on-wire format — this is internal consolidation.
+- **Effort:** M (1 day).
+- **Links:** `src/lib/events/event-bus.ts:1-61`, `src/services/cli-monitor/cli-monitor.service.ts`, `src/server/routes/events.ts`; `specs/events_review/roadmap.md` P1-2.
+
+### F05-09 — `session_events.sessionId` stores unrelated stream IDs with no FK
+
+- **Priority:** P2
+- **Observation:** The column stores bare session CUIDs *and* `plan:*` stream IDs *and* `sandbox:*` stream IDs (the comment on `src/db/schema/sqlite/session-events.ts:11-13` acknowledges this). The absence of an FK is intentional, but the column is misnamed and cleanup is fragmented across `session-crud.service.ts` (sessions), `codespace.service.ts` (plans + sandboxes), and `EventCleanupService` (age-based sweep). A developer reading the schema first-time expects FK-backed cardinality guarantees.
+- **Risk:** Orphan rows for any stream type whose parent entity gets deleted by a code path that forgets the explicit-cleanup call. Confusion for anyone adding a new stream type — "do I need to add cleanup, or will the FK cascade?" The answer is always "you need to add cleanup" but there is no compile-time reminder.
+- **Recommendation:** Rename the column (or add an alias view) `stream_id`, and split into two tables or add a `streamKind` enum column (`session | plan | sandbox | task-creation | container-agent`) indexed alongside the stream ID. Better: a registry that every stream-owning service registers with at startup (`registerStreamOwner('plan', planModeService)`) and which the cleanup service enumerates on delete.
+- **Effort:** M (1-2 days with migration) — migrations touch a hot table, test carefully.
+- **Links:** `src/db/schema/sqlite/session-events.ts:11-13`; `CLAUDE.md:405-411`.
+
+### F05-10 — SQLite single-writer serialises all event persistence
+
+- **Priority:** P2 (P1 at >10 concurrent agents)
+- **Observation:** Every event goes through the same SQLite writer lock. With the post-batching state, writes per second are an order of magnitude lower than before (roughly 10x reduction per the ChunkBatcher PR b1448dc1), but the lock is still global: tool events, topology progress, sandbox lifecycle, plan turns, and batched chunk flushes all serialize on the writer. 5+ concurrent agents in team mode approach contention; 20+ is unambiguous.
+- **Risk:** Write contention ceiling, measurable as increased `p99` publish latency under concurrent agent load. Symptoms: SSE delivery lag, occasional `UNIQUE constraint` retry under the atomic INSERT pattern (it is handled, but retries are still latency).
+- **Recommendation:** Monitor first — add a histogram of publish latency by stream type. Batching makes this materially less urgent than the March review suggested. Only pursue libSQL/Turso (P3-5) when the metric actually shows contention. In the meantime, increase `PRAGMA journal_mode=WAL` busy timeout, verify `synchronous=NORMAL` is set (WAL + NORMAL is the right tradeoff for event writes).
+- **Effort:** S to instrument; L to migrate DB driver if needed.
+- **Links:** `src/services/durable-streams.service.ts:595-625`; `specs/events_review/roadmap.md` P3-5.
+
+### F05-11 — Container-agent double-hop latency and parse cost
+
+- **Priority:** P2
+- **Observation:** `agent-runner/src/event-emitter.ts` emits JSON lines to stdout, `container-agent.service.ts` parses each line with `readline`, maps the type, and re-publishes via `DurableStreamsService.publish`. Adds ~1–5 ms per event. At token frequency during a long execution, accumulates. Token batching was added for the direct SDK path (ChunkBatcher); the container path has no equivalent.
+- **Risk:** Increased CPU on the API server and slower perceived streaming for containerized agents relative to SDK-direct agents — inconsistent UX between sandbox modes.
+- **Recommendation:** Mirror `ChunkBatcher` on the container side (P3-3 "Edge CEP"): accumulate 10 tokens or 50ms, flush as one JSON line, let the host process pass through. Host emits the batched payload directly to Caddy. Also opens the door to stall detection (>30s no output) and rate alerts inside the container.
+- **Effort:** M (1-2 weeks for full Edge CEP; S for just token batching).
+- **Links:** `agent-runner/src/event-emitter.ts`, `src/services/container-agent.service.ts`; `specs/events_review/roadmap.md` P3-3.
+
+### F05-12 — Ephemeral Terraform streams lose data on Caddy restart mid-compose
+
+- **Priority:** P2
+- **Observation:** `isEphemeral = streamId.startsWith('terraform:')` (`durable-streams.service.ts:682`) skips the DB write entirely. Caddy failure on an ephemeral stream returns a hard error (good — surfaced to the caller), but if Caddy restarts *mid-compose*, the compose job has produced events, users have seen some, reconnecting clients will see no replay because there is no DB row to replay from. `deleteStream` after each turn (per `CLAUDE.md:411`) intentionally discards. There is no local buffer in the service.
+- **Risk:** Partial compose output on Caddy flap — user sees "processing..." then an empty chat panel because the reconnect has nothing to replay. Unlike durable streams where the DB is the fallback, terraform has none.
+- **Recommendation:** Two options: (a) persist terraform events to a short-lived `terraform_compose_events` table with TTL (24h) and read from it on reconnect; (b) accept ephemerality but require `generatedCode` in the `done` event (already the pattern) and ensure the API server buffers the full compose in memory until the `done` SSE is ack-ed — if Caddy drops, the client reconnect can pull the buffered response via a new REST endpoint. (b) is simpler and matches how the client-side fallback `extractHclFromText` already works.
+- **Effort:** S (option b) to M (option a).
+- **Links:** `src/services/durable-streams.service.ts:682-716`; `src/services/terraform-compose.service.ts`; `CLAUDE.md:405-411`.
+
+### F05-13 — Publish path has no application-level backpressure
+
+- **Priority:** P2
+- **Observation:** `IdempotentProducer` has `lingerMs: 5, maxBatchBytes: 1_048_576, maxInFlight: 5` (`caddy-producer.ts:113-117`). Beyond those, there is no producer-level backpressure to the calling agent code. `publish` returns immediately; Caddy/LMDB is expected to swallow the event. Under a hostile scenario (8 agents in team mode, each producing 10 tokens/sec with ChunkBatcher still allowing per-turn bursts), LMDB grows and the producer pool's 5-in-flight limit becomes a silent queue at the producer.
+- **Risk:** Under sustained high-throughput, memory pressure on the Caddy side accumulates and publish latency rises without the application noticing. No signal to throttle the agent.
+- **Recommendation:** Emit a `publish_lag_ms` gauge per stream. If the 95th percentile exceeds a threshold, signal the agent to pause token streaming (drain before producing more). Longer term — consumer-ack-based backpressure (NATS JetStream per P2-1 in the roadmap).
+- **Effort:** S (metric + threshold) now, L (NATS) later.
+- **Links:** `src/lib/streams/caddy-producer.ts:113-129`; `specs/events_review/roadmap.md` §3.1 (RS-008) and P2-1.
+
+### F05-14 — `@durable-streams/client@0.2.3` vs `@durable-streams/server@0.3.1` major version skew
+
+- **Priority:** P2
+- **Observation:** `package.json` pins `@durable-streams/client ^0.2.3` and `@durable-streams/server ^0.3.1`. At 0.x semver, a minor bump is a breaking change, so 0.2 vs 0.3 is explicitly a major delta. Both packages are produced by the same project. The code compiles and tests pass, so the used surface is presumably compatible today, but there is no compatibility matrix documented, no test that asserts the wire format round-trips, and no CI guard against an `npm update` that drags one package onto 0.4 while leaving the other on 0.3.
+- **Risk:** Latent incompatibility; an innocent dependency bump may break stream delivery. The failure mode is subtle (events validated client-side by Zod, so malformed wire gets rejected quietly).
+- **Recommendation:** (1) Pin exact versions (remove carets for these two packages). (2) Add a contract test: start a local `DurableStreamTestServer`, publish via `IdempotentProducer`, consume via `durableStream()`, assert the envelope round-trips. (3) Document the known-good matrix in `specs/application/integrations/durable-streams.md`.
+- **Effort:** S (half day).
+- **Links:** `package.json` `@durable-streams/*`; `src/lib/streams/caddy-producer.ts:8`; `src/lib/streams/client.ts:12`.
+
+### F05-15 — Reconnect ceiling is 8 attempts on clean closure, silent afterwards
+
+- **Priority:** P2
+- **Observation:** `src/lib/streams/client.ts:377` sets `MAX_RECONNECT_ATTEMPTS = 8` with an exponential backoff capped at 30s. After attempt 8, the subscription stays disconnected with no visible state beyond `getState() === 'disconnected'`. The hook surfaces `onDisconnect` once per disconnect but not "terminal give-up." Users see a stale UI with no banner.
+- **Risk:** Long-lived sessions (especially on a laptop sleeping overnight) exceed the reconnect budget and land in a dead state. No user-facing cue.
+- **Recommendation:** Add `onTerminalDisconnect` callback, render a "Reconnect" button in the session panel when it fires. Consider resetting the attempt counter on a successful `markConnected` (current code already does this implicitly by recreating `connect()`), but a stale tab that loses power may re-enter `connect()` from a zero-attempts state multiple times — add a total-budget window (e.g., 32 attempts in 10 min).
+- **Effort:** S (2-4h).
+- **Links:** `src/lib/streams/client.ts:377, 942-948`.
+
+### F05-16 — Event-type taxonomy remains inconsistent
+
+- **Priority:** P3
+- **Observation:** `StreamEventMap` uses `category:action` hierarchical names (`plan:started`, `container-agent:tool:start`) while the session-event domain uses shorter non-prefixed names (`chunk`, `tool:start`, `tool:result`, `presence:joined`). The client's `SessionEventType` union (`src/lib/streams/client.ts:382-412`) mixes both worlds. No versioning field on events; no CloudEvents envelope at the transport layer (the OC-005 envelope is structural metadata, not event-schema versioning).
+- **Risk:** Consumers must know two naming conventions. Adding a field to a chunk payload requires mirrored changes in server types, Zod schemas, and client callbacks with no `schema_version` to support graceful rollouts.
+- **Recommendation:** P2-4 from the roadmap. Normalize to `io.agentpane.{entity}.{action}` with a dual-publish (old + new) for two release cycles, then retire. Add a `schemaVersion` field. Publish an AsyncAPI 3.0 spec. Much larger than other findings — keep at P3 until consumer count grows (e.g., an external webhook exporter).
+- **Effort:** L (1-2 weeks). Migration pain.
+- **Links:** `src/services/durable-streams.service.ts:416-482`; `src/lib/streams/client.ts:382-412`; `specs/events_review/roadmap.md` P2-4.
+
+### F05-17 — Single-node Caddy is the live-delivery SPOF
+
+- **Priority:** P3 (P1 if you horizontally scale the API server)
+- **Observation:** Today there is one API server process and one Caddy process. Multiple API instances cannot publish to the same LMDB without a Caddy-to-Caddy coordination layer that doesn't exist. SQLite remains the source of truth, so durability survives a Caddy restart (clients replay on reconnect once F05-06 is in place), but real-time delivery is single-node.
+- **Risk:** Blocker for horizontal API scaling. Single Caddy also means one process in the hot path between every agent event and every browser — scheduled maintenance requires user-visible reconnects.
+- **Recommendation:** Defer until horizontal scale is actually needed. At that point, P2-1 (NATS JetStream as routing/distribution layer with Caddy as SSE bridge) is the documented path. Short term, add a second Caddy for HA with LMDB replication via file-level sync, or front Caddy with a TCP LB — but both have caveats (LMDB file sync isn't guaranteed clean; TCP LB doesn't solve LMDB split-brain). NATS is the clean answer.
+- **Effort:** L (2-3 weeks when triggered).
+- **Links:** `Caddyfile`; `src/lib/streams/caddy-producer.ts`; `specs/events_review/roadmap.md` P2-1.
+
+### F05-18 — `subscribe` on the server interface is a silent no-op
+
+- **Priority:** P3
+- **Observation:** `CaddyDurableStreamsServer.subscribe` (`caddy-producer.ts:210-223`) returns an immediately-`{done: true}` async iterable. The interface `DurableStreamsServer.subscribe` exists on the type (`durable-streams.service.ts:33-36`), so any server-side consumer that tried to iterate would get no events and no error. The no-op is documented as intentional (RS-015), but the type signature invites misuse.
+- **Risk:** A future developer implements server-side processing (e.g., metrics aggregation, DLQ relay) by calling `subscribe`, sees nothing, and doesn't immediately learn it's a no-op.
+- **Recommendation:** Either remove `subscribe` from the interface (SSE-only is an architectural choice — encode it in the type) or throw `NOT_IMPLEMENTED` so misuse fails loud. If server-side subscription becomes real (for P1-5 webhook DLQ relay or P2-1 NATS bridge), implement it properly.
+- **Effort:** S (1 hour).
+- **Links:** `src/services/durable-streams.service.ts:33-36`; `src/lib/streams/caddy-producer.ts:205-223`.
+
+## What this supersedes
+
+| Prior finding | Location | Disposition |
+| --- | --- | --- |
+| 2.1 Unbounded retention | `events_review/README.md` §2.1 | **Resolved** — `EventCleanupService` delivers P0-2 (60d / 90d defaults, settings-overridable). No new finding. |
+| 2.2 SQLite single-writer serialisation | §2.2 | Still valid — superseded by **F05-10** with lowered priority because ChunkBatcher (2.3) mitigated the pressure. |
+| 2.3 No chunk batching | §2.3 | **Resolved** — `ChunkBatcher` delivers P0-3. No new finding. |
+| 2.4 O(n²) accumulated-text bloat | §2.4 | **Resolved** — P0-1 removed `accumulated`. No new finding. |
+| 2.5 Single-node Caddy | §2.5 | Still valid — superseded by **F05-17**, priority kept at P3 until horizontal scale is triggered. |
+| 2.6 50-connection SSE cap | §2.6 | Still valid — superseded by **F05-03**, promoted to P1 because team mode makes it reachable. |
+| 2.7 Silent chunk truncation | §2.7 | Still valid — superseded by **F05-04**, P1-4 remains untriggered. |
+| 3.1 No backpressure | §3.1 / RS-008 | Still valid — superseded by **F05-13** (instrumentation first, then NATS). |
+| 3.2 No dead-letter queue | §3.2 | Folded into **F05-05** (outbox) and **F05-02** (plan-mode visibility). Webhook-specific DLQ (P1-5) remains out of scope here — covered in the operations theme. |
+| 3.3 Container-agent double-hop | §3.3 | Still valid — superseded by **F05-11**. |
+| 3.5 Offset-based pagination fragility | §3.5 | Partially mitigated — atomic INSERT removed the obvious race, but cursor-based pagination isn't implemented. No finding here; small enough to leave as a P3 polish. |
+| 3.6 Memory accumulation in stream handler | §3.6 | Mitigated by batching — accumulated text still held per phase but no longer duplicated per chunk. No new finding. |
+| RS-001 Producer pool unbounded growth | hybrid §2 | **Resolved** — LRU + idle sweep in `caddy-producer.ts`. No new finding. |
+| RS-002 Duplicate SSE tracking | hybrid §2 | Still valid — folded into **F05-08** (unified bus). |
+| RS-006 No gap detection | hybrid §2 | Still valid — superseded by **F05-06**. |
+| RS-009 Three disconnected systems | hybrid §2 | Still valid — superseded by **F05-08**. |
+| RS-010 Shared subscription map cleanup | hybrid §2 | **Resolved** — 60s orphan audit in `client.ts:1504-1522`. No new finding. |
+| RS-011 `useSession` unbounded array | hybrid §2 | **Resolved** for growth (MAX_CHUNKS enforces a bound); surface gap remains — see **F05-04**. |
+| RS-013 Dual-write inconsistency | hybrid §2 | Still valid — superseded by **F05-05** (outbox). |
+| RS-014 Offset collision retry limited to 3 | hybrid §2 | **Resolved** by atomic INSERT pattern; 3 retries is a soft ceiling, not a correctness issue. No new finding. |
+| RS-019 Caddy unauthenticated | hybrid §2 | Still valid — superseded by **F05-07**, priority raised to P1. |
+| P1-5 Webhook DLQ | roadmap | Out of scope for this theme — belongs in the webhook/ops review. |
+| P3-2 Durable execution (Inngest) | roadmap | Out of scope for this theme — belongs in the agent-execution review. |
+| P3-4 CQRS snapshots | roadmap | Not yet justified — trigger condition (5k+-event sessions routine) not met; MAX_CHUNKS cap and offset-based replay still fine for current sessions. No new finding. |
+| Stream-ID convention enforcement | CLAUDE.md docs | **New gap** — **F05-01**. |
+| `droppedEventCount` silent swallowing | plan-mode.service.ts | **New gap** (was a TODO note in the counter) — **F05-02**. |
+| `@durable-streams/*` version skew | package.json | **New finding** — **F05-14**. |
+| Reconnect ceiling invisibility | client.ts | **New finding** — **F05-15**. |
+| `subscribe` no-op footgun | caddy-producer.ts | **New finding** — **F05-18**. |
+| Ephemeral Terraform loss on Caddy restart | durable-streams.service.ts | **New finding** — **F05-12**. |
+
+## Open questions
+
+1. **Operational topology.** Is the target deployment single-process + single-Caddy indefinitely, or is horizontal API scaling on the 6-month roadmap? This decides whether F05-17 (single-node Caddy) and F05-10 (single-writer SQLite) stay at P3 or promote to P1, and whether NATS JetStream enters the critical path.
+2. **Auth model for Caddy streams.** Is network isolation of the Caddy port a deployable assumption in every environment AgentPane runs (self-hosted in customer infra, cloud-hosted, developer machines)? If not — specifically if `/v1/stream/*` is ever routed through the same ingress as the public API — F05-07 promotes to P0.
+3. **Stream-ID tagging appetite.** F05-01 asks for tagged types at every publish site. This touches ~40 call sites. Is the migration worth the safety (author's view: yes), or should we invest in a runtime assertion only (cheaper but catches less)?
+4. **Client memory ceiling.** `MAX_CHUNKS = 5000` is the right bound for RAM, but the user surface (F05-04) needs product direction: do we render a truncation banner with "load earlier" (fetches REST), or do we virtualize the chunk list so MAX_CHUNKS becomes irrelevant?
+5. **Plan-mode dropped-event policy.** Should each drop be user-visible (banner in the plan UI), operator-visible (admin endpoint + alert), or both? F05-02 proposes both — confirm before implementing.
+6. **Terraform ephemeral contract.** Is there a customer use case that needs terraform-compose replay after a Caddy restart, or is "restart the compose" an acceptable UX? F05-12's chosen remedy depends on this.
+7. **Event schema versioning trigger.** F05-16 / P2-4 is heavy. Is there an external consumer on the horizon (webhook exporter, third-party integrations, CLI ingestion) that would justify the normalization and CloudEvents envelope now, or does this remain deferred until the consumer appears?

--- a/specs/arch_review_april/06-security.md
+++ b/specs/arch_review_april/06-security.md
@@ -1,0 +1,140 @@
+# 06 — Security
+
+Theme scope: injection surfaces (shell, YAML, SQL, path, CRLF), authentication & OAuth flow, RBAC enforcement parity, token storage & rotation, secret handling, CORS/CSP, supply chain (Dependabot), sandbox escape, tenant isolation.
+
+This review consolidates status against the prior assessment in `specs/release_plan/02-security-hardening.md` (3 critical + 5 high) and adds new findings. The security foundation is demonstrably stronger than the code of three months ago — path validation helpers, array-form `Bun.spawn` for git clone, AES-256-GCM at rest for API keys, `CapDrop: ['ALL']` + `no-new-privileges` on Docker containers, cookie hashing (SHA-256) for session tokens, OAuth CSRF state cookie, token ceiling on API tokens, and a dedicated `enrichAuthContext` + `requireRole` middleware pair have all landed. The remaining risk is weighted toward supply-chain, multi-tenant rate limiting, policy drift (CSP, tenant isolation in shared sandbox), and a small set of shell surfaces that still interpolate. Sixteen findings follow.
+
+---
+
+## Consolidated status — prior findings in `02-security-hardening.md`
+
+| Prior ID | Title | Prior P | Status now |
+|---|---|---|---|
+| C1 | Docker `CapDrop` / `SecurityOpt` | CRITICAL | **Resolved** — `docker-provider.ts:570-574` drops `ALL`, re-adds minimal caps, sets `no-new-privileges`. |
+| C2 | Path traversal in GitHub clone destination | CRITICAL | **Resolved** — `isValidClonePath()` applied in `github.ts:127` + `create-from-template`. |
+| C3 | Shell interpolation in `codespace.service.cloneRepository` | CRITICAL | **Partially resolved** — input validation rejects shell-breaking chars and `..`, but the `mkdir -p "${resolved}"` / `git clone "${url}" "${targetPath}"` pattern remains in the runner path. See F06-03. |
+| C4 | Hardcoded CORS origin in SSE headers | HIGH | **Resolved** — `shared.ts` reads `CORS_ORIGIN`. |
+| H1 | No expired session cleanup / revoke-all | HIGH | **Resolved** — hourly purge + `POST /api/auth/revoke-all`. |
+| H2 | XFF spoofing in rate limiter | HIGH | **Resolved** — `TRUSTED_PROXIES` + right-to-left walk added. |
+| H3 | Audit hook empty catch | HIGH | **Resolved** — `log.error()` added. |
+| H4 | In-memory rate limiting bypassed by restart / multi-instance | HIGH | **Still live** — see F06-07. |
+| H5 | Empty tool whitelist allows all | HIGH | **Still live** — see F06-06. |
+| H6 | `Secure` cookie only in NODE_ENV=production | MEDIUM-HIGH | **Still live** — see F06-13. |
+
+---
+
+## F06-01 — P0 — Dependabot: 42 open advisories (2 critical, 17 high)
+
+Current inventory from GitHub security alerts: 2 critical, 17 high, 22 moderate, 1 low. For an application that handles OAuth tokens, executes untrusted agent code in shared containers, and ingests arbitrary markdown/YAML, carrying two critical advisories into any production push is not acceptable.
+
+Direction: treat the alert list as a release blocker. Triage in this order — (a) criticals and highs on server-side packages (Hono, octokit, drizzle, better-sqlite3, dockerode, @kubernetes/client-node, react-markdown), (b) transitive advisories against dev-only tooling that run inside CI (vite, playwright) where supply-chain exposure is still real because CI has write access to the registry, (c) browser-side (react, @xyflow, @radix-ui). Wire `npm audit --audit-level=high` into the CI `lint-and-typecheck` job as a non-blocking comment first, then promote to blocking once criticals are clear. Add a weekly Dependabot auto-merge for patch-level advisories on pinned internal packages.
+
+Cross-ref: F07-* (release), F12-* (supply chain cross-cutting).
+
+## F06-02 — P0 — Shell interpolation in `createBunCommandRunner`
+
+`src/server/bootstrap/service-container.ts:62` shells out via `Bun.spawn(['sh', '-c', command])` where `command` is a pre-composed string. This is the host-process `CommandRunner` that `WorktreeService`, `GitService`, and `CodespaceService.cloneRepository` consume when not routed through a sandbox. The runner has no `validateShellCommand()` guard on this path; validation lives in the sandbox runner only (`agent-sandbox-provider.ts`). Every caller that composes a command string — including `git clone "${url}"` in `codespace.service.ts:528`, `mkdir -p "${resolved}"` on :527, and every `git worktree` / `git fetch` that does string interpolation — inherits this surface.
+
+Even with the C3 input validation landed, any future caller that forgets to pre-validate will silently inherit shell-injection potential. The CLAUDE.md "Key patterns found in reviews" section calls this out explicitly (positional args with `--`, never string interpolation).
+
+Direction: convert `CommandRunner.exec` to take `(argv: string[], cwd)` and delete the `sh -c` shim. Migrate callers one at a time; any remaining string-command path goes through a single `validateShellCommand()` helper with a failure mode that throws, not logs. Track the migration as a semgrep rule that forbids `sh -c` spawns outside a specific allowlist.
+
+## F06-03 — P0 — YAML injection via skill/agent metadata → SKILL.md frontmatter
+
+`src/lib/sandbox/skill-injector.ts:42-48` escapes `"`, `\`, `\n`, `\r` for values written inside YAML double-quoted strings, which handles the main double-quoted attack vector. However: the `tags` field at line 132 writes `tags: ${skill.tags.join(', ')}` with zero escaping — a tag containing `\n` or `#` or `:` or `` ` `` breaks the frontmatter and can inject arbitrary YAML keys (e.g. `pre_tool_use: bash -c "..."` if the Claude runner reads hook config from frontmatter, which it does via the Claude Agent SDK). The `source` and `executionSkill` fields are written unquoted / partially quoted respectively. Skill/template content originates from marketplaces, which per the release plan are explicitly "untrusted" ingestion paths.
+
+Direction: emit frontmatter through a real YAML serializer (`yaml` package) rather than string concatenation. Validate every tag against `/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/` at ingestion (same regex used for skill IDs) and reject on mismatch. Add a test that feeds a hostile tag containing `\n---\nhooks:` and asserts the materialized file still parses as a single frontmatter block.
+
+---
+
+## F06-04 — P1 — Plan content → GitHub issue body is neither escaped nor sanitized
+
+`src/lib/github/issue-creator.ts:47-54` passes the plan `body` straight to `octokit.rest.issues.create`. The body originates from LLM output in `extractIssueContent()` at :169 (last assistant message) and `formatConversationSummary()` at :202 which interpolates raw session values (`session.id`, `session.taskId`, `turn.interaction.answers`) with no escaping. GitHub renders markdown, and `@mention`, `#<number>`, and `Fixes #<id>` are all action-triggering tokens. A hostile plan can post back-references, auto-close unrelated issues via `closes #N`, or post mentions that spam notifications. `labels` defaults to `['plan', 'agent-generated']` but is concatenated with `input.labels ?? []` at `:102` with no validation — a label named `"evil,urgent"` would round-trip as one label but looks like two in the UI.
+
+Direction: when building the issue body, strip / escape `closes #`, `fixes #`, `resolves #` keywords (prepend with zero-width space or wrap in a code fence), escape `@` mentions, and reject labels that don't match a safe regex. Add a test harness fixture that feeds a hostile plan text and asserts the resulting body contains only inert markdown.
+
+## F06-05 — P1 — Dev-mode bypass depends on env-var alignment across two layers
+
+`rbac-middleware.ts:62` rejects `auth.authMethod === 'dev'` when `NODE_ENV !== 'development'`, which is a correct defense-in-depth. But the production gate upstream relies on `server-config.ts` aborting when `SKIP_AUTH=true` in production, and on the auth middleware never tagging a request as `dev` unless both conditions are met. Any future refactor that introduces a third auth mode or renames `NODE_ENV` (e.g. `APP_ENV` in k8s) re-opens the hole.
+
+Direction: introduce a single `isDevAuthAllowed()` helper that hard-codes the gate and is consumed by (a) bootstrap, (b) auth middleware, (c) rbac middleware. Add a functional test that boots with `SKIP_AUTH=true NODE_ENV=production` and asserts the server fails to start. Audit for any code path that sets `auth.authMethod='dev'` without going through the helper.
+
+## F06-06 — P1 — Default-allow tool whitelist when `allowedTools` is empty
+
+Restated from prior H5 and still live. `tool-whitelist.ts:8-9` treats empty array as "allow all" — a failure-open default. The blast radius is the Claude Agent SDK tool surface (Bash, Write, Edit, WebFetch), which in a container with any credentials mounted is effectively arbitrary code execution against the host-visible filesystem.
+
+Direction: require an explicit `allowedTools: ['*']` sentinel for open access and make empty-array a hard deny. Sweep callers to verify none rely on the old semantics. This is a 1-hour change blocked only by the caller sweep.
+
+## F06-07 — P1 — In-memory rate limiter: bypassable by restart + multi-instance drift
+
+Restated from prior H4. Currently a single-process `Map` holds counters. Under any rolling restart, counters reset; under multi-instance deployment (which the release plan envisages), each replica has independent counters, so effective limits are `limit × N`. For a multi-tenant install, the per-IP key is also insufficient — every tenant shares the same IP space behind the same Caddy, so a single abusive tenant can exhaust the per-IP budget for everyone else on that address.
+
+Direction: move to a shared store (Redis/Valkey). Scope the key to `(tenantId|userId|tokenId, endpoint-class, window)` with per-IP as a secondary envelope. Distinguish unauthenticated limits (IP-only) from authenticated limits (user/token-keyed). Keep the in-memory path as a fallback when `REDIS_URL` is not set, but log loudly at boot.
+
+## F06-08 — P1 — Tenant isolation in shared sandbox mode
+
+With `sandbox.mode = Shared Container` (the default per CLAUDE.md), a single Docker container services every codespace. All `/workspace` bind mounts land inside the same filesystem namespace, and the agent-runner executes with a single OAuth credential file (`~/.claude/.credentials.json`). There is no per-tenant uid mapping, no per-tenant seccomp profile, no mount namespace split. A hostile codespace writing to `/workspace/../.claude/.credentials.json` reads every other tenant's OAuth token.
+
+Direction: treat "Shared Container" as single-tenant-only and gate it on a `MULTI_TENANT=false` flag. For multi-tenant deployments, force per-codespace container + per-codespace credentials file scoped to a chroot/namespaced mount. K8s provider should use per-pod ServiceAccount with a scoped secret mount. Add a startup self-check that refuses to boot a shared container when more than one team exists in the database.
+
+## F06-09 — P1 — API keys and GitHub OAuth tokens: no rotation, no expiry
+
+`api-key.service.ts` handles save/get/delete/markInvalid but has no `rotateKey`, no `expiresAt` field, no scheduled rotation job. Same for `github-token.service.ts` — decrypted tokens live indefinitely once stored, and the refresh logic (if any — grep shows none) is not exercised. For the GitHub OAuth App path, tokens are not short-lived user tokens, so this is an accepted but undocumented posture; for the GitHub **App** path (installation tokens, `github-app.service.ts:399`), tokens are short-lived and refreshed correctly. Clarity should be in the model.
+
+Direction: add `expiresAt` and `rotatedAt` columns, default Anthropic API keys to a 90-day rotation reminder (banner, not hard expiry), and emit a `key:rotation_due` event into the same event subsystem used for task lifecycle. For installation tokens, document the 1-hour TTL and confirm the cache honours it (a cursory read of `getInstallationToken` suggests yes, but write a test).
+
+## F06-10 — P1 — CSP blocks required external resources; likely unused in production
+
+`src/server/router.ts:110` CSP allows only `'self'` + `data:` for images and `'self'` for connect. The UI loads GitHub avatars (`avatars.githubusercontent.com`), fetches from Anthropic/GitHub APIs via the backend (fine) but also opens EventSource connections to `/api/sessions/:id/stream` (same-origin so OK), and, via Shiki, dynamically imports WASM/JSON grammars at runtime. Production CSP will either break the UI on first load or be silently disabled by the reverse proxy — both outcomes undermine the control.
+
+Direction: run the app once with `CSP-Report-Only` for a week, collect violations, then tune. Add `img-src 'self' data: https://avatars.githubusercontent.com;`, `script-src 'self' 'wasm-unsafe-eval';` (Shiki needs WASM eval), `connect-src 'self' https://api.github.com;`. Add a Playwright test that loads the dashboard in a production build and asserts zero CSP violations in the console.
+
+## F06-11 — P1 — Markdown rendering trusts Shiki's HTML but the input path is agent-controlled
+
+`markdown-content.tsx:82` and `terraform-right-panel.tsx:242` both use `dangerouslySetInnerHTML` with Shiki-produced HTML. The biome-ignore comment says "shiki escapes code input and returns safe HTML" — correct for current Shiki versions, but the input code comes from LLM-generated or user-pasted content and the surrounding markdown renderer (`react-markdown`) escapes HTML tags by default. The risk window is a Shiki regression or a grammar-specific escape gap. Given both files contain the same pattern with the same comment, a single Shiki CVE affects both panels.
+
+Direction: route all Shiki output through a single `<HighlightedCode html={...} />` wrapper that additionally runs DOMPurify on the HTML string before injecting. Keep the wrapper in one file so a future upgrade / CVE response is one edit. Add a regression test that feeds `<script>alert(1)</script>` into the code block and asserts the DOM has no `<script>` node.
+
+## F06-12 — P2 — RBAC enforcement parity: six route modules miss `useRoleGuard`
+
+`router.ts` applies `useRoleGuard`/`requireRole` to most routes but notably not to: `/api/me`, `/api/invitations`, `/api/auth`, `/api/teams/*` (intentional — handler-level RBAC per AR-008/AR-009), `/api/sandbox-configs` child resource paths if any land post-review, and the `/api/codespaces/:id/members`, `/api/tokens`, `/api/tags`, `/api/codespaces/:id/tags`, `/api/tasks/:id/tags` routes which rely on handler-level checks. The pattern "handler-level RBAC" is risky because any future handler added without reading the AGENTS.md note inherits zero authz. The middleware-level guard enforces by default; handler-level requires opt-in.
+
+Direction: for `tags`, `rbac-tokens`, `codespace-members` — wrap their create factories with a `withHandlerRbac()` higher-order helper that throws at route registration time if the handler does not call `requireTeamRole()` / `requireMemberRole()` before any DB access. Add a test that iterates every registered `app.route` and asserts either a middleware guard or a handler-level marker exists. Document the split in `specs/application/security/` and cross-link from the route AGENTS.md.
+
+## F06-13 — P2 — Session cookie `Secure` flag keyed on NODE_ENV, not protocol
+
+Restated from prior H6. `auth.ts:196` sets `Secure` only when `NODE_ENV === 'production'`. A staging deployment with HTTPS and `NODE_ENV=staging` (or any non-production label) sends session cookies over TLS without the `Secure` flag, which is harmless in practice but fails security scanners and leaves the door open if TLS termination ever bypasses Caddy. The `oauth_state` cookie at `:50` is already `Secure` unconditionally — inconsistent.
+
+Direction: derive `secure` from `c.req.url.startsWith('https://')` rather than env. Keep an override env for local HTTP-to-HTTPS testing. Apply the same logic to the post-logout clear-cookies at `:236`, `:252`, `:276`, `:295`.
+
+## F06-14 — P2 — Plan/sandbox/terraform stream IDs cross boundaries without origin checks
+
+The durable-streams table has no FK on `sessionId` (documented in CLAUDE.md), and the stream-ID prefixing convention (`plan:`, `sandbox:`, `terraform:`) is enforced by convention only. A caller who passes a bare CUID expecting a session subscribes to a different tenant's session because the stream server has no tenant scoping. The SSE endpoint `/api/sessions/:id/stream` enforces tag-based RBAC via `requireTagAccess`, but plan and sandbox streams (subscribed via `/v1/stream?streamId=...` direct to Caddy) bypass the API server entirely.
+
+Direction: sign stream IDs with an HMAC keyed per tenant, include the tenant in the key, and require the HMAC on every stream subscribe. Alternatively, move all stream access through the API server so RBAC runs on the subscribe handshake — Caddy can still do the persistence, but subscription auth lives in the app.
+
+## F06-15 — P2 — Request body size is bounded only by Bun defaults
+
+Hono has no explicit body-size middleware. Large multipart or JSON payloads on `/api/tasks` or webhook routes can burn memory. Bun's default is generous (~100MB). For an auth-gated API this is a minor risk; for `/hooks/events/*` which is unauthenticated, it is a DoS vector even with the 60/min rate limiter because one request is enough to OOM.
+
+Direction: add a 1MB limit on public webhook routes (`/hooks/*`) and a 10MB limit on authenticated routes, with a 50MB opt-in for `/api/memory/*` if large embeddings round-trip. Configure via env with conservative defaults.
+
+## F06-16 — P3 — Env vars injected into sandbox containers are visible in `ps auxe`
+
+`docker-provider.ts:562` writes `Env: [...config.env]` which includes any credential strings the service passes through. On Linux, a privileged process inside the namespace can read `/proc/<pid>/environ`. In the Shared Container mode, the container already violates per-tenant isolation so this is moot; in Per-Project mode, the container is single-tenant and the risk is limited to an attacker already inside the container, which is the threat the sandbox exists to contain.
+
+Direction: for secret-shaped env vars (`*_TOKEN`, `*_KEY`, `ANTHROPIC_*`), write them to a `tmpfs`-mounted file at `/run/secrets/<name>` and point the runner at the file via a non-secret `*_FILE` env var. The Claude Agent SDK already prefers `~/.claude/.credentials.json` (per CLAUDE.md) — extend the same pattern to every secret. Drop secret env vars entirely from the container spec.
+
+---
+
+## Cross-references
+
+- Prior security assessment: `specs/release_plan/02-security-hardening.md` — consolidated status table above.
+- Dependabot inventory: F06-01 is a blocker for the release plan in `specs/release_plan/04-release-deployment.md`.
+- Multi-tenant posture (F06-07, F06-08, F06-12): informs `specs/arch_review_april/07-performance-scalability.md` and `12-cross-cutting.md`.
+- Supply-chain and CSP (F06-10, F06-01): informs `08-frontend-readiness.md`.
+- Durable-stream auth (F06-14): informs `05-events-streaming.md` and `03-agent-execution.md`.
+
+---
+
+**Summary:** 3 P0, 8 P1, 4 P2, 1 P3 across 16 findings.

--- a/specs/arch_review_april/07-api-surface.md
+++ b/specs/arch_review_april/07-api-surface.md
@@ -1,0 +1,138 @@
+# API Surface — Architecture Review (April 2026)
+
+## Summary
+
+The HTTP surface totals ~240 endpoints across **39 Hono route modules** (the "352" quoted elsewhere counts internal sub-paths and SSE). The middleware stack in `src/server/router.ts` is correct on paper — CORS → logger → request-ID → security headers → IP rate limit → auth → auth-enrichment → per-token rate limit → tag-access → role guards → route factory — but rigour falls off once you leave `router.ts`. Response envelopes are *mostly* `{ok, data}` but list shapes vary (bare `T[]` vs `{items}` vs `{items, totalCount, nextCursor}`), the cursor-based pagination spec is not honoured in code (offset everywhere, plus a bespoke `page`/`size` in memory routes), the rate limit is in-process per-IP with a documented multi-instance caveat, the request-ID is emitted but never surfaces in service logs or event payloads, and two modules (`events.ts` 1,168 LOC / 19 endpoints; `sandbox.ts` 1,341 LOC / 15 endpoints) mix CRUD, SSE, validation and RBAC. There is **no OpenAPI schema** and **no Hono typed client**: `src/lib/api/client.ts` hand-writes every response type, which is the direct cause of the `apiServerFetch<T>` double-wrap footgun flagged in `CLAUDE.md`.
+
+## Map
+
+| Layer | File(s) | Purpose |
+|-------|---------|---------|
+| Router / middleware | `src/server/api.ts`, `src/server/router.ts:227` | Mounts 39 modules; CORS → logger → request-ID → security headers → rate limits → auth → RBAC |
+| Request-ID | `src/server/router.ts:91-98`, `src/lib/context/request-context.ts` | `X-Request-Id` + AsyncLocalStorage |
+| Auth / RBAC | `src/lib/api/auth-middleware.ts`, `src/lib/api/rbac-middleware.ts`, `src/server/shared.ts:183-377` | `requireRole`, `requireTeamRole`, `requireCodespaceRole`, `requireTagAccess` |
+| Rate limiter | `src/lib/api/rate-limiter.ts` | In-memory per-IP (200/min); per-token (100/min); multi-instance caveat documented |
+| Response helpers / validation | `src/server/shared.ts`, `src/server/validation.ts:239` | `json`, `errorResponse`, `ApiResponse<T>`, `parseLimit/Offset/Pagination`, `parseJsonBody(c, schema)` |
+| Largest modules | `sandbox.ts` 1,341 / `events.ts` 1,168 / `sandbox-k8s.ts` 680 / `memory.ts` 638 / `workflow-designer.ts` 597 | CRUD + SSE + RBAC mixed |
+| Frontend client | `src/lib/api/client.ts` (~1,600 LOC) | Hand-rolled; duplicates server shapes |
+| Pagination spec | `specs/application/api/pagination.md` | Declares cursor-based default; code uses offset |
+
+## What's working
+
+- Middleware order is correct: request-ID before auth, auth before RBAC, RBAC before per-token rate limiter (which needs enriched token scope).
+- `createAuthMiddleware` exempts only `/api/health*`, `/api/readyz`, and `/api/auth/*` — no module can silently skip auth.
+- Global `onError` and `notFound` emit canonical `{ok:false, error}`; dev-mode message echo is gated on `NODE_ENV`.
+- `validateIdParam` / `requireQueryId` / `parseJsonBody` centralise the boring parts; `parseJsonBody` distinguishes `SyntaxError` from other parse failures and is used in ~17 modules.
+- Rate-limiter emits `X-RateLimit-*` headers and honours `TRUSTED_PROXIES` for XFF unrolling.
+- RBAC exceptions are commented with `AR-*` rationales (e.g., `/api/invitations`, `/api/me` intentionally skip middleware guards).
+
+## Findings
+
+### F07-01 — Pagination: cursor spec vs offset reality
+
+- **Priority:** P1
+- **Observation:** `specs/application/api/pagination.md` declares cursor-based as the primary strategy with Base64 payloads. In reality almost every list endpoint uses `parseLimit`/`parseOffset`: bare array (`/api/memory/insights`), `{items, totalCount}` without cursor (`/api/sandbox-configs`), or a degenerate `{items, nextCursor:null, hasMore:false, totalCount}` (`/api/tasks`). `memory.ts:48` even defines its own `parsePagination(page, size)` that collides with `shared.ts:40`. `events.ts:1419` is the only module with real `cursor`/`hasMore` wiring.
+- **Risk:** Deep-page offset scans degrade as data grows; insert/delete during scroll causes skip/dup; cursor-scroll UIs are unreachable.
+- **Recommendation:** Pick one strategy. Introduce a `paginate<T>()` helper emitting `{items, nextCursor, hasMore}` and migrate sessions, tasks, events.log first; or rewrite `pagination.md` to match code.
+- **Effort:** L.
+- **Links:** [`specs/application/api/pagination.md`](../application/api/pagination.md).
+
+### F07-02 — Response envelope variance: list shapes diverge
+
+- **Priority:** P2
+- **Observation:** Canonical envelope is `{ok, data: T}`, but `/api/tasks` returns `{data:{items, nextCursor, hasMore, totalCount}}`, `/api/memory/insights` returns `{data: Insight[]}`, `/api/teams/:id/members` returns `{data:{items}}` (no pagination), and `/api/events/sources` uses `{data:{items, nextCursor, hasMore}}`. The `apiServerFetch<T>` double-wrap warning in `CLAUDE.md` exists because developers guess `T` from one endpoint and mis-apply it to another.
+- **Risk:** Silent UI bugs (`result.data.data` undefined); divergent refactoring.
+- **Recommendation:** Define `ListResponse<T> = {items: T[], nextCursor: string|null, hasMore: boolean}` and enforce it for every list endpoint. Generate frontend types from schemas (F07-06).
+- **Effort:** M.
+
+### F07-03 — `{ok:true, data:[]}` used to mask infrastructure failures
+
+- **Priority:** P1
+- **Observation:** `CLAUDE.md` explicitly warns against this pattern, yet `src/server/routes/codespaces.ts:430,434` does it in `GET /api/codespaces/:id/skills`: when `templateService.getMergedConfig` fails (repo unreachable, parse error), the handler returns an empty list instead of `{ok:false, error}`. Same shape in `events.ts:193,675,682` when plugin directories are missing.
+- **Risk:** UI cannot distinguish "no skills" from "sync broken"; users see empty state with no recovery signal.
+- **Recommendation:** Return `{data:{items:[], source:'empty'|'degraded', degradedReason?}}` or propagate `{ok:false, error}`. Audit every `ok:true, data:[]` return.
+- **Effort:** S.
+
+### F07-04 — Rate limit is per-IP, in-process, multiplies across instances
+
+- **Priority:** P1
+- **Observation:** `rate-limiter.ts:6-13` admits "each instance maintains its own counters." Global IP limit 200/min, per-token 100/min, webhooks 60/min. A corporate NAT bottlenecks all users behind one IP; distributed attackers from many IPs are unthrottled. Session-cookie auth bypasses the per-token limiter entirely.
+- **Risk:** DoS exposure, noisy-neighbour issues, throttling of legitimate teams behind proxies.
+- **Recommendation:** Swap in Redis-backed counters keyed primarily on `userId`, with IP fallback for unauthenticated endpoints. Webhook routes should key on source slug.
+- **Effort:** M.
+- **Links:** [`specs/release_plan/02-security-hardening.md`](../release_plan/02-security-hardening.md).
+
+### F07-05 — Request-ID never reaches services or event payloads
+
+- **Priority:** P1
+- **Observation:** `requestIdMiddleware` generates `req-{ts}-{counter}`, stores it via `requestContextStorage.run`, and echoes `X-Request-Id`. Only **7 callsites** use `getRequestId` across `src/` (router, logger×2, api/middleware×2, context file×2) — **zero in `src/services/`**. Detached tasks (`queueMicrotask`, `setImmediate`, stream handlers) lose AsyncLocalStorage. DurableStream event payloads carry no `requestId`.
+- **Risk:** No correlation between an API request and the agent run, stream event, or DB write it triggered; when a 500 is reported, the trace chain is broken.
+- **Recommendation:** Add `requestId` to the logger context unconditionally; thread it as an explicit field on service calls that publish events; add a regression test asserting `X-Request-Id` appears in at least one downstream log line.
+- **Effort:** M.
+- **Links:** [`specs/release_plan/03-observability.md`](../release_plan/03-observability.md).
+
+### F07-06 — No OpenAPI schema; frontend types duplicate server types
+
+- **Priority:** P2
+- **Observation:** No `@hono/zod-openapi`, no swagger route, no `hc<AppType>` typed client. `src/lib/api/client.ts` is ~1,600 LOC of hand-typed wrappers; many use inline `apiServerFetch<{id:string;…}>` generics (marketplaces, terraform) instead of named types. Drizzle `$inferSelect` types are not reused for wire shapes.
+- **Risk:** Silent drift on server renames; onboarding requires editing both sides per endpoint.
+- **Recommendation:** Cheapest — move route Zod schemas to `validation.ts`, export `z.infer<>` types, import into the client. Richer — adopt `@hono/zod-openapi` and serve `/api/openapi.json`.
+- **Effort:** M / L.
+
+### F07-07 — Two route modules are oversized and mix concerns
+
+- **Priority:** P2
+- **Observation:** `events.ts` (1,168 LOC, 19 endpoints) hosts sources/subscriptions CRUD, log queries, the SSE stream, and inline auth helpers (`:7-11` defers splitting). `sandbox.ts` (1,341 LOC, 15 endpoints) covers K8s/Nomad/config CRUD, DNS validation, minikube start, CRD install, and credential encryption — overlapping `sandbox-k8s.ts` (680) and `sandbox-nomad.ts` (447).
+- **Risk:** Long review diffs; mixed concerns in one file; hard to extract tests.
+- **Recommendation:** Extract shared helpers (`getUserTeamIds` → `src/lib/rbac/team-scope.ts`, SSE → `events-stream.ts`, event-log → `events-log.ts`); for sandbox, move shared body schema and credential encryption to `src/lib/sandbox/config-schema.ts`.
+- **Effort:** M.
+- **Links:** parallels F01-07 in [`./01-service-architecture.md`](./01-service-architecture.md).
+
+### F07-08 — Zod validation usage is inconsistent
+
+- **Priority:** P2
+- **Observation:** ~17 modules use the canonical `parseJsonBody(c, schema)`. The rest call `c.req.json()` directly and cast (`cli-monitor.ts`, some `workflow-designer.ts` handlers, one `settings.ts` handler) or wrap in bespoke try/catch (`webhooks.ts:22-28` returns `INVALID_JSON`). Error codes vary: `INVALID_JSON`, `VALIDATION_ERROR`, `INVALID_PARAMS`, `MISSING_PARAMS`, `INVALID_ID`, `INVALID_STATE`, `CONFIG_ERROR`.
+- **Risk:** Inconsistent client error handling; Zod field messages (`issues[0]?.message`) dropped in some routes.
+- **Recommendation:** Mandate `parseJsonBody` via a Biome rule catching raw `c.req.json()`. Standardise on `VALIDATION_ERROR` with optional `details.issues` (the `ApiFailure` shape already supports `details`).
+- **Effort:** S.
+
+### F07-09 — Endpoint discoverability: no live index; docs stale
+
+- **Priority:** P3
+- **Observation:** `CLAUDE.md` lists "33 route modules, 60+ endpoints" — reality is 39 and ~240. No `/api/routes` or `/api/openapi.json`. Support and new contributors grep `src/server/routes/` to start a `curl` session.
+- **Risk:** Doc-code drift; security reviews miss endpoints.
+- **Recommendation:** Adopt `@hono/zod-openapi` (see F07-06) or add admin-only `GET /api/routes` that introspects Hono's `showRoutes()`; update CLAUDE.md count.
+- **Effort:** S.
+
+### F07-10 — `tags.ts` exports three factories for one data model
+
+- **Priority:** P3
+- **Observation:** `tags.ts` (413 LOC) ships `createTagsRoutes` (`/api/tags`), `createProjectTagRoutes` (`/api/codespaces/:id/tags`), and `createTaskTagRoutes` (`/api/tasks/:id/tags`) — three factories for the same model. `memory.ts` achieves similar scope variants with a single factory.
+- **Risk:** Three places to fix when tag rules change; URL-shape split masquerading as behaviour split.
+- **Recommendation:** Collapse to one factory exposing sub-routers per parent scope, or inline assoc routes into `codespaces.ts`/`tasks.ts`.
+- **Effort:** S.
+
+### F07-11 — No body-size cap; large JSON bodies parse before Zod rejects
+
+- **Priority:** P3
+- **Observation:** Bun's `c.req.json()` enforces no size cap by default. No route sets `maxBodyLength`; no global body-size middleware. Memory routes cap `content` at 4096 chars via Zod, but JSON is parsed in full before Zod runs.
+- **Risk:** Memory amplification via oversized JSON; slow handling under load.
+- **Recommendation:** Add body-size middleware under `/api/*` (reject `Content-Length > 1 MB` for most, higher cap for webhooks).
+- **Effort:** S.
+- **Links:** [`specs/release_plan/02-security-hardening.md`](../release_plan/02-security-hardening.md).
+
+### F07-12 — Mixed middleware-level vs handler-level RBAC
+
+- **Priority:** P3
+- **Observation:** Most routes use middleware role guards (`router.ts:324-390`). Team routes use handler-level `requireTeamRole` because the role depends on the `:id` param (AR-008 comment). The two styles coexist silently: a future dev writing `/api/codespaces/:id/members` can miss the check or duplicate it.
+- **Risk:** Missed or double authorisation; reviewer can't see the RBAC story for a route without opening the handler.
+- **Recommendation:** Add a `useScopedRoleGuard(app, '/api/teams/:id', 'viewer')` helper resolving per-resource role once; document the "middleware vs handler" decision matrix inline.
+- **Effort:** S.
+- **Links:** [`specs/application/security/rbac.md`](../application/security/rbac.md).
+
+## Cross-theme pointers
+
+- Rate limit, auth exemptions, and body-size caps intersect with [`specs/release_plan/02-security-hardening.md`](../release_plan/02-security-hardening.md).
+- Request-ID propagation and structured logging are the backbone of [`specs/release_plan/03-observability.md`](../release_plan/03-observability.md).
+- Pagination re-implementation should pair with [`specs/arch_review_april/02-data-layer.md`](./02-data-layer.md) (cursor-based queries need compound index support).
+- "Empty list masks error" mirrors error-bubbling gaps in [`specs/arch_review_april/03-agent-execution.md`](./03-agent-execution.md) F3.

--- a/specs/arch_review_april/08-frontend.md
+++ b/specs/arch_review_april/08-frontend.md
@@ -1,0 +1,111 @@
+# Frontend
+
+## Summary
+Stack: TanStack Start 1.167 + Router with `autoCodeSplitting`, TanStack DB, React 19 (`useEffectEvent`), Radix + Tailwind v4, Durable Streams. Shell wiring is good: root `errorComponent`, disciplined effect hooks, rAF-batched stream ingest, offset-based SSE resume, ref-counted shared EventSources. The prior readiness review (`specs/release_plan/08-frontend-readiness.md`) flagged 14 MB/484-chunk build, missing error boundaries on Kanban/designer/session-history, six `fallback={null}` sites, ~120 stray `console.*` calls, no global connectivity banner — **none shipped**; all five reproduce at HEAD. Design-token drift (`warning` classes as no-ops), hardcoded SVG hex, and an empty frontend test directory are new findings. No P0: the two `dangerouslySetInnerHTML` sites both consume Shiki-escaped output.
+
+## Map
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| Router root | `src/app/routes/__root.tsx`, `src/app/router.tsx` | `createRootRouteWithContext`, `defaultPendingMs: 200`, `defaultPreload: 'intent'`, `RootErrorComponent` |
+| Routes | `src/app/routes/*.tsx` (21 files) + nested codespaces/settings/sessions/events/folders/templates/terraform/catalog | File-based, auto code-split |
+| UI primitives | `src/app/components/ui/*.tsx` (23 files) | Radix wrappers + CVA variants |
+| Feature modules | `src/app/components/features/*` (~19) | Kanban, workflow designer, topology, session views, terraform, CLI monitor, memory |
+| Hooks | `src/app/hooks/*.ts` (23 files) | `use-session`, `use-session-subscription` (ref-counted SSE), `use-topology-stream`, effect factories |
+| Stream client | `src/lib/streams/{client,caddy-producer,envelope}.ts` | Exponential backoff, fatal-error classification, Zod validation, offset resume |
+| Styling | `src/app/styles/globals.css` + `@tailwindcss/vite` | Light/dark CSS vars; tokens: accent/success/danger/attention/done/secondary/claude |
+| Build | `vite.config.ts` | TanStack Router plugin + custom `serverOnlyStubs()` to keep Node modules out of the browser bundle |
+| Markdown / code | `ui/markdown-content.tsx`, `terraform/terraform-right-panel.tsx` | `react-markdown` + Shiki (dynamic import), both feed `dangerouslySetInnerHTML` |
+
+## What's working
+- Root `errorComponent` + `notFoundComponent` catch what the three component boundaries (`TopologyErrorBoundary`, `CliMonitorErrorBoundary`, `MemoryTabErrorBoundary`) miss.
+- `DurableStreamsClient` fatal/non-fatal classification: NOT_FOUND pre-connect non-fatal; `ALREADY_CONSUMED` stops retries; Zod validates events.
+- `useSessionSubscription` ref-counts shared EventSources (FC-006). `useSession` rAF-batches flushes, caps `chunks` at `MAX_CHUNKS=5000`, and `seenEventIdsRef` dedupes on reconnect.
+- `useEffectEvent` (React 19) stabilises callbacks without the classic "empty deps + ref" hack.
+- `serverOnlyStubs()` cleanly keeps `better-sqlite3` and Claude Agent SDK out of the browser build.
+- `use-session.ts` FC-020 comment documents the explicit choice to skip TanStack Query.
+- Radix primitives deliver accessibility for free on dialogs / toasts / selects.
+
+## Findings
+
+### F08-01: Every prior readiness critical is still open
+- **Priority**: P1
+- **Observation**: `specs/release_plan/08-frontend-readiness.md` C1-C5 all reproduce at HEAD. `fallback={null}` in six sites (`routes/index.tsx:511`, `codespaces/index.tsx:477`, `codespaces/$codespaceId/index.tsx:467`, `workflow-designer/index.tsx:599`, `live-task-view/index.tsx:249`, `global-shortcuts.tsx:387`). 229 `console.*` calls across 62 `src/app` files. Only three component error boundaries. `ui/connection-status-banner.tsx` exists but is never mounted.
+- **Risk**: Kanban render crash still wipes the route tree; blank panels on lazy-load; API outages produce inconsistent per-view errors.
+- **Recommendation**: One PR: wrap Kanban / WorkflowDesigner / SessionHistory in boundaries, replace `fallback={null}` with skeletons, mount `ConnectionStatusBanner` at `__root.tsx`, strip `console.debug/log` via Vite define. Close the readiness doc.
+
+### F08-02: Frontend test directory is empty
+- **Priority**: P1
+- **Observation**: `find src/app -name "*.test.*"` returns zero results. No component, hook, or route-loader tests. The `apiServerFetch<T>` double-wrap bug has a server-side test but 40+ frontend consumers have none. `use-session` rAF batching, seen-event dedupe, SSE reconnect state, Kanban DnD reorder, plan-approval transitions are all UI-untested.
+- **Risk**: Regressions land silently. Refactors to `use-session.ts` or `DurableStreamsClient` can break streaming without a CI signal.
+- **Recommendation**: Stand up Vitest + `@testing-library/react` + `jsdom`. Seed three tests: (a) `use-session` dedupe across reconnect, (b) flat-array shape of `apiClient.sessions.listEvents()`, (c) `TopologyErrorBoundary` recovers. Add `src/app` to the 3-way Vitest shard split.
+
+### F08-03: `warning` Tailwind classes are silent no-ops
+- **Priority**: P2
+- **Observation**: `globals.css` defines `--attention-*` but no `--warning-*`. Yet `bg-warning`, `text-warning`, `border-warning`, `bg-warning-muted`, `text-warning-fg` are used in 11+ files on hot paths: `container-agent-panel/container-agent-stream.tsx`, `container-agent-header.tsx` (status badge + reconnecting icon), `agent-session-view/{header-bar,stream-line,activity-sidebar,stream-panel}.tsx`, `folder-rail/index.tsx:207`, `new-project-dialog.tsx:1450-1454`, `project-settings.tsx:424-427`. CLAUDE.md explicitly says "design system uses `attention` not `warning`".
+- **Risk**: Paused / cancelled / reconnecting states render invisibly — users can't see that an agent is paused or a connection degraded.
+- **Recommendation**: Codemod `warning` -> `attention`; add a Biome rule forbidding `\b(bg|text|border)-warning\b`. Visually QA `agent-session-view/*`.
+
+### F08-04: Hardcoded SVG hex colours violate the theme contract
+- **Priority**: P2
+- **Observation**: CLAUDE.md bans hex in SVG. 40+ violations: `settings-sidebar.tsx:159-207`, `sidebar.tsx:289`, `folder-rail/index.tsx:104-150`, `terraform/terraform-dependency-edge.tsx`, `agent-topology/edges/agent-edge-markers.tsx`, `ai-action-button.tsx:64-83`. Most are GitHub dark-palette literals that look right in dark mode, wrong in light.
+- **Risk**: Sidebar / folder rail / topology edges jar in light theme; palette changes need grep-and-replace instead of token edits.
+- **Recommendation**: Replace with `var(--{accent,done,success,secondary,attention}-emphasis)`. Extend the Biome rule from F08-03 to flag hex inside `.tsx` under `src/app/components/**`.
+
+### F08-05: Shiki v4 language loading strategy needs runtime verification
+- **Priority**: P2
+- **Observation**: PR #160 upgraded Shiki v3 -> v4. `markdown-content.tsx:13` and `terraform-right-panel.tsx:131` both call `import('shiki')` at module scope — triggers on module evaluation, not first use. Readiness doc saw `emacs-lisp` (780 KB), `cpp` (626 KB), `wasm` (622 KB) chunks in `dist/`; whether they are eager-preloaded or lazy on `codeToHtml` depends on v4 internals and needs confirming.
+- **Risk**: If preloaded, 1.4 MB+ of unused grammars on first code-block render.
+- **Recommendation**: Check Network tab on a cold markdown render. If eager, switch to `createHighlighter({ langs: [...] })` with an allowlist (typescript, javascript, json, yaml, hcl, markdown, python, bash). Move the `import('shiki')` inside `MarkdownCodeBlock`'s effect so markdown-without-code doesn't touch Shiki.
+
+### F08-06: `elk.bundled` (1.45 MB) lazy only for topology; check workflow designer
+- **Priority**: P2
+- **Observation**: `AgentTopologyInner` is `React.lazy()` — correct. Workflow designer (`features/workflow-designer/index.tsx`) is not lazy and uses React Flow; if it transitively imports `elkjs`, the 1.45 MB chunk becomes eager on that route. `vite.config.ts` also lists `elkjs/lib/elk.bundled.js` in `optimizeDeps.include`.
+- **Risk**: 1.45 MB mandatory download on first visit to the designer route.
+- **Recommendation**: Run `rollup-plugin-visualizer` to confirm import edges. If designer imports `elkjs`, wrap its graph in `React.lazy`. Drop `elkjs/lib/elk.bundled.js` from `optimizeDeps.include` unless dev cold-start regresses.
+
+### F08-07: Stream event contract is stringly-typed on the client
+- **Priority**: P2
+- **Observation**: `DurableStreamsClient` returns Zod-validated events, but `use-session.ts` / `use-topology-stream.ts` / `use-container-agent.ts` branch on `event.type === 'agent:completed'` with no exhaustive union check. If the server renames an event type (has happened with task columns), the client silently no-ops. No shared `StreamEvent` discriminated union covers both sides.
+- **Risk**: Event-schema drift between `stream-handler.ts` and client hooks — silent-drop.
+- **Recommendation**: Define the event union once in a shared module; backend uses `satisfies StreamEvent`, clients use a `switch` with `never` exhaustive check.
+
+### F08-08: Two `dangerouslySetInnerHTML` sites — Shiki, safe today but no defence in depth
+- **Priority**: P2
+- **Observation**: Audit returned exactly two: `ui/markdown-content.tsx:82` and `terraform/terraform-right-panel.tsx:242`. Both pass Shiki `codeToHtml` output with biome-ignore comments citing Shiki's escape guarantee — which is why P2 not P0. But both sinks carry user-derived content (agent markdown, generated HCL, task descriptions). A Shiki CVE, transformer plugin change, or highlighter migration reopens the risk silently.
+- **Risk**: Zero-day XSS if Shiki escaping regresses; invisible foot-gun for future refactors.
+- **Recommendation**: Add a `sanitizeShikiHtml(html)` helper (DOMPurify with an allowlist of `pre`/`code`/`span`) and call at both sites. Redundant today, defensive forever.
+
+### F08-09: No per-route `errorComponent` — route crash unmounts the shell
+- **Priority**: P2
+- **Observation**: `__root.tsx` has `errorComponent: RootErrorComponent`. No per-route `errorComponent` anywhere in `src/app/routes/`. TanStack Router supports them; today a thrown error in e.g. `codespaces/$codespaceId/git.tsx` unmounts the whole shell.
+- **Risk**: Users lose nav context on a single failed fetch.
+- **Recommendation**: Add `errorComponent` to the top routes (codespaces detail/list, sessions detail, terraform, designer, memory) via a shared `RouteErrorBoundary`.
+
+### F08-10: State-management stack is three layers with no documented boundary
+- **Priority**: P3
+- **Observation**: TanStack DB is a core dep, but grep finds **one** consumer: `use-sandbox-status.ts`. Everything else is `useState`/`useReducer` (835 uses across 144 files) + manual `apiClient.*` fetches. `use-session.ts` FC-020 documents skipping TanStack Query, but no guidance exists for when to pick which of the three effective tiers.
+- **Risk**: Future features pick different stacks; consolidation later is expensive.
+- **Recommendation**: Either commit to TanStack DB for reactive lists (tasks, codespaces, agents) or drop it. Document the tiers in `specs/application/implementation/state-management.md`.
+
+### F08-11: `apiServerFetch<T>` double-wrap has a test server-side but nothing on the client
+- **Priority**: P3
+- **Observation**: CLAUDE.md documents the trap ("`T` must match the `data` field value, NOT the full response"). A future caller writing `apiServerFetch<{ ok: true; data: Task[] }>` compiles, runs, and returns `undefined.data` at runtime. No lint rule catches it and the client has no test.
+- **Risk**: Re-introduction of the exact bug the CLAUDE.md lesson exists to prevent.
+- **Recommendation**: Rename the wrapper to `apiServerFetchData<T>` (codemod) so `T` is unambiguous; or add a Biome / ts-morph check that rejects `{ ok: ...; data: ... }` as the type argument to `apiServerFetch`.
+
+### F08-12: Provider ordering in `__root.tsx` is load-bearing but undocumented
+- **Priority**: P3
+- **Observation**: `RootComponent` nests `ShortcutsProvider -> FolderContextProvider -> CodespaceContextProvider -> TooltipProvider`. `GlobalShortcutsWithPicker` renders outside `CodespaceContextProvider`. No comment or test explains the ordering constraints; future additions will be inserted at the wrong level.
+- **Risk**: "undefined is not a function" on provider hooks when new context is added out of order.
+- **Recommendation**: Collapse into a single `AppProviders` component with a block comment describing ordering, covered by a lightweight render-without-throwing smoke test.
+
+### F08-13: HMR cold-start of 235+ modules is developer-hours friction
+- **Priority**: P3
+- **Observation**: CLAUDE.md calls the `[Violation] 'message' handler took Nms` noise dev-only; root cause is heavy named imports (dnd-kit, React Flow, Shiki, Phosphor, Radix, react-markdown) combined with `optimizeDeps.include` pre-bundling only three packages.
+- **Risk**: Not user-facing, but significant productivity drag.
+- **Recommendation**: Add top frontend deps (Phosphor, Radix, react-markdown, dnd-kit) to `optimizeDeps.include`; measure with `DEBUG=vite:deps`.
+
+## Cross-refs
+- Remediation status should roll back into `specs/release_plan/08-frontend-readiness.md`.
+- Token findings (F08-03/F08-04) overlap `specs/application/implementation/component-patterns.md`.
+- Event drift (F08-07) connects to `specs/arch_review_april/05-events.md`; tests (F08-02) to `09-testing.md`.

--- a/specs/arch_review_april/09-testing.md
+++ b/specs/arch_review_april/09-testing.md
@@ -1,0 +1,115 @@
+# Testing
+
+## Summary
+Runner: Vitest 4.1.4, five projects (`unit` / `jsdom` / `db` / `integration` / `functional`), CI-sharded 3-way for `unit+jsdom+db` and 2-way for `integration+functional`. Stryker 9.6.1 is wired on state-machines + RBAC only; fast-check 4.7.0 is installed but used in two files. Disk count: **158 integration files, 6 functional files, 26 `route-*.test.ts`, 342 Vitest-project files + 20 Playwright/agent-browser E2E**. Prior readiness (`specs/release_plan/01-test-suite-health.md`, 2026-03-28) logged 7,328 passing / 0 failing at ~67 s; still broadly true after #156 (coverage uplift) and #161 (integration-cache fix). Material gaps: (a) 40 of 42 Drizzle tables have no schema-drift guard, (b) Stryker scope is 6 files so everything else leans on line coverage, (c) `src/app/**` has zero tests (cross-link `08-frontend.md` F08-02). No P0.
+
+## Map
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| Config | `vitest.config.ts`, `vitest.e2e.config.ts`, `stryker.config.json` | Five-project split; e2e `maxWorkers: 1` |
+| CI | `.github/workflows/ci.yml`, `mutation-testing.yml` | 3-shard main, 2-shard integration, weekly Stryker |
+| Schema drift | `tests/integration/{agents,session}-schema-drift.test.ts`, `scripts/check-schema-drift.ts` | 2 of 42 tables |
+| Factories | `tests/factories/*.factory.ts` | 7 entities — no RBAC/skill/workflow/template/settings |
+| Unit | `tests/lib/**`, `tests/mocks/**`, `tests/routes/**`, `src/**/__tests__/**` | Threads pool |
+| jsdom | `tests/components/**`, `tests/hooks/**`, `**/*.test.tsx` | Zero matches under `src/app/**` |
+| db | `tests/services/**`, `tests/api/**`, `tests/server/**`, `tests/db/**` | Forks (SQLite PRAGMA isolation) |
+| Integration | `tests/integration/**` (158 files) | Hono route + service + SQLite |
+| Functional | `tests/functional/**` (6 files, ~80 tests) | Real-service lifecycle |
+| E2E | `tests/e2e/**` + `K8S_E2E=true` | `.skipIf(!serverRunning)` |
+| Property | `src/lib/state-machines/__tests__/{state-machines.property,task-workflow.model}.test.ts` | Only 2 fast-check files |
+| Mutation | `mutate:state-machines`, `mutate:rbac`, `mutate:incremental` | Scope ~6 files, thresholds 90/80/75 |
+
+## What's working
+- Five-project topology is deliberate: forks for DB (SQLite PRAGMA isolation), threads for pure code. Integration is a separate CI job gated on `[test, lint-and-typecheck, build, semgrep]`.
+- Functional tests honour the contract: `task-lifecycle-e2e.test.ts` drives the full task lifecycle through real service methods, mocking only Claude SDK / sandbox / git / DurableStreams.
+- Schema-drift fast-fails in `lint-and-typecheck` via `scripts/check-schema-drift.ts` before any shard boots.
+- Stryker is incremental (cached), typescript-checked, thresholds real (break=75), runs per PR on touch + weekdays 04:00 UTC.
+- Factory discipline: seven factories funnel through `tests/helpers/database.ts` — one idiom, not N.
+- RBAC is best-covered: 12 test files across service unit + middleware + route integration + cross-service + token-ceiling + tag-access + role-resolution.
+- No `.only` leaks on `main`.
+
+## Findings
+
+### F09-01: Schema-drift coverage is 2 of 42 tables
+- **Priority**: P1
+- **Observation**: Drizzle defines 88 `sqliteTable` / `pgTable` declarations across `src/db/schema/` (42 logical tables × 2 dialects). Only `agents` and `sessions` have runtime drift tests. `tasks`, `worktrees`, `codespaces`, `sandboxInstances`, `sessionEvents`, `settings`, `teams`, `api_keys`, `rbac_tokens`, `workflows`, `skills`, `templates`, `github_tokens`, `plan_sessions`, `webhooks`, `schedules` — no drift guard.
+- **Risk**: The very bug class CLAUDE.md's "Preventing Regressions" section calls out is caught on 2 of 42 tables. Drift on `sandboxInstances` (sandbox ID consistency) or `sessionEvents` (no FK on `sessionId`) ships green.
+- **Recommendation**: Factor the existing test into a parameterised helper iterating `src/db/schema/index.ts` exports. One file, 42 assertions. Cross-link `02-data-layer.md`.
+
+### F09-02: Frontend project is zero-tests
+- **Priority**: P1
+- **Observation**: `find src/app -name "*.test.*"` returns 0. The `jsdom` `include` pattern has no `src/app/**` matches. 81 tests live under `src/**/__tests__/` — zero under `src/app/**`. 40+ components use `apiServerFetch<T>` with no UI-layer guard that `T` maps to `data`, not the envelope.
+- **Risk**: Silent regressions in `use-session` (rAF batching, seen-event dedupe), `DurableStreamsClient` reconnect, Kanban DnD, plan approval. CLAUDE.md cites `tests/api/sessions.test.ts` for the double-wrap bug — but that's a server test; a client change bypasses it.
+- **Recommendation**: Seed three jsdom tests: session dedupe across reconnect; `apiClient.sessions.listEvents()` returns flat array; `TopologyErrorBoundary` recovers. Don't chase parity. Cross-link `08-frontend.md` F08-02.
+
+### F09-03: Functional tests mix real-service flow with raw DB writes
+- **Priority**: P1
+- **Observation**: CLAUDE.md §"Functional Tests: Real Service Transitions" bans simulating transitions with raw DB updates. Violations: `prove-plan-approval-bugs.test.ts:330` (`db.update(tasks).set({ lastAgentStatus })`), `prove-task-service-bugs.test.ts:286,383` (raw session insert + lastAgentStatus), `state-guard-vulnerabilities.test.ts:306` (same), `prove-session-worktree-bugs.test.ts` (raw worktree inserts, session deletes).
+- **Risk**: Arrange-phase shortcuts bypass the orchestration being tested. Guards inside `updateTaskOnAgentComplete` go uncovered in the exact scenarios `prove-*` was written to expose.
+- **Recommendation**: Route preconditions through services where an API path exists; annotate `// intentional: no API path` for real out-of-band corruption tests. Add a CI grep rule against `db\.(update|insert|delete)` in `tests/functional/` that requires the comment.
+
+### F09-04: Stryker coverage is 6 files; ~400 source files rely on line coverage
+- **Priority**: P1
+- **Observation**: `stryker.config.json` mutates only state-machines + `rbac{,-token}.service.ts` + `{auth,rbac}-middleware.ts`. Agent execution (`agent-execution.service.ts`, `stream-handler.ts`, `container-agent/*`), sandbox providers, `src/lib/crypto/*`, skill-injection shell-escaping helpers — all unmutated.
+- **Risk**: A branch-deleting mutant (`if (!token) return` → `if (true) return`) in `github-token.service.ts` ships green. Semgrep covers some patterns but doesn't replace mutation scoring on crypto round-trip or FK-cascade invariants.
+- **Recommendation**: Expand scope incrementally — one critical service per sprint, starting with `src/lib/crypto/` and `github-token.service.ts`. Add `mutate:crypto` + `mutate:agent-execution` scripts with `continue-on-error: true` until baseline, then promote to blocking.
+
+### F09-05: fast-check installed but used in 2 files
+- **Priority**: P2
+- **Observation**: `fast-check@4.7.0` pinned. Uses: `state-machines.property.test.ts` + `task-workflow.model.test.ts`. Obvious candidates use hand-rolled example tables: `session-event-validation.test.ts` (Zod), `terraform-parsers.test.ts` (HCL round-trip), `crypto.test.ts` (encrypt→decrypt identity), skill-id validator, `path-safety.test.ts`, `streams-client-parsing.test.ts`.
+- **Risk**: Corner-case input classes (Unicode skill IDs, empty SSE chunks, CRLF/BOM HCL) stay unexplored.
+- **Recommendation**: Convert 3 targets — crypto round-trip, Zod event validator, skill-ID validator — to properties. Goal: 6–8 property files by quarter end.
+
+### F09-06: E2E has 20 files but no full task-lifecycle scenario
+- **Priority**: P2
+- **Observation**: Top-level E2E files: `smoke`, `agent-session`, `kanban-workflow`, `project-workflow`, `workflow`, `topology-subagent`. `kanban-workflow` covers column moves; `agent-session` covers session rendering — neither drives backlog→planning→approval→execution→verified end-to-end. Terraform compose, team mode (`launchSwarm`), workflow designer, webhook-triggered tasks, RBAC-token scope denial — no E2E.
+- **Risk**: UI-only regressions (e.g. plan approval dialog dropping `phase: 'execute'`) ship without signal. Functional covers the service contract; E2E must cover the human contract.
+- **Recommendation**: One E2E per user story: (1) task happy path backlog→verified, (2) plan reject→revise, (3) team mode spawn, (4) terraform compose, (5) webhook task creation, (6) RBAC token denial. Keep `skipIf(!serverRunning)`.
+
+### F09-07: Integration shard balance is unverified
+- **Priority**: P2
+- **Observation**: `integration+functional` is 2-way sharded with no timing artefact and no `slowTestThreshold` reporter. 158 files, 26 heavy `route-*.test.ts` on 30 s timeouts; hash-based sharding is deterministic per filename so uneven allocation caps critical-path wall clock.
+- **Risk**: Silent CI wall-clock creep as new files land unbalanced.
+- **Recommendation**: `--reporter=junit` + per-file timing on the integration job, upload as artefact. Consider splitting into `integration-route` (forks, slow) and `integration-service` (threads, fast).
+
+### F09-08: Coverage threshold exists but coverage tooling has been broken
+- **Priority**: P2
+- **Observation**: `vitest.config.ts` declares 50 % thresholds with v8. Prior readiness (2026-03-28) documented `BaseCoverageProvider` export missing in vitest 4.0.16. Current pins: vitest 4.1.4 + `@vitest/coverage-v8@4.1.4`, but CI never runs `test:coverage` — the upgrade is unverified.
+- **Risk**: Threshold is theoretical; a delete that drops lines below 50 % fires no signal.
+- **Recommendation**: Non-blocking `coverage` job running `bun vitest run --coverage --reporter=text-summary`, upload lcov.info. After two green weeks flip to hard gate.
+
+### F09-09: No retry / no flake detection
+- **Priority**: P2
+- **Observation**: Zero `retry:` in configs, no quarantine list. `concurrency-*.test.ts` (3 files) + `transaction-{atomicity,cascade}.test.ts` test real timing races with no instrumentation to distinguish flake from bug.
+- **Risk**: Flakes get `it.skip`'d (dead weight) or trained-around via `gh run rerun`, masking intermittent real bugs.
+- **Recommendation**: Keep `retry: 0`. Nightly job runs `integration+functional` 5× sequentially, count non-deterministic failures into `FLAKY_TESTS.md`. >2 weeks unfixed → quarantine with linked issue.
+
+### F09-10: Integration-cache regression (#161) had no post-mortem test
+- **Priority**: P2
+- **Observation**: `install` job caches on `hashFiles('**/bun.lock', '**/package.json')`; a stale hit against a lockfile mismatch was the #161 mode. No test asserts the test DB reflects current Drizzle schema; `--frozen-lockfile` catches structural mismatch, not logical drift in `agent-runner/bun.lock` (separate CLAUDE.md note).
+- **Risk**: Same class of cache-mismatch recurs on a different keying vector.
+- **Recommendation**: Micro-test asserting `drizzle-kit check` clean; bump `CACHE_VERSION` on migration-set changes via a PR-check script, not human habit.
+
+### F09-11: Mock strategy mixed; no `vi.mock` lint guard
+- **Priority**: P2
+- **Observation**: Functional follows "real services + I/O mocks" well. Service unit + integration mix module `vi.mock`, DI fakes, direct imports. Nothing prevents `vi.mock('drizzle-orm')`, which silently defeats DB guarantees. Per-file `exclude` overrides in `vitest.config.ts` re-route `git-token-resolver.test.ts` / `container-bridge.test.ts` to the `db` project — correct but hidden.
+- **Risk**: A DB-touching test lands in `tests/lib/`, mocks the client, ships green; production path uncovered.
+- **Recommendation**: Document project rules in `tests/AGENTS.md`. Semgrep rule: `vi.mock('drizzle-orm'|'better-sqlite3'|'@/db/client')` = ERROR in integration/functional. Move excluded files into `tests/integration/`.
+
+### F09-12: `vitest.ai-ui.config.ts` is not in CI
+- **Priority**: P3
+- **Observation**: Separate AI-UI config + `tests/ai-ui-tests/` not referenced in `ci.yml`. Manual via `bun scripts/run-ui-tests.ts`. No schedule.
+- **Risk**: AI-UI regressions invisible; contributors reading CI assume coverage doesn't exist.
+- **Recommendation**: Add `workflow_dispatch` + weekly cron, or document the local-only intent in `tests/AGENTS.md`.
+
+### F09-13: Factories cover 7 entities; 5 obvious ones missing
+- **Priority**: P3
+- **Observation**: Factories exist for agent/agent-run/event-source/project/session/task/worktree. Tests needing RBAC roles, skills, workflows, templates, settings, team-memberships, sandbox configs build inline via `db.insert(...)`.
+- **Risk**: Duplication across ~30 files; enables F09-03 by offering no service-aligned arrange helpers.
+- **Recommendation**: Add `rbac-token`, `skill`, `workflow`, `template`, `settings` factories. Wire through `tests/factories/index.ts`.
+
+## Cross-references
+- Prior state: `specs/release_plan/01-test-suite-health.md`
+- Frontend zero-tests: `specs/arch_review_april/08-frontend.md` F08-02
+- Schema context: `specs/arch_review_april/02-data-layer.md`
+- CLAUDE.md §"Functional Tests: Real Service Transitions", §"Preventing Regressions: Lessons Learned"

--- a/specs/arch_review_april/10-observability.md
+++ b/specs/arch_review_april/10-observability.md
@@ -1,0 +1,174 @@
+# Arch Review — 10: Observability
+
+Theme: logging, metrics, tracing, error bubbling, request-ID propagation, silent catches, health checks, dashboards, alerting, audit logs.
+
+## Summary
+
+Observability is the theme where the distance between "looks reasonable in code review" and "works during a real production incident" is largest. AgentPane has done the hard floor work — a structured JSON logger with sensitive-data masking, `AsyncLocalStorage`-propagated request IDs, Hono request middleware, a comprehensive `/api/health` endpoint with database / GitHub / sandbox / K8s / streams / API-key / init checks, liveness and readiness probes, `GracefulShutdown` with LIFO cleanup, and state-machine transition instrumentation. The prior `specs/release_plan/03-observability.md` pass (March 2026) closed the P0 items it opened: `maskSensitiveData()` is now live in `src/lib/logging/logger.ts:62`, the 50+ silent catch blocks have been largely filled with `log.warn`/`log.debug` calls (item 2 DONE), service-name and environment are stamped on every entry, and 231 call sites across 118 files now use `createLogger`. This is not a regressing system.
+
+What is still missing is everything past the floor. There is no `/metrics` endpoint of any kind — not Prometheus, not a JSON counter endpoint. There is no tracing: `AsyncLocalStorage` threads a `requestId` string, but nothing propagates spans across the HTTP → service → SDK → container-bridge → durable-stream boundary that defines the hot path of the product, so a flaky agent run from a stuck tool cannot be reconstructed without grepping logs by timestamp. No Sentry, no Datadog, no PagerDuty — `uncaughtException` logs to stdout and dies; `invariant()` violations in production log and continue. Frontend observability is effectively zero: 241 `console.*` occurrences across 70 files (close to the F08-02 count of 229/62) never leave the browser. Agent-runner emits 79 `console.*` calls across 3 files; those events reach the host as raw stdout lines parsed by `container-bridge.ts`, not as structured log records. The `droppedEventCount` counter on `PlanModeService` exposes a getter nobody reads. Background jobs — scheduler tick, event-cleanup, plan expiry, sandbox state reconciliation, presence heartbeat — log on failure but emit no heartbeat metric, so a silently-wedged scheduler is invisible.
+
+Also: the request ID reaches the logger via `AsyncLocalStorage` but is not attached to outbound boundaries — the Claude SDK call, the Dockerode request, the `@kubernetes/client-node` call, the durable-streams publish — so when the SDK or sandbox misbehaves, correlating "which HTTP request started this" requires manual timestamp triangulation. The `audit_logs` table is defined and hook code exists at `src/lib/agents/hooks/audit.ts`, but coverage outside agent hooks is partial.
+
+This file consolidates the prior release-plan items against their current status, then adds findings for problems that become visible only when you ask operational questions the release plan didn't.
+
+## Map
+
+- **Logger.** `src/lib/logging/logger.ts` (248 lines) — `createLogger(context)`, `debug/info/warn/error`, `maskSensitiveData()` recursive redaction (field-name and value-pattern), JSON in prod / human-readable in dev, `LOG_LEVEL` env override with validation.
+- **Request context.** `src/lib/context/request-context.ts` — `AsyncLocalStorage<RequestContext>` with `getRequestId()` helper.
+- **Request-ID middleware.** `src/server/router.ts:91-97` — reads `x-request-id`, generates otherwise, sets Hono context var, stamps response header, binds `AsyncLocalStorage` for the chain. Mounted at `app.use('*', requestIdMiddleware)` (line 248).
+- **HTTP access log.** Hono's `logger()` middleware in the router — method/path/status, no latency, no requestId.
+- **Global error handler.** `app.onError()` in `src/server/router.ts:558-565` — logs with requestId and error; sanitizes message in non-dev.
+- **Process handlers.** `uncaughtException` and `unhandledRejection` in `src/server/api.ts` route to the structured logger.
+- **Health.** `src/server/routes/health.ts` (286 lines) — `/api/health` (7 subsystem checks, latency, uptime, responseTimeMs), `/api/health/liveness`, `/api/health/readiness`.
+- **State machine telemetry.** `src/lib/state-machines/instrumented-machine.ts` — wraps `send()` to log transitions with duration-in-state and guard failures.
+- **Plan-mode drop counter.** `src/services/plan-mode.service.ts:67,114` — `droppedEventCount` field + `getMetrics()` getter, 13 increment sites, zero consumers.
+- **Agent-runner logs.** `agent-runner/src/event-emitter.ts` — JSON-line events on stdout with explicit flush; `agent-runner/src/index.ts` additionally uses 57 raw `console.*` calls. Parsed on the host by the container bridge.
+- **Audit logs.** `audit_logs` table (SQLite + PG schemas in `src/db/schema/{sqlite,postgres}/audit-logs.ts`), writer in `src/lib/agents/hooks/audit.ts`.
+- **No endpoint for metrics.** Searched `src/server` for `/metrics` or Prometheus — no hits.
+
+## What's working
+
+- **The logger is the right shape.** JSON in prod, correlation IDs from `AsyncLocalStorage`, circular-safe recursive masking with depth limit (10), value-pattern redaction for `sk-ant-*`, `ghp_*`, `ghs_*`, `gho_*`, `github_pat_*`, invalid-`LOG_LEVEL` warning with fallback. 18 tests guard the mask function.
+- **Widespread adoption.** `createLogger` is imported in 118 files (231 occurrences), so new features inherit correlation and masking for free — the adoption problem the prior review opened with is solved.
+- **Health is production-grade.** `/api/health` covers DB + DB-version detection + GitHub token + sandbox provider + K8s provider + durable streams reachability + API-key presence + sandbox init status, with a `responseTimeMs` field. `readiness` returns 503 on DB failure — correct K8s probe semantics.
+- **Request-ID middleware is correct.** Accepts a client-provided `x-request-id` (for upstream propagation), generates a fresh ID otherwise, echoes it on the response, and binds it via `AsyncLocalStorage` before calling `next()` — no threading, no footguns.
+- **Graceful shutdown.** `src/server/bootstrap/shutdown.ts` with LIFO cleanup and a 30s safety timeout; prevents half-flushed event state during SIGTERM.
+- **State machine instrumentation.** Transition timing is already logged for agent/task/session/worktree — the data to compute cycle-time percentiles is in the log stream; it just isn't counted.
+- **Prior P0 items closed.** Masking (item 1), silent-catch fixes (item 2, 47+ blocks), `console.*` audit (item 3), service/environment fields (item 4) — all DONE per the tracker, and the code matches.
+
+## Prior-review disposition
+
+| Prior item (`release_plan/03-observability.md`) | Status | Notes |
+|---|---|---|
+| Sensitive data masking in logger | **Resolved** | `maskSensitiveData()` in `logger.ts:62`, 18 tests. |
+| Fix silent catch blocks (50+) | **Partially resolved** | 47+ instances logged (commit 3d7806f). Current grep still shows empty `catch`/`catch (_...)` patterns across 168 files in the broader codebase; the "loud" ones are gone but the frontend tail remains. See F10-02. |
+| Replace `console.*` with structured logger | **Resolved for server** | Server side down to 2 instances at the time of the fix. Agent-runner (79 instances) and frontend (241 instances) are explicitly excluded and still raw. See F10-05 and F10-07. |
+| Add `service`/`environment` fields | **Resolved** | Stamped on every entry. |
+| `/api/metrics` endpoint | **Still open** | No metrics endpoint of any kind. See F10-01. |
+| Sentry / error reporting | **Still open** | No integration. See F10-04. |
+| Pino migration | **Still open, downgraded** | The current logger is not a bottleneck at current traffic; defer until throughput warrants. |
+| Prometheus `prom-client` | **Still open** | Follows F10-01. |
+| OpenTelemetry tracing | **Still open** | See F10-03. |
+| Grafana dashboards | **Still open, downgraded** | Depends on metrics + tracing. Out of scope until those exist. |
+| Alerting rules | **Still open, downgraded** | Depends on backend. |
+
+## Findings
+
+### F10-01 — No `/metrics` endpoint at all
+
+- **Priority:** P1
+- **Observation:** There is no Prometheus scrape endpoint and no JSON counter endpoint. No per-route request counts, no histogram for HTTP latency, no agent-start/complete/error counters, no task state-transition counters, no tool-execution counters, no Claude API token usage, no active-SSE gauge, no DB query latency histogram, no DB pool size. The `instrumented-machine.ts` transition telemetry goes to logs but is never aggregated. Every operational question past "is it up" requires grepping JSON.
+- **Risk:** You cannot define or measure an SLO. You cannot set an alert on "agent error rate > 10% over 5 min" because nothing counts. In an incident, mean-time-to-detect is bounded below by whoever notices the UI is broken.
+- **Recommendation:** Start with the minimum viable endpoint — `GET /api/admin/metrics` returning JSON counters maintained in memory: request count by route + status class, agent starts/completes/errors, active-agents gauge, SSE connection count (feeds F05-03), dropped-event counter (feeds F05-02), DB latency histogram (simple bucket map), sandbox-create success/failure. One file, no new dependency. Layer `prom-client` on top once the shape is known and a scraper exists. Wire `instrumented-machine.ts` to emit transition counters at each `send()`.
+- **Effort:** S (1–2 days) for the JSON endpoint; M (3–5 days) for the full Prometheus surface.
+- **Links:** prior item #5 and #8; `src/lib/state-machines/instrumented-machine.ts`.
+
+### F10-02 — Silent-catch tail across 78 server files and 168 occurrences
+
+- **Priority:** P2
+- **Observation:** A grep for `catch {` across `src/` returns 168 hits across 78 files, and `catch (_` returns 31 more. The prior review's 47+ fixes targeted the loudest services (`plan-mode`, `workflow`, `cli-monitor`, `terraform-compose`). What remains concentrates in route handlers (`routes/sandbox.ts` 7, `routes/memory.ts` 5, `settings/github.tsx` 5), bootstrap (`heal-intervals.ts` 5), and provider contexts (`folder-context.tsx` 7, `memory-context.tsx` 14). Many of these are likely "best-effort cleanup" — the pattern is correct; what's missing is the `log.debug` or `log.warn` breadcrumb that would tell you the cleanup *happened*.
+- **Risk:** A UI that silently fails to save a setting or a sandbox heal-loop that silently skips a cycle looks healthy from the outside. Debugging requires the user to reproduce.
+- **Recommendation:** Biome's `noEmptyBlockStatements` is already on in this repo — CLAUDE.md notes this. The remaining hits are `catch (_err) { /* ignore */ }` patterns where the block contains a comment, which defeats the lint. Promote a stricter custom rule that forbids bare `catch (_...)` unless it ends in a call to `log.*` or `throw` or `return`. Do this as a sweep against the 31 `catch (_` instances first — those are cheap wins.
+- **Effort:** S (1 day) for the sweep; S more for the lint rule.
+- **Links:** prior item #2 continuation.
+
+### F10-03 — No distributed tracing across the agent hot path
+
+- **Priority:** P1
+- **Observation:** The product's defining interaction is HTTP (`PATCH /api/tasks/:id/move`) → `TaskService.moveColumn` → `AgentExecutionService.start` → `runAgentPlanning` → Claude Agent SDK → (optional) Docker/K8s provider → `DurableStreamsService.publish` → Caddy → browser SSE. A request ID is threaded via `AsyncLocalStorage` **within** the API process, but it is not attached to the outbound SDK call, the Dockerode/K8s client request, or the durable-streams publish. It is not received by agent-runner, which means an error in the container cannot be correlated to the HTTP request that spawned it. `session-event` envelopes don't carry the spawning request ID.
+- **Risk:** In-production debugging of "why did this task fail" requires timestamp archaeology across stream logs, agent-runner stdout, and the API access log — exactly the problem OpenTelemetry exists to solve. Without it, a flaky run in a customer environment is effectively unreproducible.
+- **Recommendation:** Phased. (1) Propagate `requestId` manually as a `correlationId` field on the durable-stream envelope and on agent-runner's `AgentEvent` schema — no SDK needed, unblocks most of the value immediately. (2) Stamp `requestId` onto a custom header on outbound Dockerode/K8s calls where supported. (3) Once the event path is correlated, layer `@opentelemetry/sdk-node` with auto-instrumentation for HTTP + better-sqlite3, then add manual spans around `runAgentPlanning`/`runAgentExecution`. (4) Propagate W3C traceparent through durable streams so the browser can correlate user clicks to server spans.
+- **Effort:** S for step (1) alone (2 days); M for steps (2)–(3) (1 week); L for (4).
+- **Links:** prior item #9; `src/lib/agents/stream-handler.ts`, `src/services/durable-streams.service.ts`.
+
+### F10-04 — No error reporting integration
+
+- **Priority:** P1
+- **Observation:** `uncaughtException` and `unhandledRejection` log via the structured logger and either die (exception) or are swallowed (rejection). `app.onError()` logs with requestId. `invariant()` in `src/lib/utils/invariant.ts` logs-and-continues in production. No Sentry, no Bugsnag, no Honeybadger — there is no destination that aggregates errors, deduplicates them by stack, tracks regressions across deploys, or pages on-call.
+- **Risk:** First-time production errors are discovered when a user reports them. Errors that span multiple processes (API + agent-runner) are not correlated even within the error stream.
+- **Recommendation:** Wire `@sentry/node` (or `@sentry/bun` once stable) into four sites: both process handlers, `app.onError()`, `invariant()` production branch, and the catch in `AgentExecutionService.start`. Attach `requestId`, `taskId`, `sessionId`, `codespaceId` as tags. Also wire the browser SDK on the frontend — this alone covers most of F10-07's value.
+- **Effort:** S (1–2 days) for backend; S more for browser.
+- **Links:** prior item #6.
+
+### F10-05 — Agent-runner logs are raw `console.*`, not structured
+
+- **Priority:** P1
+- **Observation:** `agent-runner/src/index.ts` contains 57 `console.*` calls, `shared-session.ts` 2, `agentcore-handler.ts` 20 — 79 total, unstructured. The emitter-based JSON events on stdout (`event-emitter.ts`) are the structured channel and are parsed by `container-bridge.ts`, but errors, startup lifecycle, and diagnostic traces inside the runner are plain strings. Because the runner is a separate process in a separate container, those lines only reach the host if Docker log drivers forward them, and they cannot be correlated to a `requestId` or `sessionId` once they do.
+- **Risk:** When the runner misbehaves — wrong credentials, sandbox clock skew, Claude SDK quota error — the evidence lives in a container log that may or may not be collected, in a format that cannot be joined back to the API host.
+- **Recommendation:** Introduce a mini-logger in the runner that emits JSON lines on stdout with `taskId`, `sessionId`, and a new `correlationId` field (populated from the `AGENT_CORRELATION_ID` env var set by the host). Parse both JSON events **and** JSON log lines in `container-bridge.ts`, routing log lines to the host's `createLogger('agent-runner')` with the correlation ID preserved. Sweep `console.*` → the new logger.
+- **Effort:** M (3 days).
+- **Links:** `agent-runner/src/index.ts`, `src/lib/agents/container-bridge.ts`.
+
+### F10-06 — No heartbeat metrics for background jobs
+
+- **Priority:** P2
+- **Observation:** 13 services run intervals (`scheduler.service.ts`, `event-cleanup.service.ts`, `template-sync-scheduler.ts`, `terraform-sync-scheduler.ts`, `session-presence.service.ts`, `sandbox.service.ts`, `sandbox-state.ts`, `cli-monitor.service.ts`, `agent-retry-queue.ts`, `agent-execution.service.ts` watchdog, `dream-scheduler.service.ts`, `task-creation.service.ts`). Each logs on failure; none emit a "last-tick-at" timestamp. A silently-wedged scheduler (e.g., a promise that never settles, a lost timer ref) is invisible until users notice the downstream effect.
+- **Risk:** Event cleanup stops, `session_events` grows unboundedly, the integrity-check-gated backup stops, and nothing alerts until disk fills. Same class of risk as F02-XX (data-layer) — the loop existing does not mean the loop is running.
+- **Recommendation:** Each scheduler should update a `schedulers.lastTickAt` / `lastTickOk` pair in a small in-memory map exposed by `/api/admin/metrics` (F10-01). An external scrape can then alert on `now - lastTickAt > expected_interval * 2`. Separately, each tick should log a `debug` breadcrumb so log-based alerting works as a fallback.
+- **Effort:** S (1 day).
+
+### F10-07 — Frontend observability is effectively zero
+
+- **Priority:** P2
+- **Observation:** 241 `console.*` occurrences across 70 frontend files (close to the F08-02 number of 229/62). No Sentry browser SDK, no PostHog/Amplitude, no error boundary reporting to the server, no performance timing collection. A user's rendering crash, failed fetch, or SSE drop reaches no one unless the user files a ticket with devtools open.
+- **Risk:** For a product whose entire experience is a live dashboard over agent state, blind frontends are a large gap. Regressions in the streaming path (F05 theme) can only be detected via user reports.
+- **Recommendation:** Browser Sentry (folded into F10-04) covers errors cheaply. For a structured fallback, add a tiny `POST /api/telemetry/client-error` endpoint that the browser can call from React error boundaries and from a global `window.addEventListener('error' | 'unhandledrejection')` — payload: `{ message, stack, route, sessionId, requestId }`. Server forwards to `createLogger('client')` which masks and persists in the existing log stream.
+- **Effort:** S (1 day for the fallback endpoint); S more bundled with F10-04.
+- **Links:** `specs/arch_review_april/08-frontend.md` F08-02.
+
+### F10-08 — Request ID is not attached to durable-stream events or audit entries
+
+- **Priority:** P2
+- **Observation:** The envelope in `src/lib/streams/envelope.ts` carries OC-005 metadata but no `requestId`. `src/db/schema/{sqlite,postgres}/audit-logs.ts` doesn't appear to store a correlation ID either. So "what HTTP call caused this audit row" and "what HTTP call caused this stream event" can only be reconstructed through timestamps.
+- **Risk:** Compliance and debugging both need the join. A customer asking "who approved my plan and when" has no single record; you synthesize it from multiple sources.
+- **Recommendation:** Add a nullable `requestId` column to `audit_logs` (migration — follow the schema-drift lesson in `CLAUDE.md`), populate from `getRequestId()` in the audit hook. Add `requestId` to the durable-stream envelope as a first-class optional field; clients ignore if absent. Provides the correlation key for F10-03.
+- **Effort:** S (1 day) for envelope; S for audit column + migration.
+
+### F10-09 — `droppedEventCount` is still invisible
+
+- **Priority:** P1
+- **Observation:** Cross-linked from F05-02 but called out here because it is primarily an observability failure, not a streaming one. The counter increments on 13 catch sites, exposes a getter, and nothing calls the getter. No log emission at the increment, no `/metrics` surface, no alert.
+- **Risk:** Silent failure class the prior observability pass already flagged and "fixed" (by adding a counter that nobody reads). The shape is correct; the wiring is missing.
+- **Recommendation:** At minimum, emit `log.warn` at each increment with `{ streamId, eventType, errorCode }`. Long-term, fold the counter into F10-01's endpoint and F05-05's outbox.
+- **Effort:** XS (2 hours) for the log emissions.
+- **Links:** F05-02; `src/services/plan-mode.service.ts:67,114`.
+
+### F10-10 — Health endpoint is deep but not latency-SLA'd
+
+- **Priority:** P3
+- **Observation:** `/api/health` does seven subsystem checks sequentially with no per-check timeout except the 3s `AbortSignal.timeout` on streams. In prod under DB lock contention, the full health response can block while a K8s control-plane call queues. K8s's default liveness probe timeout (1s) will then mark the pod unhealthy and restart the API server during a transient — causing a restart loop.
+- **Risk:** Thundering-herd restarts during DB or K8s degradation.
+- **Recommendation:** Add per-check `AbortSignal.timeout(1000)` wrappers. Run checks in parallel (`Promise.allSettled`). Keep the sequential variant as `/api/health?deep=1` for human inspection. Document the readiness-probe recommendation (use `/api/health/readiness` not `/api/health`) in the deployment spec.
+- **Effort:** S (half day).
+- **Links:** `src/server/routes/health.ts`.
+
+### F10-11 — No CI observability (test runtime trend, flake rate)
+
+- **Priority:** P3
+- **Observation:** CI runs Vitest in 3 shards (`.github/workflows` per CLAUDE.md). There is no aggregation of per-test runtimes across runs, no flake detection, no slow-test watchlist. The `functional` project runs separately; drift in its runtime is invisible until a PR times out.
+- **Risk:** Test time growth is the classic "boiling frog" — adding 200ms per PR is never a blocker, and two years later the suite takes 40 minutes.
+- **Recommendation:** Upload Vitest JSON reporter output to GitHub Actions artifacts; add a once-weekly job that computes p50/p95 per test from the last 30 runs and opens an issue for tests whose p95 doubled month-over-month. Cheap to build, large payoff.
+- **Effort:** S (1 day).
+
+### F10-12 — Audit-log coverage is hook-centric, not request-centric
+
+- **Priority:** P2
+- **Observation:** `src/lib/agents/hooks/audit.ts` writes audit rows for agent-lifecycle hooks. Reviewing `audit_logs` usage: writes are localized to agent hooks. Security-relevant events outside agent flow — API key create/delete, RBAC role changes, team member add/remove, sandbox config change, OAuth token rotation, codespace delete — do not appear to route through this table systematically. The 44-error catalog referenced in CLAUDE.md captures failure surfaces; audit should capture successful state changes too.
+- **Risk:** For a multi-tenant system with GitHub tokens and Claude OAuth tokens, "who removed whom from which team" must be answerable. If audit only fires from agent hooks, the compliance story is half-built.
+- **Recommendation:** Define the set of security-relevant events (token CRUD, RBAC mutation, membership mutation, settings mutation, codespace/sandbox lifecycle) and add audit writes at each service method. Folds into F06 (security) work. The schema exists; the wiring is the gap.
+- **Effort:** M (2–3 days).
+
+### F10-13 — `invariant()` violations log-and-continue in prod
+
+- **Priority:** P2
+- **Observation:** `src/lib/utils/invariant.ts` (per prior review, line 29) logs on violation and returns. In dev mode it throws. This means: in prod, an invariant violation — by definition a "this should never happen" state — silently continues execution, usually into a worse state than failing fast.
+- **Risk:** Invariants exist because the author judged continuing to be unsafe. Logging-and-continuing defeats that judgment.
+- **Recommendation:** Throw in prod too, with the error handler at `app.onError()` catching and returning 500 with a sanitized message. The structured logger still captures the stack. Pair with F10-04 so each violation creates a Sentry issue.
+- **Effort:** XS.
+
+## Closing
+
+The floor is better than the prior review's snapshot suggests: masking is real, request IDs are threaded, health is deep, 47+ catches were fixed, 118 files have structured logging. What's missing is everything the floor doesn't give you for free — a metrics endpoint, a trace surface, error reporting, correlation across the process boundary into agent-runner, browser observability, heartbeat metrics on scheduled work, and attached request IDs on events and audit rows. The right shape of work is: F10-01 (JSON metrics), F10-03 step 1 (correlationId through streams + agent-runner), F10-04 (Sentry), F10-09 (wire the existing counter). Those four together, S/M effort each, move the product from "instrument-by-grep" to "instrument-by-query" without any infrastructure commitments.
+
+Cross-links: `specs/release_plan/03-observability.md` (prior pass), `specs/release_plan/05-error-resilience.md` (error bubbling), `specs/arch_review_april/05-event-streaming.md` (F05-02 drop counter, F05-05 outbox), `specs/arch_review_april/08-frontend.md` (F08-02 console audit), `specs/arch_review_april/04-sandbox-providers.md` (F04 health depth), `specs/arch_review_april/06-security.md` (audit coverage).

--- a/specs/arch_review_april/11-operations-deployment.md
+++ b/specs/arch_review_april/11-operations-deployment.md
@@ -1,0 +1,121 @@
+# Operations & Deployment
+
+## Summary
+CI has matured: the pipeline at `.github/workflows/ci.yml` now fans out across `install -> {build, lint-and-typecheck, test[x3], semgrep} -> integration-test[x2]` with concurrency cancellation, a shared composite action (`.github/actions/setup-bun-env`), and a `CACHE_VERSION: v2` token for manual cache busting. PRs #160 and #161 repaired the cache-hit / composite-action regression, so CI is green and reproducible. **CD remains entirely absent.** No workflow builds or publishes the Docker image, no Helm chart gets packaged, and no release is cut. The existing `specs/release_plan/04-release-deployment.md` findings on CD absence, versioning, Docker/Helm divergence, and PostgreSQL migration lag all reproduce at HEAD. Graceful shutdown exists as an LIFO registry (`src/server/bootstrap/shutdown.ts`) but does not flush in-flight agent sessions or signal agent-runner sidecars. Database backup scripts exist (`scripts/backup-db.sh`, `scripts/backup-db-pg.sh`) but are never invoked by any schedule or pre-upgrade hook. No P0: CI is stable, secrets are correctly sourced from K8s Secrets in Helm, and the `package.json` version hasn't shipped yet so a missing rollback doesn't imperil live users.
+
+## Map
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| CI workflow | `.github/workflows/ci.yml`, `.github/actions/setup-bun-env/action.yml`, `.github/workflows/mutation-testing.yml` | 6 jobs + mutation job; sharded tests; semgrep ERROR blocking, WARNING non-blocking |
+| Docker runtime | `docker/Dockerfile`, `docker/Dockerfile.agent-sandbox`, `docker/Dockerfile.agentcore`, `docker/start.sh`, `docker/entrypoint.sh`, `Caddyfile` | App image (Caddy + Bun, tini PID 1); sandbox image extends `srlynch1/terraform-ai-tools:latest` |
+| Compose | `docker/docker-compose.yml`, `docker/docker-compose.postgres.yml`, `docker/docker-compose.memory.yml` | Dev/demo only; hardcoded `agentpane_dev` Postgres password |
+| Helm chart | `charts/agentpane/{Chart.yaml,values.yaml,templates/*}`, `charts/agentpane/charts/` (Bitnami PG subchart) | 17 templates; `appVersion: 1.0.0`; image repo `agentpane/agentpane` placeholder |
+| K8s manifests | `k8s/manifests/{crds,agentpane-sandbox-template,agentpane-warm-pool,namespace,limit-range,runtime-class-gvisor}.yaml` | Sandbox CRDs + warm pool; applied manually, outside Helm lifecycle |
+| Shutdown | `src/server/bootstrap/shutdown.ts` | LIFO cleanup registry, 30s force-exit |
+| Migrations | `src/lib/bootstrap/migrations/*` (SQLite, 23 versions), `src/db/migrations-pg/` (Postgres, 4 versions), `scripts/check-schema-drift.ts` | Run at app startup (`phases/database.ts`) |
+| Backup scripts | `scripts/backup-db.sh`, `scripts/backup-db-pg.sh` | Manual; cron-ready but no CronJob template |
+| CLI monitor publish | `packages/cli-monitor/package.json` (`prepublishOnly`), CLAUDE.md publishing steps | Manual `npm publish`; token in `/specs/CLI_monitor/.env` |
+| Pre-commit / pre-push | `.pre-commit-config.yaml` (referenced in CLAUDE.md), `package.json:prepare` (echoes reminder) | Biome + tsc + detect-secrets; not installed by default |
+
+## What's working
+- CI concurrency group cancels superseded runs, and the test shards (`1/3 2/3 3/3`) plus integration shards (`1/2 2/2`) keep wall-clock under 30 minutes.
+- Composite action `setup-bun-env` centralises Bun install, `node_modules` cache, and Bun package cache, so regressions like the #161 breakage stay isolated.
+- Schema-drift check runs on every PR as part of `lint-and-typecheck`.
+- Semgrep is wired with a custom ruleset at `.semgrep/rules/` and correctly splits ERROR (blocking) vs WARNING (continue-on-error).
+- `GracefulShutdown` registers LIFO and sets an unref'd force-exit timer, matching canonical shutdown patterns. Signal handlers for SIGINT and SIGTERM are installed centrally.
+- Helm chart has genuine production bones: Pod Security Standard `restricted` on the sandbox namespace, `runAsNonRoot`, `readOnlyRootFilesystem`, seccomp `RuntimeDefault`, config/secret checksum annotations for rollout on change, Bitnami Postgres `existingSecret` support, and Gateway API / OpenShift Route coverage.
+- Both backup scripts are defensive: `pg_dump --dbname=` avoids flag injection, `umask 077` locks backup perms, and the Postgres script verifies via `pg_restore --list` before rotating.
+- Multi-arch support via `TARGETARCH` in the app Dockerfile.
+
+## Findings
+
+### F11-01: No CD pipeline — zero automated path from main to a running image
+- **Priority**: P1
+- **Observation**: `.github/workflows/` contains `ci.yml` and `mutation-testing.yml` only. No job builds the production image, scans it, pushes to a registry, tags a release, or triggers a `helm upgrade`. The Helm chart's `image.repository: agentpane/agentpane` is a placeholder with no registry behind it. No git tags exist and `package.json` is pinned at `1.0.0`. Cross-reference `specs/release_plan/04-release-deployment.md` "Missing CD Pipeline" section — all six gaps (build/push, release workflow, deployment trigger, environment promotion, canary, smoke test) still apply.
+- **Risk**: Every deployment is a manual `docker build && docker push && helm upgrade`, which means no audit trail, no reproducibility, and no rollback by digest. A production environment built this way cannot credibly meet SOC2 / ISO change-control controls.
+- **Recommendation**: Add a `release.yml` workflow triggered on `push: tags: ['v*']` that builds multi-arch with buildx, runs Trivy with a severity gate, pushes `ghcr.io/agentdevsl/agentpane:${git_sha}` + `:v${semver}`, packages the Helm chart via `helm package charts/agentpane`, and uploads both to a GitHub Release. Separately, add an `auto-tag.yml` using release-please or Changesets to generate tags/CHANGELOG from conventional commits. Document a `helm rollback` runbook in `specs/application/operations/deployment.md`.
+
+### F11-02: Docker image and Helm chart expose divergent runtime architectures
+- **Priority**: P1
+- **Observation**: `docker/start.sh` runs Caddy (durable-streams-server) on port 3000 as parent process and `bun src/server/api.ts` on 3001 as a child. `docker-compose.yml` exposes only port 3000. The Helm `deployment.yaml` (line 41-44) sets `containerPort: 3001` and has no sidecar for durable streams. This means the K8s deployment bypasses Caddy entirely — SSE streaming through the durable-streams-server binary is unavailable unless deployed externally. Feature parity tests do not exist, so regressions land silently per environment.
+- **Risk**: Durable stream resume (`offset=` replay, ephemeral terraform streams) works in `docker compose up` and fails in K8s without anyone noticing until a user hits an SSE disconnect. The "stream endpoints have no auth at the Caddy level" mitigation relies on network isolation that K8s does not enforce when Caddy is absent.
+- **Recommendation**: Ship durable-streams-server as a named sidecar in the Helm chart (same container image, different command), add a service port for `/v1/stream`, and run a Helm test that hits `/v1/stream/healthz`. Alternatively, remove Caddy from the app image, ship it as a separate chart dependency, and have the API always talk to it via a ClusterIP — same architecture in both topologies.
+
+### F11-03: Graceful shutdown does not flush in-flight agent runs or sandbox containers
+- **Priority**: P1
+- **Observation**: `GracefulShutdown` calls registered cleanups in LIFO order and hard-exits after 30s. A scan of the bootstrap phases shows no cleanup that writes pending `agent_runs` rows, marks running agents as `interrupted`, or signals agent-runner containers to checkpoint. Running sub-processes (Docker agent-runner, K8s sandbox pods) have their own lifecycle detached from the API process, so a SIGTERM on the API pod during a rolling upgrade leaves orphaned containers running against a DB that no longer believes they exist. The recovery phase (`phases/recovery.ts`) resets stale agents on next boot, but there is no window where a running plan can save its state before the pod dies.
+- **Risk**: Deploying during active agent work loses partial progress, leaves orphan Docker containers on the host, and confuses the Kanban UI (task shows `in_progress` but no agent is alive). With the planned auto-deploy-on-merge, every merge during business hours risks interrupting a user's agent.
+- **Recommendation**: Add a cleanup that: (1) sets all `agent_status='running'` rows to `interrupted` with a shutdown reason, (2) writes a pre-shutdown session event so the UI can show "restarting", (3) best-effort calls `sandboxProvider.stop()` for tracked containers, (4) waits up to N seconds for in-flight SSE flushes. Set `terminationGracePeriodSeconds: 60` in the Helm chart to match.
+
+### F11-04: PostgreSQL migrations are 19 versions behind SQLite
+- **Priority**: P1
+- **Observation**: `src/lib/bootstrap/migrations/index.ts` has 23 SQLite migrations (v1-v23). `src/db/migrations-pg/` has 4 Drizzle-generated files (0000-0003). Per `specs/release_plan/06-database-integrity.md` F#CRITICAL, PG migrations still reference `projects` table, lack RBAC / events / memory tables, and would produce a broken schema on fresh deploy. The `check-schema-drift.ts` script only compares module exports — it does not catch missing migrations.
+- **Risk**: Any Helm-based deployment (the only K8s path) against a fresh Postgres instance will fail at runtime — not at migrate time, because Drizzle will "succeed" applying its four stale files, then the app will issue queries against tables that don't exist. The blast radius hits the exact deployment target the Helm chart was built for.
+- **Recommendation**: Regenerate PG migrations from the current Drizzle schema (`drizzle-kit generate --config=drizzle.config.pg.ts`), verify the DDL matches all 23 SQLite migrations, and add a functional test that boots a fresh Postgres, runs `migratePg()`, and exercises the task -> agent -> session path. Add schema-parity enforcement to CI: compare `INFORMATION_SCHEMA` columns across both DBs after migrate.
+
+### F11-05: Migrations race on multi-replica rollouts
+- **Priority**: P1
+- **Observation**: `src/server/bootstrap/phases/database.ts` calls `migratePg()` (or the SQLite migration runner) at startup. The Helm chart supports `replicaCount` and HPA, meaning N pods call migrate in parallel on every rollout. Drizzle Kit uses advisory locks internally but the behaviour under parallel startup is not exercised in tests. No Helm pre-upgrade hook Job runs migrations out-of-band.
+- **Risk**: Partial migration state on rolling updates; deadlocks if the advisory lock path regresses upstream; flakes that only appear at replicaCount >= 2.
+- **Recommendation**: Add a Helm `pre-upgrade,pre-install` hook Job that runs `bun run migrate:pg` once. Switch app startup to verify (but not apply) migration state; if drift is detected, fail fast. Gate rollouts on the Job's success.
+
+### F11-06: Helm chart persists application data in `emptyDir`
+- **Priority**: P1
+- **Observation**: `charts/agentpane/templates/deployment.yaml:131-136` declares `volumes: - name: data, emptyDir: {}`. In Postgres mode this is fine because data lives in the subchart; in SQLite mode or for local durable-streams data it means every pod restart wipes state. The chart has no PVC template. No `PodDisruptionBudget`, no `Deployment.strategy` pinning (defaults to `RollingUpdate` with `maxUnavailable: 25%`).
+- **Risk**: If someone accidentally deploys `database.mode: sqlite`, they lose data on every rollout. Durable-streams backing files (if added per F11-02) would also die. Without a PDB, voluntary node drain can drop all replicas.
+- **Recommendation**: Add an optional PVC template guarded on `persistence.enabled`. Add a PDB template with `maxUnavailable: 0` default. Pin the deployment strategy to `RollingUpdate` with `maxSurge: 1, maxUnavailable: 0` explicitly, and document that SQLite mode is unsupported on K8s.
+
+### F11-07: Agent sandbox base image is a personal DockerHub tag with `:latest`
+- **Priority**: P1
+- **Observation**: `docker/Dockerfile.agent-sandbox:13-15` pins `BASE_IMAGE=srlynch1/terraform-ai-tools:latest`. `RUN npm install -g @anthropic-ai/claude-code` installs at build time with no version pin. No image scanning in CI. This is the image every user's agent actually executes in — the sandbox boundary.
+- **Risk**: Supply-chain risk — a personal account's compromised image ships as the default sandbox. `:latest` means reproducibility is impossible and a base-image refresh can silently change the tool surface. Cross-ref `specs/arch_review_april/06-security.md` for sandbox security coverage.
+- **Recommendation**: Mirror the base image into the agentdevsl org (`ghcr.io/agentdevsl/agent-sandbox-base:v1.x.y`), pin by digest, and pin `@anthropic-ai/claude-code` to a semver in the Dockerfile. Add Trivy to CI for both images with a MEDIUM severity gate.
+
+### F11-08: CLI monitor publishing puts the npm token in a spec directory
+- **Priority**: P1
+- **Observation**: CLAUDE.md "Publishing `@agentpane/cli-monitor` to npm" documents storing the npm access token at `/specs/CLI_monitor/.env` and passing it via `--//registry.npmjs.org/:_authToken=<token>`. The publish process is entirely manual (`npm version patch && npm publish`). The `prepublishOnly` script runs tests + build but there is no CI verification, no provenance, and no signed release. Cross-ref `specs/arch_review_april/06-security.md` for the secrets-handling theme.
+- **Risk**: A token kept under `/specs/` sits next to files routinely edited and committed — one `git add specs/` away from leaking. No npm 2FA / OIDC provenance means the package can be silently hijacked. Manual publishing offers no changelog or signature trail.
+- **Recommendation**: Move the token to a GitHub repo secret (`NPM_TOKEN`), add a `publish-cli-monitor.yml` workflow triggered on `packages/cli-monitor/package.json` version bumps (or a `cli-monitor-v*` tag), publish with `--provenance`, and require npm 2FA-required-for-publish. Delete `/specs/CLI_monitor/.env` and grep-sweep for any committed copies.
+
+### F11-09: Secret management differs between Compose and Helm with no parity
+- **Priority**: P2
+- **Observation**: `docker-compose.yml` passes `ANTHROPIC_API_KEY` / `CLAUDE_OAUTH_TOKEN` as `${VAR:-}` env passthrough from the host shell. `docker-compose.postgres.yml` hard-codes `POSTGRES_PASSWORD: agentpane_dev`. The Helm chart sources all three from K8s Secrets with `existingSecret` override. No `.env.example`, no documented list of required variables, and the project-root `.env` is effectively empty.
+- **Risk**: New contributors guess at env var names; staging vs prod drift because there is no shared source of truth; developers paste real keys into `.env` and risk checking them in.
+- **Recommendation**: Create `.env.example` enumerating every variable (`ANTHROPIC_API_KEY`, `CLAUDE_OAUTH_TOKEN`, `DATABASE_URL`, `DB_MODE`, `GITHUB_*`, `STREAMS_DATA_DIR`, `CADDY_STREAMS_URL`, `LOG_LEVEL`, `CORS_ORIGIN`). Add a Helm `values-production.yaml` that requires `existingSecret`. Document External Secrets Operator as the recommended prod path.
+
+### F11-10: Backup scripts exist but nothing runs them
+- **Priority**: P2
+- **Observation**: `scripts/backup-db.sh` (SQLite) issues `PRAGMA wal_checkpoint(TRUNCATE)` and copies the file, rotating to 7. `scripts/backup-db-pg.sh` uses `pg_dump --format=custom --compress=6` and verifies with `pg_restore --list`. Both are well-written. Neither is invoked: no Helm CronJob template, no docker-compose sidecar, no GitHub Actions schedule. The Helm `data` volume is `emptyDir` (F11-06) so even if someone ran the SQLite script there's nowhere to put the output. No documented restore procedure.
+- **Risk**: "We have backup scripts" creates a false sense of safety; in practice there are no backups. A DB migration that corrupts data (F11-04 made worse) has no rollback artefact.
+- **Recommendation**: Add a Helm CronJob template (`backup-cronjob.yaml`) that mounts a backup PVC and invokes `backup-db-pg.sh` daily with retention configurable via values. Document the restore flow. Also run the backup script as a Helm `pre-upgrade` hook so every migration has a known-good snapshot.
+
+### F11-11: Dependabot automation has no policy, producing churn
+- **Priority**: P2
+- **Observation**: Default branch shows 42 dependency vulnerabilities (2 critical) per Dependabot. Four open Dependabot PRs (#152, #153, #154, #159) are likely superseded by #160's bulk bump but have not been auto-closed. No `dependabot.yml` grouping or auto-merge configuration is present.
+- **Risk**: Maintainers spend time triaging obsolete PRs; critical CVEs sit unpatched while stale PRs age; the visible vuln count makes it hard to tell which need action.
+- **Recommendation**: Add `.github/dependabot.yml` with `groups:` entries (one per ecosystem + one for `@tanstack/*`, `@radix-ui/*`, `@durable-streams/*`), set `open-pull-requests-limit: 10`, and add a GitHub Action that auto-closes Dependabot PRs whose target version is already satisfied. Add `auto-merge` labels for patch-level updates once CI passes. Triage the 2 critical CVEs immediately.
+
+### F11-12: Semgrep policy is binary and undocumented
+- **Priority**: P2
+- **Observation**: `ci.yml` runs semgrep twice — ERROR blocking, WARNING non-blocking — against `src/ agent-runner/src/ packages/`. The `.semgrep/rules/` directory exists but the policy on promoting WARNING -> ERROR, suppressing false positives, or syncing with upstream `p/ci` is not documented. `tests/**` are excluded globally, but there is no rule for new test-adjacent scripts.
+- **Risk**: WARNING-severity findings accumulate unseen (no one reads `continue-on-error` logs); rules drift; suppression patterns vary per developer.
+- **Recommendation**: Document the rule-promotion and suppression policy in `specs/application/operations/deployment.md`. Add a scheduled workflow that posts a weekly WARNING report to Slack / an issue. Consider pulling in `p/typescript` and `p/react` rulesets once the baseline is clean.
+
+### F11-13: `prepare` script only reminds, never installs pre-commit hooks
+- **Priority**: P3
+- **Observation**: `package.json:50` sets `"prepare": "echo 'Run: pre-commit install --hook-type pre-commit --hook-type pre-push'"`. Fresh clones therefore have no hooks until each developer manually runs the command. Hooks that do install (Biome, tsc, detect-secrets) enforce real invariants, so the installed/uninstalled distinction matters.
+- **Risk**: New contributors land lint / secret-detection failures in CI that local hooks would have caught; CLAUDE.md's "pre-commit hooks (automatic)" line is subtly misleading.
+- **Recommendation**: Replace with `"prepare": "command -v pre-commit >/dev/null && pre-commit install --hook-type pre-commit --hook-type pre-push || echo 'Install pre-commit: pipx install pre-commit'"`. Document the Python-tool dependency in README. Consider migrating to husky + lint-staged to drop the Python requirement.
+
+### F11-14: No release notes, no CHANGELOG, no documented rollback
+- **Priority**: P3
+- **Observation**: No `CHANGELOG.md` at repo root. No git tags. The Helm chart stays at `0.1.0`. `specs/release_plan/04-release-deployment.md` already called this out and nothing changed. Rollback procedure for image, Helm release, and database migration is undefined anywhere.
+- **Risk**: Users and operators have no artefact describing what ships in a given build; incident response has no rollback runbook.
+- **Recommendation**: When F11-01 lands the CD pipeline, seed a CHANGELOG generated by release-please from conventional commits, auto-bump `Chart.yaml` / `package.json` versions, and add an operator runbook at `specs/application/operations/deployment.md` covering `helm rollback`, image-tag revert, and the Postgres restore path (depends on F11-10).
+
+## Cross-links
+- `specs/release_plan/04-release-deployment.md` — consolidated here; all gaps from that document reproduce.
+- `specs/release_plan/06-database-integrity.md` — PostgreSQL migration lag (F11-04), schema drift tooling limits.
+- `specs/arch_review_april/06-security.md` — sandbox base image supply chain (F11-07), CLI monitor token storage (F11-08).
+- `specs/arch_review_april/04-sandbox-providers.md` — graceful shutdown coordination with Docker / K8s providers (F11-03).
+- `specs/application/operations/deployment.md` — target home for the CD / rollback / backup runbook additions recommended here.

--- a/specs/arch_review_april/12-cross-cutting.md
+++ b/specs/arch_review_april/12-cross-cutting.md
@@ -1,0 +1,98 @@
+# Cross-Cutting Concerns
+
+## Summary
+Horizontal hygiene that spans every subsystem: type-safety escapes, `Result<T,E>` discipline, background-job lifecycles, config duplication, import coupling, date/time handling, retry/timeout policy, stream-ID generation, Biome-ignore inventory, and magic-number centralisation. The codebase scores well on the primitives — `Result<T,E>` is defined once and used across 442 occurrences in 79 files, `CircuitBreaker` and `withRetry` live in `src/lib/utils`, and CLAUDE.md codifies the "no empty catch / no silent failure" rule. The drift is in consistent *application*: 29 `as unknown as` casts concentrate in three root causes (Drizzle polymorphism, event-payload narrowing, Cron config JSON), `Result` discipline breaks at the route boundary, four background timers have either unclear shutdown semantics or non-idempotent start, and the retry/circuit-breaker utilities are not imported outside their own test files. No P0 — the discipline exists; it is unevenly enforced.
+
+## Map
+| Cross-cutting concern | Primary files | Scope |
+|-----------------------|---------------|-------|
+| Type escapes | `services/*.service.ts`, `server/bootstrap/phases/database.ts`, `server/routes/health.ts` | 29 prod, 31 test `as unknown as` |
+| Result discipline | `lib/utils/result.ts` + 79 consumers | Services return `Result`; routes mix `throw` + `Result` |
+| Background jobs | `services/{scheduler,event-cleanup,task-creation,agent/agent-execution,sandbox,session/session-presence,container-agent/sandbox-state,memory/dream-scheduler}.service.ts`, `lib/sandbox/controllers/sandbox-controller.ts`, `server/routes/auth.ts` | 11 long-lived `setInterval` producers |
+| Retry / CB utilities | `lib/utils/retry.ts`, `lib/utils/circuit-breaker.ts` | Zero production imports outside tests |
+| Config sources | `services/settings.service.ts`, `lib/env.ts`, `server/bootstrap/server-config.ts`, `src/settings` DB table | Three layers, precedence ad-hoc per consumer |
+| Stream ID factory | 81 `createId()` call sites across 30 files; ID prefixes (`plan:`, `sandbox:`, `terraform:`) applied inline | No central factory |
+| Biome ignores | 37 `biome-ignore` comments across 28 files | `router.ts` has 9 duplicates in one block |
+| Time / dates | 611 `new Date()` / `Date.now()` across 211 files | Mix of ISO strings, Unix ms, `Date` objects in DB |
+
+## What's working
+- `src/lib/utils/result.ts` gives one canonical `Result<T, AppError>` with `ok()` / `err()` constructors; 79 files use it.
+- `CircuitBreaker` (`src/lib/utils/circuit-breaker.ts`) has proper half-open transition logic and 200-line test coverage.
+- CLAUDE.md explicitly forbids empty catches and "fake success" responses; the Biome rule `noEmptyBlockStatements` is an error (seen in theme 10 findings).
+- Timer handles are uniformly typed as `ReturnType<typeof setInterval>` — TypeScript catches handle reuse.
+- `@paralleldrive/cuid2` is the one ID library; no `Math.random`-based IDs survive.
+- `src/lib/env.ts` exists as a single env-parsing module (even if under-used).
+
+## Findings
+
+### F12-01: Drizzle polymorphism forces three runtime type holes
+- **Priority**: P2
+- **Observation**: `server/bootstrap/phases/database.ts:47,49,73` casts both `drizzlePg(...)` and `drizzle(...)` results to the internal `Database` union via `as unknown as Database`. `server/routes/health.ts:99,102` repeats the same pattern to call Postgres-only `execute()`. Root cause: the unified `Database` type in `src/types/database.ts` is an intersection the two concrete drivers can't structurally satisfy.
+- **Risk**: Any future Drizzle API change slips past TypeScript silently; a wrong driver at runtime produces "method is not a function" rather than a compile error.
+- **Recommendation**: Introduce a narrow `DatabaseClient` interface exposing only the subset both dialects truly share (`select/insert/update/delete/transaction/execute?`). Keep driver-specific capabilities behind discriminated helpers (`isPg(db)` / `isSqlite(db)`). Delete the three `as unknown as Database` casts in `database.ts` and both in `health.ts`.
+
+### F12-02: Cron config is stored as JSON and cast four times
+- **Priority**: P2
+- **Observation**: `services/scheduler.service.ts:195,602,758,817` and `server/routes/events.ts:547` all cast `source.config as unknown as CronEventSourceConfig`. The column is typed `json` in Drizzle but the runtime shape is only validated on write in some paths and not at all on read.
+- **Risk**: A corrupt or older-schema `event_sources.config` row becomes an unchecked read that blows up deep in the tick loop (silent reschedule failure).
+- **Recommendation**: Define `cronConfigSchema` (Zod) once in `src/db/schema/shared/cron-config.ts`, parse on read inside `SchedulerService.loadSource()`, and return `Result<CronEventSourceConfig, AppError>`. Downstream casts disappear and malformed rows fail fast with a logged diagnostic.
+
+### F12-03: Plan row cast repeated four times across container-agent
+- **Priority**: P2
+- **Observation**: `container-agent/plan-approval.service.ts:197,474,485` and `container-agent/container-exec.service.ts:1186` all cast `db.select({...}).get()` to `TaskPlanRow` via `as unknown`. Same SELECT shape, same target type, four copies.
+- **Risk**: Shape drift (new column, renamed field) updates the type but not all four SELECTs; a reader silently receives `undefined` for the new field.
+- **Recommendation**: Add `plan-approval/queries.ts` exporting `selectTaskPlanRow(db, taskId): Promise<Result<TaskPlanRow | null, AppError>>`. Both services call it; the cast lives in exactly one place and is covered by the single query shape.
+
+### F12-04: Background timer lifecycle is inconsistent
+- **Priority**: P1
+- **Observation**: Eleven services own long-lived `setInterval`s. Cleanup discipline varies: `SchedulerService`, `EventCleanupService`, `DreamScheduler`, `CliMonitorService`, `SandboxController`, `SessionPresenceService`, `AgentExecutionService`, `SandboxStateManager` all expose `stop()` and are drained by bootstrap shutdown. `TaskCreationService` starts `cleanupInterval` at line 214 but exposes no stop method (grep: 0 matches for `stop()`/`dispose()`/`shutdown()` in the file). `server/routes/auth.ts:312` starts a session-cleanup `setInterval` in module init and relies on `unref()` alone — no way to stop from tests or graceful shutdown. `agentcore-bridge.service.ts:302` sets a per-agent `setTimeout` with `unref()` but never `clearTimeout`s it on successful completion — dangling timers accumulate one-per-task.
+- **Risk**: Vitest cross-test leaks (timers firing against a closed DB handle), process taking longer than the shutdown deadline, and in `agentcore-bridge` a monotonic memory footprint across agent runs.
+- **Recommendation**: Standardise a `BackgroundJob` interface (`start()` / `stop()` / `isRunning()`), require every service owning a timer to implement it, and have `ServerBootstrap` track them in an array drained on `SIGTERM`. Add an ESLint/Semgrep rule: top-level `setInterval` outside a class owning a `stop()` is an error.
+
+### F12-05: `Result<T,E>` discipline stops at the route boundary
+- **Priority**: P2
+- **Observation**: Services return `Result<T, AppError>` uniformly (79 service files). Routes (`src/server/routes/*.ts`) mostly unwrap with `if (!result.ok) return json(...)` but several call sites still `throw` from services (`session-stream.service.ts` has 2 `throw new Error`, `task-creation.service.ts` has 7 — per grep). A mixed pattern in the same call stack means a caller has to both check `.ok` *and* wrap in `try/catch`, which in practice means one or the other gets skipped.
+- **Risk**: Unhandled throw leaks to the default Hono error handler; `AppError.code` is lost, the UI gets a generic 500, and the error never reaches the service-level logger.
+- **Recommendation**: Adopt "services never throw" as a hard rule. Replace every `throw new AppError(...)` in a service with `return err(appError(...))`. Add a Biome custom rule or Semgrep to flag `throw` inside files matching `*.service.ts` (allow `invariant()`-style assertions only). Routes then need *only* the `.ok` check.
+
+### F12-06: `retry` and `CircuitBreaker` utilities have zero production consumers
+- **Priority**: P2
+- **Observation**: `src/lib/utils/retry.ts` and `src/lib/utils/circuit-breaker.ts` exist with full tests. Grep for `from '@/lib/utils/retry'` or `from '@/lib/utils/circuit-breaker'` across `src/` returns **no files**. Meanwhile `github.service.ts`, `terraform-registry.service.ts`, `caddy-producer.ts`, `plan-mode/claude-client.ts` each implement bespoke retry loops with ad-hoc backoff constants.
+- **Risk**: Six independent retry policies drift in behaviour (jitter vs no jitter, cap differences, non-idempotent retries on POST). Rate-limit handling is copy-pasted instead of shared.
+- **Recommendation**: Migrate `github/rate-limit.ts`, `terraform-registry.service.ts`, and Caddy producer flush to `withRetry()` in one PR. Wrap outbound HTTP to Caddy and GitHub in `CircuitBreaker` so upstream outages don't cascade to 100% of agent operations.
+
+### F12-07: Config has three sources, no typed precedence layer
+- **Priority**: P2
+- **Observation**: Config lives in (a) `settings` DB table (read via `SettingsService.get()` — 25 sites), (b) `process.env` (135 sites across 43 files), (c) hard-coded defaults inside service constructors. Precedence is decided ad-hoc: `agentcore-bridge.service.ts` uses "env var > DB setting > default 4hr" for max runtime; other services read env directly, others read only from DB.
+- **Risk**: Operator changes a UI setting, restarts the server, and the value silently loses to a stale env var. Tests can't easily override because the lookup is per-site.
+- **Recommendation**: Introduce `AppConfig` keyed by config-name, each entry declaring `{ envVar, settingsKey, default, schema }`. `AppConfig.get('agent.maxRuntimeMs')` centralises precedence. The 25 `settingsService.get()` sites and 135 `process.env.` sites collapse toward this single surface over time.
+
+### F12-08: Stream ID prefixes are applied at 4+ call sites without a factory
+- **Priority**: P2
+- **Observation**: The durable-stream ID scheme (`plan:{id}`, `sandbox:{id}`, `terraform:{id}`, bare CUID for sessions) is documented in CLAUDE.md but applied by string concatenation at each producer: `plan-mode.service.ts`, `codespace.service.ts`, `terraform-compose.service.ts`, `sandbox.service.ts`, plus every consumer that has to strip the prefix.
+- **Risk**: A typo (`"plan-"` vs `"plan:"`) produces a silent non-overlap between producer and consumer — observed in the past per the CLAUDE.md "Plan stream ID prefix" note.
+- **Recommendation**: Add `src/lib/streams/stream-id.ts` exporting `streamId.forPlan(id)`, `streamId.forSandbox(id)`, `streamId.forTerraform(jobId)`, `streamId.forSession(id)` plus `parseStreamId(raw): { kind, id }`. Replace the 81 `createId()` + concat sites that build durable-stream IDs.
+
+### F12-09: Magic numbers are scattered, not centralised
+- **Priority**: P3
+- **Observation**: 152 literals matching `60_000 / 60 * 1000 / 3600` appear across 82 files. TTLs, ping intervals (SSE 30s), session idle timeouts, retry backoffs, rate-limit windows — each defined where it's used. Some are `const` inside the class (`TaskCreationService.CLEANUP_INTERVAL`), some are inline (`setInterval(..., 30000)`), some reference `DREAM_TICK_INTERVAL_HOURS * 60 * 60 * 1000` with the math done in-place.
+- **Risk**: Tuning in ops means grepping for numbers; two constants drift (e.g., frontend poll interval and backend expiry) because they're in different files.
+- **Recommendation**: `src/lib/constants/timing.ts` with named exports (`SSE_PING_INTERVAL_MS`, `SESSION_IDLE_TIMEOUT_MS`, `AGENT_ORPHAN_SWEEP_MS`, etc.). No logic change; purely a rename pass. Makes the ops knob surface explicit.
+
+### F12-10: `@ts-nocheck` on five test files hides schema drift
+- **Priority**: P2
+- **Observation**: `src/services/memory/__tests__/{memory,dream,memory-store,skill-tracking,insight-deriver}.service.test.ts` all open with `// @ts-nocheck — test mocks use loose types`. Combined with `as unknown as SettingsService` / `as unknown as SkillTrackingService` mocks (seven occurrences in `dream.service.test.ts` alone), the memory subsystem's tests exercise almost no type contract.
+- **Risk**: A service signature change in `MemoryStoreService` passes TypeScript *and* its own tests because the tests have type-checking disabled. The regression surfaces in integration or prod.
+- **Recommendation**: Delete `@ts-nocheck`, create `src/services/memory/__tests__/mocks.ts` with typed partial-mock factories (`createMockSettingsService(overrides?)`), and fix whatever type errors surface. Small tactical effort; removes an entire class of silent regressions.
+
+### F12-11: `router.ts` carries 9 identical `biome-ignore useHookAtTopLevel`
+- **Priority**: P3
+- **Observation**: `src/server/router.ts:323-337` has nine copies of `// biome-ignore lint/correctness/useHookAtTopLevel: useRoleGuard is a Hono middleware helper, not a React hook`. The rule fires because the helper is named `useRoleGuard` — Biome's heuristic is purely syntactic.
+- **Risk**: Noise invites cargo-culting (new ignores added without checking). A genuine misuse would be buried in the same visual block.
+- **Recommendation**: Rename `useRoleGuard` → `requireRole` (or `roleGuard`). One rename deletes all nine ignores and removes the false positive permanently. Most of the remaining 28 `biome-ignore`s are legitimate (Shiki HTML, dnd-kit attribute spread, intentional `noAutofocus`) — they should carry a short "why this is correct" rationale, which most already do.
+
+### F12-12: Date/time representation is not normalised
+- **Priority**: P3
+- **Observation**: 611 `new Date()` / `Date.now()` sites across 211 files. Drizzle columns are a mix of `text('created_at')` (ISO string via `new Date().toISOString()`), `integer('created_at', { mode: 'timestamp_ms' })` (Unix ms), and `timestamp` (PG-only). The Caddy-produced event envelope uses Unix ms; `session_events.created_at` is ISO text; `userSessions.expiresAt` is ISO text compared via `lt(..., now)` string comparison in `auth.ts:317`.
+- **Risk**: String-comparison of ISO timestamps works only because the format is fixed-width; a migration to local-offset or microseconds would silently break ordering. Mixing `Date.now()` with ISO-stored columns requires `new Date(ms).toISOString()` at every boundary — easy to forget.
+- **Recommendation**: Pick Unix ms as the canonical internal representation, keep ISO text only for human-readable audit columns. Add `src/lib/utils/time.ts` with `nowMs()`, `toIso(ms)`, `fromIso(text)` helpers; run a migration to convert the handful of ISO-stored timestamp columns. Follow-up, not urgent — but document the convention in CLAUDE.md so it stops drifting.

--- a/specs/arch_review_april/README.md
+++ b/specs/arch_review_april/README.md
@@ -1,0 +1,253 @@
+# AgentPane Architecture Review — April 2026
+
+## Scope & method
+
+- **Date**: 2026-04-20
+- **Branch**: `arch-review-april` (forked from `main` at commit `f9605383`)
+- **Reviewer**: generated via multi-agent pass. Each themed file was authored by a focused agent reading current code on the branch head; findings are anchored to real file paths and line numbers at that commit.
+- **What was reviewed** (12 themes):
+  1. [Service architecture](01-service-architecture.md) — bootstrap, DI container, facade services, state holders
+  2. [Data layer](02-data-layer.md) — Drizzle schemas (SQLite + Postgres), migrations, JSON columns, transactions
+  3. [Agent execution](03-agent-execution.md) — host-mode vs container-mode, plan/approval/execute, AgentCore remnant
+  4. [Sandbox providers](04-sandbox-providers.md) — Docker / K8s (`Sandbox` CRD) / Nomad parity, image supply chain
+  5. [Event streaming](05-event-streaming.md) — Durable Streams, SSE, SQLite event table, Caddy fan-out
+  6. [Security](06-security.md) — injection surfaces, RBAC parity, OAuth/tokens, CSP, supply chain, sandbox escape
+  7. [API surface](07-api-surface.md) — envelopes, pagination, rate limits, request-ID, OpenAPI gap
+  8. [Frontend](08-frontend.md) — TanStack Start routing, shell providers, tests, theming
+  9. [Testing](09-testing.md) — Vitest projects, Stryker, fast-check, E2E, schema-drift coverage
+  10. [Observability](10-observability.md) — logging, metrics, tracing, silent catches, audit logs
+  11. [Operations & deployment](11-operations-deployment.md) — CI/CD, Docker, Helm, backups, release process
+  12. [Cross-cutting](12-cross-cutting.md) — type escapes, `Result<T,E>` discipline, timers, config, magic numbers
+- **What was NOT reviewed**: roadmap items in `specs/roadmap/` (explicitly future work); scope consciously skipped includes memory/Honcho deep review, Terraform Compose UX, topology-designer UX, and `@agentpane/cli-monitor` package internals (it was reviewed only at the packaging layer in theme 11).
+
+## How to read this review
+
+- **Priority key**
+  - **P0** — release blocker: data-loss, silent data corruption, RCE, auth bypass, or an operational dead-end we cannot ship past.
+  - **P1** — must-fix before the next major release: silent failure modes, scaling walls, material security gaps, compliance risk, or foundational debt that multiplies the cost of every future feature.
+  - **P2** — should-fix in the next 2–3 sprints: maintainability, type-safety, test-coverage gaps, consistency drift, polish that materially affects debuggability.
+  - **P3** — opportunistic: docs, minor cleanup, feature-flagged improvements, candidates for "cleanup Friday".
+- **Effort key**
+  - **XS** — < 2 hours
+  - **S** — < 1 day
+  - **M** — 1–3 days
+  - **L** — 1–2 weeks
+  - **XL** — > 2 weeks
+- **File refs** use `path:line` format; line numbers were verified against the branch head (`f9605383`). Where a finding cites multiple files, the master table lists the primary reference.
+- **Cross-links** to prior reviews — consolidated against `specs/events_review/` (streaming) and `specs/release_plan/` (01 test-suite, 02 security, 03 observability, 04 release, 05 error-resilience, 06 database-integrity, 08 frontend). See the "What this supersedes" table below.
+- **Anchor format** — GitHub renders `### F06-02: Title` as `#f06-02-title`. Short `#f06-02` anchors are used in the master table where themes used plain numeric anchors (03, 04 use `#f1`..`#f17` / `#p0-01` etc.); full title slugs are used where the theme file uses the `### FXX-NN: Title` format.
+
+## Executive summary
+
+AgentPane is a **pre-production, late-beta** system: the service skeleton is sound (30+ services with a properly ordered DI container, a 7/8-subsystem `/api/health` probe, a structured JSON logger with redaction, a comprehensive Vitest + integration + functional test split, Drizzle with dual SQLite/Postgres schemas, and a real facade refactor on Agent/ContainerAgent/Session), and the core Kanban→plan→execute loop works end-to-end. The three biggest risks to a production launch are (1) **supply-chain / sandbox boundary** — the default agent-sandbox image is an unpinned personal Docker Hub tag (`srlynch1/agent-sandbox:latest`) pulled by every tenant, with no signing, scanning, or reproducible build, while Dependabot carries 2 critical and 17 high advisories against the main branch; (2) **no CD, no release artefact, Postgres migrations 19 versions behind SQLite, Helm stores state in `emptyDir`, backups exist but never run** — so a Helm-based production deployment today would fail on first rollout and have no rollback path; and (3) **silent-failure surface** — plan-mode drops events into a getter nobody reads, three sandbox providers disagree on `list()`/`execAsRoot()` semantics, schema-drift tests cover 2 of 42 tables, the in-memory rate limiter can be bypassed by restart, and two execution paths (host-mode vs container-mode) have drifted on plan→execute resume. Net read: **production-ready with caveats** for a trusted-tenant self-hosted install on SQLite + single-host Docker; **pre-production** for multi-tenant, K8s, or Postgres deployments.
+
+## Priority snapshot
+
+| Priority | Count | Themes contributing most |
+| --- | --- | --- |
+| **P0** | 4 | 06-security (3), 04-sandbox-providers (1) |
+| **P1** | 59 | 11-operations (8), 06-security (8), 05-event-streaming (7), 04-sandbox-providers (7), 03-agent-execution (6), 10-observability (5) |
+| **P2** | 81 | 02-data-layer (10), 01-service-architecture (7), 03-agent-execution (8), 04-sandbox-providers (8), 05-event-streaming (8), 08-frontend (7), 09-testing (7), 12-cross-cutting (8), 10-observability (6) |
+| **P3** | 31 | 04-sandbox-providers (5), 07-api-surface (4), 08-frontend (4), 11-operations (2), others |
+| **Total** | **175** | across 12 themes |
+
+## Top recommendations (prioritized)
+
+Master table sorted by priority DESC, then theme number ASC. Includes every P0 (4) and every P1 (59), plus top P2 and P3 by operational blast radius.
+
+| # | Priority | Theme | Finding | File refs | Effort | Link |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | P0 | 04 Sandbox | Container-escape blast radius hinges on unpinned `srlynch1/agent-sandbox:latest` | `src/lib/sandbox/types.ts:91`, `docker/Dockerfile.agent-sandbox` | L | [P0-01](04-sandbox-providers.md#p0-01-container-escape-blast-radius-hinges-on-one-undocumented-docker-image-tag-srlynch1agent-sandboxlatest-with-no-signature-pinning-no-scanning-and-no-reproducible-build) |
+| 2 | P0 | 06 Security | Dependabot: 42 open advisories (2 critical, 17 high) | GitHub security alerts | M | [F06-01](06-security.md#f06-01--p0--dependabot-42-open-advisories-2-critical-17-high) |
+| 3 | P0 | 06 Security | Shell interpolation in `createBunCommandRunner` | `src/server/bootstrap/service-container.ts:62`, `src/services/codespace.service.ts:528` | M | [F06-02](06-security.md#f06-02--p0--shell-interpolation-in-createbuncommandrunner) |
+| 4 | P0 | 06 Security | YAML injection via skill/agent metadata → SKILL.md frontmatter | `src/lib/sandbox/skill-injector.ts:42-132` | S | [F06-03](06-security.md#f06-03--p0--yaml-injection-via-skillagent-metadata--skillmd-frontmatter) |
+| 5 | P1 | 01 Service | In-memory running-agent state has no DB reconciliation on restart | `src/services/container-agent/sandbox-state.ts:19-28`, `phases/recovery.ts:36-85` | M | [F01-01](01-service-architecture.md#f01-01-in-memory-running-agent-state-has-no-db-reconciliation-on-restart) |
+| 6 | P1 | 01 Service | Sandbox provider initialization is fire-and-forget with no readiness gate | `src/server/bootstrap/server-bootstrap.ts:211-217`, `sandbox-init.ts:185` | S | [F01-03](01-service-architecture.md#f01-03-sandbox-provider-initialization-is-fire-and-forget-with-no-readiness-gate-for-dependents) |
+| 7 | P1 | 01 Service | Bootstrap phase failures have inconsistent exit behaviour | `phases/database.ts:43`, `phases/api-key-resolution.ts:36-42`, `phases/schedulers.ts:51-57` | S | [F01-05](01-service-architecture.md#f01-05-bootstrap-phase-failures-have-inconsistent-exit-behaviour) |
+| 8 | P1 | 02 Data | PostgreSQL migration chain lives in one 590-line mega-migration | `src/db/migrations-pg/0004_schema_catchup.sql` | M | [F02-01](02-data-layer.md#f02-01-postgresql-migration-chain-lives-in-one-590-line-mega-migration) |
+| 9 | P1 | 02 Data | Schema-drift tests cover 2 of 42 tables | `tests/integration/*-schema-drift.test.ts`, `scripts/check-schema-drift.ts` | M | [F02-02](02-data-layer.md#f02-02-schema-drift-tests-cover-2-of-42-tables) |
+| 10 | P1 | 02 Data | PostgreSQL client has no pool/timeout tuning | `src/server/bootstrap/phases/database.ts:46` | S | [F02-05](02-data-layer.md#f02-05-postgresql-client-has-no-pooltimeout-tuning) |
+| 11 | P1 | 02 Data | PostgreSQL path has no runtime migration-safety tests | `src/db/migrations-pg/`, `tests/integration/` | M | [F02-13](02-data-layer.md#f02-13-postgresql-path-has-no-runtime-migration-safety-tests) |
+| 12 | P1 | 03 Agent | AgentCore path is dead code but still present in two packages | `src/services/container-agent/agentcore-*`, `packages/agentcore-*` | M | [F1](03-agent-execution.md#f1--agentcore-path-is-dead-code-but-still-present-in-two-packages) |
+| 13 | P1 | 03 Agent | Tool-use hooks are registered but never installed in the SDK session | `src/lib/agents/stream-handler.ts`, `agent-execution.service.ts:80-85` | M | [F2](03-agent-execution.md#f2--tool-use-hooks-are-registered-but-never-installed-in-the-sdk-session) |
+| 14 | P1 | 03 Agent | `launchSwarm`/`teammateCount` carried end-to-end but never acted on | `src/lib/agents/stream-handler.ts`, `agent-runner/src/index.ts` | S/XL | [F3](03-agent-execution.md#f3--plan-option-fields-launchswarm-teammatecount-are-carried-end-to-end-but-never-acted-on) |
+| 15 | P1 | 03 Agent | Host-mode cannot resume an SDK session across plan approval | `src/services/agent/agent-execution.service.ts:932`, `stream-handler.ts:947` | M | [F5](03-agent-execution.md#f5--host-mode-cannot-resume-an-sdk-session-across-plan-approval) |
+| 16 | P1 | 03 Agent | `rejectPlan` has no host-mode fallback | `src/services/task.service.ts:242-250` | S | [F6](03-agent-execution.md#f6--rejectplan-has-no-host-mode-fallback) |
+| 17 | P1 | 03 Agent | `agent-runner` mints fake OAuth `expiresAt` and null `refreshToken` | `agent-runner/src/index.ts:303` | M | [F11](03-agent-execution.md#f11--agent-runner-mints-fake-oauth-expiresat-and-a-null-refreshtoken) |
+| 18 | P1 | 04 Sandbox | `SandboxProvider` interface is not uniform; three providers diverge on `list`/`execAsRoot`/errors | `src/lib/sandbox/sandbox-provider.ts:124-167`, `agent-sandbox-provider.ts`, `nomad-sandbox-provider.ts` | L | [P1-01](04-sandbox-providers.md#p1-01-the-sandboxprovider-interface-is-not-actually-uniform--agentcore-is-a-fourth-execution-path-that-doesnt-implement-it-and-the-three-crd-style-providers-diverge-on-key-contracts) |
+| 19 | P1 | 04 Sandbox | AgentCore half-deleted; dynamic-import AWS SDK not declared as dependency | `agentcore-sandbox-provider.ts:247-337`, `package.json` | M | [P1-02](04-sandbox-providers.md#p1-02-agentcore-is-half-deleted--migration-0011-dropped-the-db-columns-but-1200-loc-of-providerinstancebridgeerrors-code-remains-reachable-and-the-health-path-uses-a-dynamic-import-aws-sdk-that-is-never-declared-as-a-dependency) |
+| 20 | P1 | 04 Sandbox | K8s/Nomad have no orphan cleanup on startup | `agent-sandbox-provider.ts`, `nomad-sandbox-provider.ts`, `src/server/bootstrap/sandbox/` | M | [P1-03](04-sandbox-providers.md#p1-03-provider-cleanup-of-orphans-only-exists-for-docker--kubernetes-podspvcs-and-nomad-jobs-have-no-startup-sweep-so-a-crash-leaves-cluster-side-resources-running-forever) |
+| 21 | P1 | 04 Sandbox | `POD_ALREADY_EXISTS`/`JOB_ALREADY_EXISTS` guards check only in-memory state | `agent-sandbox-provider.ts:125-137`, `nomad-sandbox-provider.ts:130-143` | M | [P1-04](04-sandbox-providers.md#p1-04-pod_already_exists--job_already_exists-guards-check-only-in-memory-state-so-a-server-restart-with-a-still-running-k8snomad-sandbox-creates-a-duplicate) |
+| 22 | P1 | 04 Sandbox | Credentials injected via shell exec — token visible in argv | `src/lib/sandbox/credentials-injector.ts:71-87`, `container-exec.service.ts:767` | S | [P1-05](04-sandbox-providers.md#p1-05-credentials-injection-writes-the-oauth-token-via-a-shell-exec-that-embeds-it-in-the-command-string--base64-helps-but-a-compromisedhostile-image-can-still-capture-it-from-argv) |
+| 23 | P1 | 04 Sandbox | No network policy, egress filtering, or east-west isolation on any provider | `docker-provider.ts:568`, `SandboxBuilder`, `nomad-sandbox-provider.ts` | L | [P1-06](04-sandbox-providers.md#p1-06-no-network-policy-egress-filtering-or-east-west-isolation-on-any-provider) |
+| 24 | P1 | 04 Sandbox | Resource limits not validated per-tenant (32GB/16CPU global cap only) | `src/lib/sandbox/types.ts:104-115`, `SandboxConfigService` | M | [P1-07](04-sandbox-providers.md#p1-07-resource-limits-are-not-validated-per-tenant--sandboxconfigschema-caps-at-32-gb-memory--16-cpu-cores-globally-but-nothing-enforces-a-per-tenant-ceiling) |
+| 25 | P1 | 05 Stream | No code enforcement of stream-ID conventions (`plan:`/`sandbox:`/`terraform:`) | `src/services/durable-streams.service.ts:422-482`, `src/lib/streams/caddy-producer.ts:12-22` | S | [F05-01](05-event-streaming.md#f05-01--no-code-enforcement-of-stream-id-conventions) |
+| 26 | P1 | 05 Stream | `droppedEventCount` is invisible beyond a getter (13 drop sites, 0 consumers) | `src/services/plan-mode.service.ts:67-116,194,206,263,386,403,453,532,545,570,600,667,679` | S | [F05-02](05-event-streaming.md#f05-02--droppedeventcount-is-invisible-beyond-a-getter) |
+| 27 | P1 | 05 Stream | SSE connection cap still 50 with two separate counters | `src/services/durable-streams.service.ts`, `src/lib/streams/` | S | [F05-03](05-event-streaming.md#f05-03--sse-connection-cap-still-50-with-two-separate-counters) |
+| 28 | P1 | 05 Stream | `MAX_CHUNKS=5000` silently drops history on the client | `src/app/hooks/useSession.ts` | S | [F05-04](05-event-streaming.md#f05-04--max_chunks5000-silently-drops-history-on-the-client) |
+| 29 | P1 | 05 Stream | Dual-write still best-effort; no transactional outbox | `src/services/durable-streams.service.ts`, `session_events` table | M | [F05-05](05-event-streaming.md#f05-05--dual-write-still-best-effort-no-transactional-outbox) |
+| 30 | P1 | 05 Stream | No client-side gap detection on reconnect | `src/lib/streams/client.ts` | S-M | [F05-06](05-event-streaming.md#f05-06--no-client-side-gap-detection-on-reconnect) |
+| 31 | P1 | 05 Stream | Caddy SSE endpoints still unauthenticated | `Caddyfile`, `src/lib/streams/caddy-producer.ts` | M | [F05-07](05-event-streaming.md#f05-07--caddy-sse-endpoints-still-unauthenticated) |
+| 32 | P1 | 06 Security | Plan content → GitHub issue body is neither escaped nor sanitized | `src/lib/github/issue-creator.ts:47-54,169,202` | S | [F06-04](06-security.md#f06-04--p1--plan-content--github-issue-body-is-neither-escaped-nor-sanitized) |
+| 33 | P1 | 06 Security | Dev-mode bypass depends on env-var alignment across two layers | `src/server/middleware/rbac-middleware.ts:62`, `server-config.ts` | S | [F06-05](06-security.md#f06-05--p1--dev-mode-bypass-depends-on-env-var-alignment-across-two-layers) |
+| 34 | P1 | 06 Security | Default-allow tool whitelist when `allowedTools` is empty | `src/lib/agents/tool-whitelist.ts:8-9` | XS | [F06-06](06-security.md#f06-06--p1--default-allow-tool-whitelist-when-allowedtools-is-empty) |
+| 35 | P1 | 06 Security | In-memory rate limiter: bypassable by restart + multi-instance drift | `src/server/middleware/rate-limit.ts` | M | [F06-07](06-security.md#f06-07--p1--in-memory-rate-limiter-bypassable-by-restart--multi-instance-drift) |
+| 36 | P1 | 06 Security | Tenant isolation in shared sandbox mode | `docker-provider.ts`, `~/.claude/.credentials.json` injection path | L | [F06-08](06-security.md#f06-08--p1--tenant-isolation-in-shared-sandbox-mode) |
+| 37 | P1 | 06 Security | API keys and GitHub OAuth tokens: no rotation, no expiry | `src/services/api-key.service.ts`, `src/services/github-token.service.ts` | M | [F06-09](06-security.md#f06-09--p1--api-keys-and-github-oauth-tokens-no-rotation-no-expiry) |
+| 38 | P1 | 06 Security | CSP blocks required external resources; likely unused in production | `src/server/router.ts:110` | S | [F06-10](06-security.md#f06-10--p1--csp-blocks-required-external-resources-likely-unused-in-production) |
+| 39 | P1 | 06 Security | Markdown rendering trusts Shiki HTML; agent-controlled input | `src/app/components/markdown-content.tsx:82`, `terraform-right-panel.tsx:242` | S | [F06-11](06-security.md#f06-11--p1--markdown-rendering-trusts-shikis-html-but-the-input-path-is-agent-controlled) |
+| 40 | P1 | 07 API | Pagination: cursor spec vs offset reality | `src/server/routes/*.ts`, `specs/application/api/pagination.md` | L | [F07-01](07-api-surface.md#f07-01--pagination-cursor-spec-vs-offset-reality) |
+| 41 | P1 | 07 API | `{ok:true, data:[]}` used to mask infrastructure failures | `src/server/routes/events.ts`, `sandbox.ts` | S | [F07-03](07-api-surface.md#f07-03--oktrue-data-used-to-mask-infrastructure-failures) |
+| 42 | P1 | 07 API | Rate limit is per-IP, in-process, multiplies across instances | `src/server/middleware/rate-limit.ts` | M | [F07-04](07-api-surface.md#f07-04--rate-limit-is-per-ip-in-process-multiplies-across-instances) |
+| 43 | P1 | 07 API | Request-ID never reaches services or event payloads | `src/lib/context/request-context.ts`, services, event publishers | M | [F07-05](07-api-surface.md#f07-05--request-id-never-reaches-services-or-event-payloads) |
+| 44 | P1 | 08 Frontend | Every prior readiness critical is still open (14 MB bundle, missing error boundaries, 120 console.*) | `src/app/routes/**`, `src/app/components/**` | M | [F08-01](08-frontend.md#f08-01-every-prior-readiness-critical-is-still-open) |
+| 45 | P1 | 08 Frontend | Frontend test directory is empty | `src/app/__tests__/`, `vitest.config.ts` | M | [F08-02](08-frontend.md#f08-02-frontend-test-directory-is-empty) |
+| 46 | P1 | 09 Testing | Schema-drift coverage is 2 of 42 tables | `tests/integration/*-schema-drift.test.ts` | M | [F09-01](09-testing.md#f09-01-schema-drift-coverage-is-2-of-42-tables) |
+| 47 | P1 | 09 Testing | Frontend project is zero-tests | `src/app/**` | M | [F09-02](09-testing.md#f09-02-frontend-project-is-zero-tests) |
+| 48 | P1 | 09 Testing | Functional tests mix real-service flow with raw DB writes | `tests/functional/**` | M | [F09-03](09-testing.md#f09-03-functional-tests-mix-real-service-flow-with-raw-db-writes) |
+| 49 | P1 | 09 Testing | Stryker coverage is 6 files; ~400 source files rely on line coverage | `stryker.config.json` | L | [F09-04](09-testing.md#f09-04-stryker-coverage-is-6-files-400-source-files-rely-on-line-coverage) |
+| 50 | P1 | 10 Observability | No `/metrics` endpoint at all | `src/server/routes/` | S-M | [F10-01](10-observability.md#f10-01--no-metrics-endpoint-at-all) |
+| 51 | P1 | 10 Observability | No distributed tracing across the agent hot path | `src/lib/context/`, Claude SDK call sites | S-L | [F10-03](10-observability.md#f10-03--no-distributed-tracing-across-the-agent-hot-path) |
+| 52 | P1 | 10 Observability | No error reporting integration (Sentry/Datadog) | `src/server/api.ts`, `uncaughtException` handler | S | [F10-04](10-observability.md#f10-04--no-error-reporting-integration) |
+| 53 | P1 | 10 Observability | Agent-runner logs are raw `console.*`, not structured | `agent-runner/src/index.ts` (79 sites) | M | [F10-05](10-observability.md#f10-05--agent-runner-logs-are-raw-console-not-structured) |
+| 54 | P1 | 10 Observability | `droppedEventCount` is still invisible (duplicate F05-02) | `src/services/plan-mode.service.ts:67-116` | XS | [F10-09](10-observability.md#f10-09--droppedeventcount-is-still-invisible) |
+| 55 | P1 | 11 Operations | No CD pipeline — zero automated path from main to running image | `.github/workflows/` | L | [F11-01](11-operations-deployment.md#f11-01-no-cd-pipeline--zero-automated-path-from-main-to-a-running-image) |
+| 56 | P1 | 11 Operations | Docker image and Helm chart expose divergent runtime architectures (Caddy absent in K8s) | `docker/start.sh`, `charts/agentpane/templates/deployment.yaml:41-44` | M | [F11-02](11-operations-deployment.md#f11-02-docker-image-and-helm-chart-expose-divergent-runtime-architectures) |
+| 57 | P1 | 11 Operations | Graceful shutdown does not flush in-flight agent runs or sandbox containers | `src/server/bootstrap/shutdown.ts`, `phases/recovery.ts` | M | [F11-03](11-operations-deployment.md#f11-03-graceful-shutdown-does-not-flush-in-flight-agent-runs-or-sandbox-containers) |
+| 58 | P1 | 11 Operations | PostgreSQL migrations are 19 versions behind SQLite | `src/lib/bootstrap/migrations/index.ts`, `src/db/migrations-pg/` | L | [F11-04](11-operations-deployment.md#f11-04-postgresql-migrations-are-19-versions-behind-sqlite) |
+| 59 | P1 | 11 Operations | Migrations race on multi-replica rollouts | `src/server/bootstrap/phases/database.ts`, `charts/agentpane/` | M | [F11-05](11-operations-deployment.md#f11-05-migrations-race-on-multi-replica-rollouts) |
+| 60 | P1 | 11 Operations | Helm chart persists application data in `emptyDir` | `charts/agentpane/templates/deployment.yaml:131-136` | M | [F11-06](11-operations-deployment.md#f11-06-helm-chart-persists-application-data-in-emptydir) |
+| 61 | P1 | 11 Operations | Agent sandbox base image is a personal DockerHub tag with `:latest` | `docker/Dockerfile.agent-sandbox:13-15` | M | [F11-07](11-operations-deployment.md#f11-07-agent-sandbox-base-image-is-a-personal-dockerhub-tag-with-latest) |
+| 62 | P1 | 11 Operations | CLI monitor publishing puts the npm token in a spec directory | `/specs/CLI_monitor/.env`, `packages/cli-monitor/package.json` | S | [F11-08](11-operations-deployment.md#f11-08-cli-monitor-publishing-puts-the-npm-token-in-a-spec-directory) |
+| 63 | P1 | 12 Cross-cutting | Background timer lifecycle is inconsistent (11 `setInterval` producers) | `src/services/{scheduler,event-cleanup,task-creation,…}.service.ts` | S | [F12-04](12-cross-cutting.md#f12-04-background-timer-lifecycle-is-inconsistent) |
+| 64 | P2 | 01 Service | Late-binding optional setters on TaskService bypass type-level guarantees | `src/services/task.service.ts:122-132,194-236` | M | [F01-02](01-service-architecture.md#f01-02-late-binding-optional-setters-on-taskservice-bypass-type-level-init-guarantees) |
+| 65 | P2 | 01 Service | Two overlapping "running agents" maps create consistency hazards | `sandbox-state.ts:19-22`, `agent-execution.service.ts:80-85` | M | [F01-06](01-service-architecture.md#f01-06-two-overlapping-running-agents-maps-create-consistency-hazards) |
+| 66 | P2 | 01 Service | TaskCreationService is a 2,623-line monolith | `src/services/task-creation.service.ts` | L | [F01-07](01-service-architecture.md#f01-07-taskcreationservice-is-a-2623-line-monolith-that-escaped-the-facade-refactor) |
+| 67 | P2 | 02 Data | Raw SQL in `/api/health` violates "Never bypass Drizzle" | `src/server/routes/health.ts:99-114` | S | [F02-03](02-data-layer.md#f02-03-raw-sql-in-apihealth-violates-never-bypass-drizzle-rule) |
+| 68 | P2 | 02 Data | `as unknown as TaskPlanRow` indicates schema/query shape mismatch | `plan-approval.service.ts:197,474,485`, `container-exec.service.ts:1186` | S | [F02-04](02-data-layer.md#f02-04-as-unknown-as-taskplanrow-indicates-schemaquery-shape-mismatch) |
+| 69 | P2 | 02 Data | Migration runner swallows every "duplicate column" exception | `src/lib/bootstrap/migrations/runner.ts:41-47,53-60` | M | [F02-07](02-data-layer.md#f02-07-migration-runner-swallows-every-duplicate-column-exception) |
+| 70 | P2 | 02 Data | Task-delete and many multi-step writes skip transactions | `src/services/task.service.ts`, `codespace.service.ts` | M | [F02-11](02-data-layer.md#f02-11-task-delete-and-many-multi-step-writes-skip-transactions) |
+| 71 | P2 | 02 Data | Two parallel migration chains — inline runner vs Drizzle Kit | `src/lib/bootstrap/migrations/`, `src/db/migrations-pg/` | L | [F02-12](02-data-layer.md#f02-12-two-parallel-migration-chains--inline-runner-vs-drizzle-kit) |
+| 72 | P2 | 03 Agent | Two stream handlers evolved in parallel and drifted | `src/lib/agents/stream-handler.ts`, `agent-runner/src/index.ts` | L | [F12](03-agent-execution.md#f12--two-stream-handlers-evolved-in-parallel-and-drifted) |
+| 73 | P2 | 03 Agent | `executeAgentExecution` catches too broadly; agent stays "starting" on sub-failures | `src/services/agent/agent-execution.service.ts` | M | [F14](03-agent-execution.md#f14--executeagentexecution-catches-too-broadly-agent-stays-starting-on-sub-failures) |
+| 74 | P2 | 04 Sandbox | Three near-identical tmux implementations across providers | `docker-provider.ts:120-217`, `agent-sandbox-instance.ts:210-313`, `nomad-sandbox-instance.ts:268-397` | M | [P2-01](04-sandbox-providers.md#p2-01-three-near-identical-tmux-implementations-across-dockersandbox-agentsandboxinstance-and-nomadsandboxinstance) |
+| 75 | P2 | 04 Sandbox | `shellEscape` implemented three times; K8s `indexOf('exec ')` is latent bug | `agent-sandbox-instance.ts:100-102,154`, `nomad-sandbox-instance.ts:137-139,182` | S | [P2-02](04-sandbox-providers.md#p2-02-shellescape-is-implemented-three-times-with-subtle-differences-and-execstream-env-injection-logic-differs-between-nomad-lastindexofexec--and-k8s-indexofexec-) |
+| 76 | P2 | 04 Sandbox | `validateContainers`/`validateSandboxes` silently remove entries | `docker-provider.ts:680-686`, `agent-sandbox-provider.ts:240-248`, `nomad-sandbox-provider.ts:274-283` | S | [P2-05](04-sandbox-providers.md#p2-05-validatecontainersvalidatesandboxes-silently-remove-entries--no-event-no-db-reconciliation) |
+| 77 | P2 | 04 Sandbox | Health checks don't probe sandbox liveness, only provider connectivity | `docker-provider.ts`, `agent-sandbox-provider.ts`, `nomad-sandbox-provider.ts` | M | [P2-07](04-sandbox-providers.md#p2-07-health-checks-dont-probe-sandbox-liveness-only-provider-connectivity) |
+| 78 | P2 | 05 Stream | Three parallel SSE subsystems, three connection counters | `src/services/durable-streams.service.ts`, `cli-monitor.service.ts`, plan-mode | M | [F05-08](05-event-streaming.md#f05-08--three-parallel-sse-subsystems-three-connection-counters) |
+| 79 | P2 | 05 Stream | `session_events.sessionId` stores unrelated stream IDs with no FK | `src/db/schema/*/session-events.ts` | M | [F05-09](05-event-streaming.md#f05-09--session_eventssessionid-stores-unrelated-stream-ids-with-no-fk) |
+| 80 | P2 | 05 Stream | SQLite single-writer serialises all event persistence | `src/db/client.ts`, `session_events` table | S-L | [F05-10](05-event-streaming.md#f05-10--sqlite-single-writer-serialises-all-event-persistence) |
+| 81 | P2 | 06 Security | RBAC enforcement parity: six route modules miss `useRoleGuard` | `src/server/router.ts`, `src/server/routes/{tags,rbac-tokens,codespace-members}.ts` | M | [F06-12](06-security.md#f06-12--p2--rbac-enforcement-parity-six-route-modules-miss-useroleguard) |
+| 82 | P2 | 06 Security | Session cookie `Secure` flag keyed on NODE_ENV, not protocol | `src/server/routes/auth.ts:196,236,252,276,295` | S | [F06-13](06-security.md#f06-13--p2--session-cookie-secure-flag-keyed-on-nodeenv-not-protocol) |
+| 83 | P2 | 06 Security | Plan/sandbox/terraform stream IDs cross boundaries without origin checks | `src/services/durable-streams.service.ts`, `Caddyfile` | L | [F06-14](06-security.md#f06-14--p2--plansandboxterraform-stream-ids-cross-boundaries-without-origin-checks) |
+| 84 | P2 | 07 API | No OpenAPI schema; frontend types duplicate server types | `src/lib/api/client.ts`, `src/server/routes/` | M-L | [F07-06](07-api-surface.md#f07-06--no-openapi-schema-frontend-types-duplicate-server-types) |
+| 85 | P2 | 07 API | Two route modules (events.ts, sandbox.ts) are oversized and mix concerns | `src/server/routes/events.ts` (1168 LOC), `sandbox.ts` (1341 LOC) | M | [F07-07](07-api-surface.md#f07-07--two-route-modules-are-oversized-and-mix-concerns) |
+| 86 | P2 | 08 Frontend | Hardcoded SVG hex colours violate the theme contract | `src/app/components/**/*.tsx` (SVG inlines) | S | [F08-04](08-frontend.md#f08-04-hardcoded-svg-hex-colours-violate-the-theme-contract) |
+| 87 | P2 | 08 Frontend | Stream event contract is stringly-typed on the client | `src/app/hooks/useSession.ts`, `src/lib/streams/client.ts` | M | [F08-07](08-frontend.md#f08-07-stream-event-contract-is-stringly-typed-on-the-client) |
+| 88 | P2 | 08 Frontend | No per-route `errorComponent` — route crash unmounts the shell | `src/app/routes/**` | S | [F08-09](08-frontend.md#f08-09-no-per-route-errorcomponent--route-crash-unmounts-the-shell) |
+| 89 | P2 | 09 Testing | fast-check installed but used in 2 files | `tests/**`, `package.json` | M | [F09-05](09-testing.md#f09-05-fast-check-installed-but-used-in-2-files) |
+| 90 | P2 | 09 Testing | E2E has 20 files but no full task-lifecycle scenario | `tests/e2e/**` | M | [F09-06](09-testing.md#f09-06-e2e-has-20-files-but-no-full-task-lifecycle-scenario) |
+| 91 | P2 | 09 Testing | No retry / no flake detection | `vitest.config.ts`, `.github/workflows/ci.yml` | S | [F09-09](09-testing.md#f09-09-no-retry--no-flake-detection) |
+| 92 | P2 | 10 Observability | Silent-catch tail across 78 server files and 168 occurrences | `src/**/*.ts` (catch blocks) | S | [F10-02](10-observability.md#f10-02--silent-catch-tail-across-78-server-files-and-168-occurrences) |
+| 93 | P2 | 10 Observability | Frontend observability is effectively zero (241 console.* in 70 files) | `src/app/**` | S | [F10-07](10-observability.md#f10-07--frontend-observability-is-effectively-zero) |
+| 94 | P2 | 10 Observability | Request ID not attached to durable-stream events or audit entries | `src/lib/context/request-context.ts`, event publishers | S | [F10-08](10-observability.md#f10-08--request-id-is-not-attached-to-durable-stream-events-or-audit-entries) |
+| 95 | P2 | 10 Observability | `invariant()` violations log-and-continue in prod | `src/lib/assert/invariant.ts`, call sites | XS | [F10-13](10-observability.md#f10-13--invariant-violations-log-and-continue-in-prod) |
+| 96 | P2 | 11 Operations | Secret management differs between Compose and Helm with no parity | `docker/docker-compose*.yml`, `charts/agentpane/values.yaml` | S | [F11-09](11-operations-deployment.md#f11-09-secret-management-differs-between-compose-and-helm-with-no-parity) |
+| 97 | P2 | 11 Operations | Backup scripts exist but nothing runs them | `scripts/backup-db.sh`, `scripts/backup-db-pg.sh` | S | [F11-10](11-operations-deployment.md#f11-10-backup-scripts-exist-but-nothing-runs-them) |
+| 98 | P2 | 12 Cross-cutting | Drizzle polymorphism forces three runtime type holes | `src/db/schema/**`, `src/services/**` (29 casts) | M | [F12-01](12-cross-cutting.md#f12-01-drizzle-polymorphism-forces-three-runtime-type-holes) |
+| 99 | P2 | 12 Cross-cutting | `@ts-nocheck` on five test files hides schema drift | `tests/**/*.ts` (5 files) | S | [F12-10](12-cross-cutting.md#f12-10-ts-nocheck-on-five-test-files-hides-schema-drift) |
+| 100 | P3 | 06 Security | Env vars injected into sandbox containers are visible in `ps auxe` | `docker-provider.ts:562`, `container-exec.service.ts:767` | S | [F06-16](06-security.md#f06-16--p3--env-vars-injected-into-sandbox-containers-are-visible-in-ps-auxe) |
+| 101 | P3 | 04 Sandbox | `SandboxMetrics` returns zeroes on K8s/Nomad; UI renders misleading "0 MB used" | `agent-sandbox-instance.ts:327-335`, `nomad-sandbox-instance.ts:411-419` | M | [P3-05](04-sandbox-providers.md#p3-05-the-sandboxmetrics-interface-typests39-47-promises-cpu--memory-mb-disk-mb-network-bytes-uptime-k8s-and-nomad-return-zero-for-everything-except-uptime-agent-sandbox-instancets327-335-nomad-sandbox-instancets411-419-the-uis-sandbox-indicator-panel-renders-these-zeros-as-0-mb-used-which-is-materially-misleading-either-wire-them-up-via-metrics-server-k8s--nomad-alloc-status--stats-nomad-or-mark-them--null-in-the-type-and-render-unavailable-in-the-ui) |
+| 102 | P3 | 11 Operations | `prepare` script only reminds, never installs pre-commit hooks | `package.json:50` | XS | [F11-13](11-operations-deployment.md#f11-13-prepare-script-only-reminds-never-installs-pre-commit-hooks) |
+| 103 | P3 | 11 Operations | No release notes, no CHANGELOG, no documented rollback | repo root | S | [F11-14](11-operations-deployment.md#f11-14-no-release-notes-no-changelog-no-documented-rollback) |
+| 104 | P3 | 07 API | No OpenAPI schema / endpoint discoverability (docs stale) | `specs/application/api/endpoints.md` | S | [F07-09](07-api-surface.md#f07-09--endpoint-discoverability-no-live-index-docs-stale) |
+
+## Theme index
+
+| File | Theme | Findings | P0 / P1 / P2 / P3 |
+| --- | --- | --- | --- |
+| [01](01-service-architecture.md) | Service architecture | 12 | 0 / 3 / 7 / 2 |
+| [02](02-data-layer.md) | Data layer (Drizzle, migrations, JSON, TX) | 14 | 0 / 4 / 10 / 0 |
+| [03](03-agent-execution.md) | Agent execution (host + container, plan/exec) | 17 | 0 / 6 / 8 / 3 |
+| [04](04-sandbox-providers.md) | Sandbox providers (Docker/K8s/Nomad) | 21 | 1 / 7 / 8 / 5 |
+| [05](05-event-streaming.md) | Event streaming & SSE | 18 | 0 / 7 / 8 / 3 |
+| [06](06-security.md) | Security (injection, RBAC, supply chain) | 16 | 3 / 8 / 4 / 1 |
+| [07](07-api-surface.md) | API surface (envelopes, RL, OpenAPI) | 12 | 0 / 4 / 4 / 4 |
+| [08](08-frontend.md) | Frontend (TanStack Start, theming, tests) | 13 | 0 / 2 / 7 / 4 |
+| [09](09-testing.md) | Testing (Vitest, Stryker, E2E, drift) | 13 | 0 / 4 / 7 / 2 |
+| [10](10-observability.md) | Observability (logs, metrics, tracing) | 13 | 0 / 5 / 6 / 2 |
+| [11](11-operations-deployment.md) | Ops & deployment (CI/CD, Docker/Helm) | 14 | 0 / 8 / 4 / 2 |
+| [12](12-cross-cutting.md) | Cross-cutting (types, timers, config) | 12 | 0 / 1 / 8 / 3 |
+| **Total** | | **175** | **4 / 59 / 81 / 31** |
+
+## What this supersedes
+
+Consolidated from the "What this supersedes" / "Prior-review disposition" tables in themes 05, 06, and 10. Every item below was audited against current code; new findings carry the `FXX-NN` pointer to the new home, resolved items have no new finding.
+
+| Prior finding | Location | Disposition | New home |
+| --- | --- | --- | --- |
+| 2.1 Unbounded retention | `events_review/README.md` §2.1 | **Resolved** — `EventCleanupService` delivers P0-2 | — |
+| 2.2 SQLite single-writer serialisation | `events_review/README.md` §2.2 | Still valid | [F05-10](05-event-streaming.md#f05-10--sqlite-single-writer-serialises-all-event-persistence) |
+| 2.3 No chunk batching | `events_review/README.md` §2.3 | **Resolved** — `ChunkBatcher` | — |
+| 2.4 O(n²) accumulated-text bloat | `events_review/README.md` §2.4 | **Resolved** — `accumulated` removed | — |
+| 2.5 Single-node Caddy | `events_review/README.md` §2.5 | Still valid | [F05-17](05-event-streaming.md#f05-17--single-node-caddy-is-the-live-delivery-spof) |
+| 2.6 50-connection SSE cap | `events_review/README.md` §2.6 | Still valid, promoted to P1 | [F05-03](05-event-streaming.md#f05-03--sse-connection-cap-still-50-with-two-separate-counters) |
+| 2.7 Silent chunk truncation | `events_review/README.md` §2.7 | Still valid | [F05-04](05-event-streaming.md#f05-04--max_chunks5000-silently-drops-history-on-the-client) |
+| 3.1 No backpressure | `events_review/README.md` §3.1 / RS-008 | Still valid | [F05-13](05-event-streaming.md#f05-13--publish-path-has-no-application-level-backpressure) |
+| 3.2 No dead-letter queue | `events_review/README.md` §3.2 | Folded; webhook-specific DLQ out of scope | [F05-05](05-event-streaming.md#f05-05--dual-write-still-best-effort-no-transactional-outbox), [F05-02](05-event-streaming.md#f05-02--droppedeventcount-is-invisible-beyond-a-getter) |
+| 3.3 Container-agent double-hop | `events_review/README.md` §3.3 | Still valid | [F05-11](05-event-streaming.md#f05-11--container-agent-double-hop-latency-and-parse-cost) |
+| 3.5 Offset-based pagination fragility | `events_review/README.md` §3.5 | Partially mitigated; P3 polish | — |
+| 3.6 Memory accumulation in stream handler | `events_review/README.md` §3.6 | Mitigated by batching | — |
+| RS-001 Producer pool unbounded growth | events_review hybrid §2 | **Resolved** — LRU + idle sweep | — |
+| RS-002 Duplicate SSE tracking | events_review hybrid §2 | Still valid | [F05-08](05-event-streaming.md#f05-08--three-parallel-sse-subsystems-three-connection-counters) |
+| RS-006 No gap detection | events_review hybrid §2 | Still valid | [F05-06](05-event-streaming.md#f05-06--no-client-side-gap-detection-on-reconnect) |
+| RS-009 Three disconnected systems | events_review hybrid §2 | Still valid | [F05-08](05-event-streaming.md#f05-08--three-parallel-sse-subsystems-three-connection-counters) |
+| RS-010 Shared subscription map cleanup | events_review hybrid §2 | **Resolved** — 60s orphan audit | — |
+| RS-011 `useSession` unbounded array | events_review hybrid §2 | **Resolved** for growth; surface gap | [F05-04](05-event-streaming.md#f05-04--max_chunks5000-silently-drops-history-on-the-client) |
+| RS-013 Dual-write inconsistency | events_review hybrid §2 | Still valid | [F05-05](05-event-streaming.md#f05-05--dual-write-still-best-effort-no-transactional-outbox) |
+| RS-014 Offset collision retry limited to 3 | events_review hybrid §2 | **Resolved** by atomic INSERT | — |
+| RS-019 Caddy unauthenticated | events_review hybrid §2 | Still valid, raised to P1 | [F05-07](05-event-streaming.md#f05-07--caddy-sse-endpoints-still-unauthenticated) |
+| C1 Docker CapDrop/SecurityOpt | `release_plan/02-security-hardening.md` | **Resolved** | — |
+| C2 Path traversal in GitHub clone | `release_plan/02-security-hardening.md` | **Resolved** | — |
+| C3 Shell interpolation in `codespace.service.cloneRepository` | `release_plan/02-security-hardening.md` | **Partially resolved** — runner path still interpolates | [F06-02](06-security.md#f06-02--p0--shell-interpolation-in-createbuncommandrunner) |
+| C4 Hardcoded CORS origin in SSE | `release_plan/02-security-hardening.md` | **Resolved** | — |
+| H1 No expired session cleanup | `release_plan/02-security-hardening.md` | **Resolved** | — |
+| H2 XFF spoofing in rate limiter | `release_plan/02-security-hardening.md` | **Resolved** | — |
+| H3 Audit hook empty catch | `release_plan/02-security-hardening.md` | **Resolved** | — |
+| H4 In-memory rate limiting | `release_plan/02-security-hardening.md` | Still valid | [F06-07](06-security.md#f06-07--p1--in-memory-rate-limiter-bypassable-by-restart--multi-instance-drift) |
+| H5 Empty tool whitelist allows all | `release_plan/02-security-hardening.md` | Still valid | [F06-06](06-security.md#f06-06--p1--default-allow-tool-whitelist-when-allowedtools-is-empty) |
+| H6 `Secure` cookie only in NODE_ENV=production | `release_plan/02-security-hardening.md` | Still valid | [F06-13](06-security.md#f06-13--p2--session-cookie-secure-flag-keyed-on-nodeenv-not-protocol) |
+| Sensitive data masking in logger | `release_plan/03-observability.md` | **Resolved** — `maskSensitiveData()`, 18 tests | — |
+| Fix silent catch blocks (50+) | `release_plan/03-observability.md` | **Partially resolved** — loud ones fixed, 168 occurrences remain | [F10-02](10-observability.md#f10-02--silent-catch-tail-across-78-server-files-and-168-occurrences) |
+| Replace `console.*` with structured logger | `release_plan/03-observability.md` | **Resolved for server**; agent-runner + frontend untouched | [F10-05](10-observability.md#f10-05--agent-runner-logs-are-raw-console-not-structured), [F10-07](10-observability.md#f10-07--frontend-observability-is-effectively-zero) |
+| Add `service`/`environment` fields | `release_plan/03-observability.md` | **Resolved** | — |
+| `/api/metrics` endpoint | `release_plan/03-observability.md` | Still open | [F10-01](10-observability.md#f10-01--no-metrics-endpoint-at-all) |
+| Sentry / error reporting | `release_plan/03-observability.md` | Still open | [F10-04](10-observability.md#f10-04--no-error-reporting-integration) |
+| OpenTelemetry tracing | `release_plan/03-observability.md` | Still open | [F10-03](10-observability.md#f10-03--no-distributed-tracing-across-the-agent-hot-path) |
+| Pino migration / Prometheus / Grafana / Alerts | `release_plan/03-observability.md` | Still open, downgraded | Follow F10-01 / F10-03 |
+
+## Not in scope
+
+- **Roadmap items in `specs/roadmap/`** — explicitly future work, marked NOT FOR IMPLEMENTATION in each file. Examples: phase-2 sandbox plugins, durable-execution Inngest, CQRS snapshots, webhook DLQ.
+- **Open work already owned by PR #158** — agent approval mode, auto-start, skill visibility fixes.
+- **Open work already owned by issue #143** — `secureexec.dev` integration for task creation isolation.
+- **`@agentpane/cli-monitor` runtime internals** — reviewed only at the packaging/publishing layer ([F11-08](11-operations-deployment.md#f11-08-cli-monitor-publishing-puts-the-npm-token-in-a-spec-directory)). Deep review deferred.
+- **Memory / Honcho / Dream services** — noted only where they cross other themes ([F01-11](01-service-architecture.md#f01-11-memory-and-dream-services-are-constructed-eagerly-but-initialized-asynchronously-post-construction)).
+- **Terraform Compose UX** — stream delivery covered in [F05-12](05-event-streaming.md#f05-12--ephemeral-terraform-streams-lose-data-on-caddy-restart-mid-compose); product UX not covered.
+- **Topology designer / workflow designer UX** — bundle size flagged in [F08-06](08-frontend.md#f08-06-elkbundled-145-mb-lazy-only-for-topology-check-workflow-designer); product UX not covered.
+- **AgentCore (AWS Bedrock) path** — reviewed only to recommend deletion ([P1-02](04-sandbox-providers.md#p1-02-agentcore-is-half-deleted--migration-0011-dropped-the-db-columns-but-1200-loc-of-providerinstancebridgeerrors-code-remains-reachable-and-the-health-path-uses-a-dynamic-import-aws-sdk-that-is-never-declared-as-a-dependency), [F1](03-agent-execution.md#f1--agentcore-path-is-dead-code-but-still-present-in-two-packages)); no deep review.
+
+## Reading order
+
+- **Executives / lead eng**: `README.md` → [06 Security](06-security.md) → [11 Operations & deployment](11-operations-deployment.md) — the P0s, supply chain, and production-readiness picture.
+- **Platform eng (infra + data)**: `README.md` → [01 Service](01-service-architecture.md) → [02 Data](02-data-layer.md) → [03 Agent](03-agent-execution.md) → [04 Sandbox](04-sandbox-providers.md) → [05 Streaming](05-event-streaming.md).
+- **Product eng**: `README.md` → [07 API](07-api-surface.md) → [08 Frontend](08-frontend.md) — consumer-visible surface.
+- **QA / DevEx**: `README.md` → [09 Testing](09-testing.md) → [10 Observability](10-observability.md) → [11 Operations & deployment](11-operations-deployment.md) — CI/CD, coverage, debugging.
+- **Security review / audit**: `README.md` → [06 Security](06-security.md) → [04 Sandbox](04-sandbox-providers.md) P0-01/P1-05/P1-06 → [11 Operations & deployment](11-operations-deployment.md) F11-07/F11-08.
+
+## Next steps
+
+1. **P0s become release blockers this sprint.** Four items: (a) pin + sign the agent-sandbox image with digest and Trivy scan (04 P0-01 / 11 F11-07), (b) clear the 2 critical + 17 high Dependabot advisories (06 F06-01), (c) convert `CommandRunner` to positional argv and delete the `sh -c` shim (06 F06-02), (d) route SKILL.md frontmatter through a YAML serializer and tighten tag validation (06 F06-03). Assign each an owner by end of week; track in a dedicated GitHub milestone.
+2. **P1s triage into the next 2–3 sprints as theme-scoped epics.** Each of the 12 theme files becomes an epic, with its P1 list as the initial task breakdown. The three heaviest epics by count are 11-operations (8 P1s, needs a CD + Helm push), 06-security (8 P1s, mostly platform controls), and 05-event-streaming (7 P1s, clusters around auth, backpressure, and dual-write). Expect 6–8 weeks of focused work to drain the P1 list.
+3. **P2/P3 become "cleanup Friday" candidates and dependabot-group work.** Most P2s are maintainability debt that unlocks future velocity (e.g. F02-12 two-migration-chain merge, F01-07 TaskCreationService split, P2-01/P2-02 sandbox-provider shared utilities) — schedule one per engineer per fortnight. P3s ship opportunistically.
+4. **Re-run this review at the next major release.** The 12-theme scaffolding is designed to be re-executed: each file has a "Summary" / "What's working" / "Findings" / "Open questions" block, so the same agent pass can diff findings and produce a delta. Target cadence: every 8–12 weeks, or immediately after a subsystem rewrite.

--- a/specs/arch_review_april/README.md
+++ b/specs/arch_review_april/README.md
@@ -35,7 +35,7 @@
   - **XL** — > 2 weeks
 - **File refs** use `path:line` format; line numbers were verified against the branch head (`f9605383`). Where a finding cites multiple files, the master table lists the primary reference.
 - **Cross-links** to prior reviews — consolidated against `specs/events_review/` (streaming) and `specs/release_plan/` (01 test-suite, 02 security, 03 observability, 04 release, 05 error-resilience, 06 database-integrity, 08 frontend). See the "What this supersedes" table below.
-- **Anchor format** — GitHub renders `### F06-02: Title` as `#f06-02-title`. Short `#f06-02` anchors are used in the master table where themes used plain numeric anchors (03, 04 use `#f1`..`#f17` / `#p0-01` etc.); full title slugs are used where the theme file uses the `### FXX-NN: Title` format.
+- **Anchor format** — GitHub renders `### F06-02: Title` as a full slug anchor like `#f06-02--title-words`. The master table uses full title slugs for consistency with how GitHub actually renders headings. Themes 03 and 04 use non-standard anchor conventions internally (03 uses `#f1`..`#f17`, 04 uses `#p0-01`/`#p1-03` etc.); links into those files respect each file's actual heading format.
 
 ## Executive summary
 


### PR DESCRIPTION
## Summary
Full architecture review under `specs/arch_review_april/` with 12 themed files + consolidated README index.

- **175 findings** across service architecture, data layer, agent execution, sandbox providers, event streaming, security, API surface, frontend, testing, observability, operations/deployment, and cross-cutting concerns.
- **Priority distribution**: 4 P0 / 59 P1 / 81 P2 / 31 P3.
- **Consolidates** (and supersedes where applicable) prior reviews in `specs/events_review/` and `specs/release_plan/`; cross-links to the prior detail where still valid.
- **Direction-level recommendations** with file:line refs verified against branch head. Effort estimate (S/M/L/XL) on every finding.
- **No code changes** — this PR is documentation only.

## Reading order
- Start with [`specs/arch_review_april/README.md`](../blob/arch-review-april/specs/arch_review_april/README.md) — executive summary, priority snapshot, top-recommendations master table, supersedes-mapping for prior reviews.
- Drill into themed files as needed.

## Known internal inconsistencies (flagged for reviewer)
- Theme 04's summary line reports 18 findings but has 21 (README uses the correct 21).
- Theme 03 uses `F1..F17` anchors; theme 04 uses `P0-01/P1-01/...` anchors; other themes use `FXX-NN`. Internally consistent within each file but the convention drifted across agents. README links respect each file's actual anchors.
- A few findings appear in two themes from different angles (noted in the themes' Links sections):
  - F05-02 + F10-09 (droppedEventCount invisibility)
  - F09-01 + F02-02 (schema-drift coverage of 2/42 tables)
  - F05-07 + F06-14 (Caddy SSE auth model)
  - F11-07 + F04 P0-01 (unpinned sandbox image — kept as P0 under sandbox)

## Test plan
- [ ] Skim README and confirm executive summary matches your read of system health
- [ ] Review 1 themed file (your choice) for priority calibration and file-ref accuracy
- [ ] Confirm supersedes-mapping table against prior reviews
- [ ] Flag any findings overlapping work already owned elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)