### PR TITLE
fix(arch-review): theme 03 — agent execution (P1s)

### DIFF
--- a/agent-runner/src/agentcore-handler.ts
+++ b/agent-runner/src/agentcore-handler.ts
@@ -71,6 +71,10 @@ interface InvocationPayload {
   cwd?: string;
   /** OAuth token for Claude authentication. */
   oauthToken?: string;
+  /** theme-03 F11: real OAuth expiry (ms since epoch) from the host registry. */
+  oauthExpiresAt?: number;
+  /** theme-03 F11: OAuth refresh token when the host has one. */
+  oauthRefreshToken?: string | null;
   /** Path to a sentinel file — when it exists the agent stops. */
   stopFile?: string;
 }
@@ -126,6 +130,8 @@ async function* handleInvocation(
     sdkSessionId,
     allowedPrompts,
     oauthToken,
+    oauthExpiresAt,
+    oauthRefreshToken,
     stopFile,
   } = payload;
 
@@ -155,7 +161,22 @@ async function* handleInvocation(
   }
 
   try {
-    await writeCredentialsFile(token);
+    // theme-03 F11: pass through real OAuth metadata from the host when
+    // available so the SDK does not see a fictitious 24h expiry. Prefer the
+    // per-invocation payload; fall back to process env vars for backwards
+    // compatibility with hosts that still propagate via env.
+    const rawEnvExpiresAt = process.env.CLAUDE_OAUTH_EXPIRES_AT;
+    const parsedEnvExpiresAt = rawEnvExpiresAt ? Number(rawEnvExpiresAt) : undefined;
+    const envExpiresAt =
+      parsedEnvExpiresAt && Number.isFinite(parsedEnvExpiresAt) && parsedEnvExpiresAt > 0
+        ? parsedEnvExpiresAt
+        : undefined;
+    const expiresAt =
+      oauthExpiresAt && Number.isFinite(oauthExpiresAt) && oauthExpiresAt > 0
+        ? oauthExpiresAt
+        : envExpiresAt;
+    const refreshToken = oauthRefreshToken ?? process.env.CLAUDE_OAUTH_REFRESH_TOKEN ?? null;
+    await writeCredentialsFile(token, { expiresAt, refreshToken });
   } catch (credErr) {
     yield evt('agent:error', {
       error: `Credential setup failed: ${credErr instanceof Error ? credErr.message : String(credErr)}`,

--- a/agent-runner/src/event-emitter.ts
+++ b/agent-runner/src/event-emitter.ts
@@ -147,8 +147,6 @@ export interface AgentPlanReadyData {
   sdkSessionId: string;
   /** Allowed bash prompts from ExitPlanMode */
   allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  launchSwarm?: boolean;
-  teammateCount?: number;
   skillCalls?: SkillCallRecord[];
 }
 

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -255,9 +255,39 @@ function handleTopologySystemMsg(
 // Phase type
 type AgentPhase = 'plan' | 'execute';
 
+/**
+ * Parse CLAUDE_OAUTH_EXPIRES_AT env var.
+ *
+ * theme-03 F11: Accept a real token expiry from the host. When absent, fall
+ * back to a far-future sentinel so the SDK does not treat the token as expired
+ * but we avoid pretending to know a specific lifetime. The previous "+24h"
+ * default was a fiction — a token revoked externally still appeared valid to
+ * the SDK and surfaced as opaque 401s mid-stream.
+ */
+function parseOAuthExpiresAt(raw: string | undefined): number {
+  if (!raw) {
+    // Far-future sentinel (~year 5138). Signals "unknown expiry" to the SDK
+    // without masking real expirations when the host does supply them.
+    return 100_000_000_000_000;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(
+      `[agent-runner] CLAUDE_OAUTH_EXPIRES_AT is not a positive number ('${raw}'), using far-future default`
+    );
+    return 100_000_000_000_000;
+  }
+  return parsed;
+}
+
 // Configuration from environment (declared early for error handlers)
 const config = {
   oauthToken: process.env.CLAUDE_OAUTH_TOKEN,
+  // theme-03 F11: optional real OAuth metadata from the host. When absent the
+  // credentials file still gets written, but with a sentinel expiry rather
+  // than a fake Date.now()+24h value.
+  oauthExpiresAt: parseOAuthExpiresAt(process.env.CLAUDE_OAUTH_EXPIRES_AT),
+  oauthRefreshToken: process.env.CLAUDE_OAUTH_REFRESH_TOKEN ?? null,
   taskId: process.env.AGENT_TASK_ID,
   sessionId: process.env.AGENT_SESSION_ID,
   prompt: process.env.AGENT_PROMPT,
@@ -372,9 +402,21 @@ function validateConfig(): void {
 }
 
 /**
- * Write OAuth credentials to ~/.claude/.credentials.json
+ * Write OAuth credentials to $HOME/.claude/.credentials.json
  * The Claude Agent SDK reads this file for authentication.
  * OAuth tokens passed via ANTHROPIC_API_KEY env var are blocked by the API.
+ *
+ * theme-03 F11:
+ * - `homedir()` (which reads `process.env.HOME`) is used so that the host
+ *   can place each concurrent agent-runner invocation under a distinct HOME
+ *   (e.g. /tmp/agents/<taskId>) and avoid interleaved writes to a shared
+ *   `/home/node/.claude/.credentials.json`.
+ * - `expiresAt` is read from the host via `CLAUDE_OAUTH_EXPIRES_AT` when
+ *   available; otherwise a far-future sentinel is used. The previous
+ *   `Date.now() + 24h` fiction caused revoked tokens to appear valid to the
+ *   SDK for a day.
+ * - `refreshToken` is threaded through from `CLAUDE_OAUTH_REFRESH_TOKEN`
+ *   when the host has one; otherwise null (SDK rejects empty string).
  */
 async function writeCredentialsFile(): Promise<void> {
   const home = homedir();
@@ -385,18 +427,20 @@ async function writeCredentialsFile(): Promise<void> {
   console.error(`[agent-runner] Home directory: ${home}`);
   console.error(`[agent-runner] Credentials path: ${credentialsFile}`);
   console.error(`[agent-runner] Token received: ${config.oauthToken ? 'YES' : 'NONE'}`);
+  console.error(
+    `[agent-runner] Token expiresAt: ${process.env.CLAUDE_OAUTH_EXPIRES_AT ? 'from host' : 'sentinel (far-future)'}`
+  );
+  console.error(`[agent-runner] Refresh token: ${config.oauthRefreshToken ? 'provided' : 'none'}`);
 
   if (!config.oauthToken) {
     throw new Error('No OAuth token provided via CLAUDE_OAUTH_TOKEN environment variable');
   }
 
-  // Use null instead of empty string for refreshToken - SDK may reject empty string
-  // expiresAt as milliseconds (matching SDK's expected format from `claude login`)
   const credentials = {
     claudeAiOauth: {
       accessToken: config.oauthToken,
-      refreshToken: null,
-      expiresAt: Date.now() + 86400000, // 24h from now in milliseconds
+      refreshToken: config.oauthRefreshToken,
+      expiresAt: config.oauthExpiresAt,
       scopes: ['user:inference', 'user:profile', 'user:sessions:claude_code'],
       subscriptionType: 'max',
     },

--- a/agent-runner/src/shared-session.ts
+++ b/agent-runner/src/shared-session.ts
@@ -142,9 +142,6 @@ export function extractFileChange(
 /** ExitPlanMode options captured from the tool call. */
 export interface ExitPlanModeOptions {
   allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  launchSwarm?: boolean;
-  teammateCount?: number;
-  pushToRemote?: boolean;
   remoteSessionId?: string;
   remoteSessionUrl?: string;
   remoteSessionTitle?: string;

--- a/agent-runner/src/shared-session.ts
+++ b/agent-runner/src/shared-session.ts
@@ -21,14 +21,40 @@ import type { AgentFileChangedData } from './event-emitter.js';
 // ---------------------------------------------------------------------------
 
 /**
- * Write OAuth credentials to ~/.claude/.credentials.json.
+ * Far-future sentinel (~year 5138) used when the host does not supply a real
+ * OAuth token expiry. theme-03 F11: the previous 24h fiction caused revoked
+ * tokens to appear valid to the SDK for up to a day.
+ */
+const OAUTH_EXPIRES_AT_SENTINEL = 100_000_000_000_000;
+
+/**
+ * Options accepted by `writeCredentialsFile`. All fields except `oauthToken`
+ * are optional; when absent a safe default is substituted.
+ */
+export interface WriteCredentialsOptions {
+  /** Real OAuth token expiry (ms since epoch). Defaults to a far-future sentinel. */
+  expiresAt?: number;
+  /** OAuth refresh token from the host. Defaults to null (SDK rejects empty string). */
+  refreshToken?: string | null;
+}
+
+/**
+ * Write OAuth credentials to `$HOME/.claude/.credentials.json`.
  * The Claude Agent SDK reads this file for authentication.
  * OAuth tokens passed via ANTHROPIC_API_KEY env var are blocked by the API.
  *
  * SC-014: The credentials file is written with mode 0o600 (owner-read-only)
  * to mitigate token exposure risk on shared filesystems.
+ *
+ * theme-03 F11: `expiresAt` and `refreshToken` are now threaded through from
+ * the host when available. `homedir()` (which reads `process.env.HOME`) is
+ * used so the host can place each concurrent agent-runner invocation under a
+ * distinct HOME and avoid interleaved writes to a shared credentials file.
  */
-export async function writeCredentialsFile(oauthToken: string): Promise<void> {
+export async function writeCredentialsFile(
+  oauthToken: string,
+  options: WriteCredentialsOptions = {}
+): Promise<void> {
   const home = homedir();
   const claudeDir = join(home, '.claude');
   const credentialsFile = join(claudeDir, '.credentials.json');
@@ -40,8 +66,8 @@ export async function writeCredentialsFile(oauthToken: string): Promise<void> {
   const credentials = {
     claudeAiOauth: {
       accessToken: oauthToken,
-      refreshToken: null,
-      expiresAt: Date.now() + 86_400_000, // 24h
+      refreshToken: options.refreshToken ?? null,
+      expiresAt: options.expiresAt ?? OAUTH_EXPIRES_AT_SENTINEL,
       scopes: ['user:inference', 'user:profile', 'user:sessions:claude_code'],
       subscriptionType: 'max',
     },

--- a/specs/arch_review_april/03-agent-execution.md
+++ b/specs/arch_review_april/03-agent-execution.md
@@ -59,11 +59,8 @@ AgentPane runs Claude agents through two nearly-parallel pipelines: a **host-mod
 ### F3 — Plan-option fields (`launchSwarm`, `teammateCount`) are carried end-to-end but never acted on
 
 **Priority:** P1
-**Observation:** `ExitPlanModeOptions` (`stream-handler.ts:92`) declares `launchSwarm` and `teammateCount`; `PlanReadyData`/`PlanData`/`AgentCorePlanReadyData` propagate them (`container-bridge.ts:51`, `agentcore-bridge.ts:38`, `container-agent/types.ts:93`, `plan-approval.service.ts:95`, `durable-streams.service.ts:219`). Plan approval logs them but passes only `prompt`, `phase`, `sdkSessionId` to `startAgentFn` (`plan-approval.service.ts:330`). `runAgentExecution` never reads these fields. Nothing in `container-exec.service.ts` spawns multiple `agent-runner` processes. Meanwhile `.claude/CLAUDE.md` "Team Mode" section states this is a live feature.
-**Risk:** Documentation fiction; agents that call `ExitPlanMode({ launchSwarm: true })` get no parallelism, users see single-agent execution. CLAUDE.md misleads future contributors. The SDK's own subagent spawning (`task_started` system messages) is what actually provides concurrency — it does not depend on these fields.
-**Recommendation:** Either delete the fields from the type chain and update CLAUDE.md to describe the actual SDK-driven topology, or implement a worktree-per-teammate fan-out in `PlanApprovalService.approvePlan`. Given the existing SDK subagent support, deletion is cheaper.
-**Effort:** S (delete) / XL (implement).
-**Links:** `.claude/CLAUDE.md` "Team Mode" section; `specs/application/state-machines/agent-lifecycle.md`.
+**Status:** Resolved (theme-03). Fields `launchSwarm`, `teammateCount`, and `pushToRemote` deleted from `ExitPlanModeOptions`, `PlanData`, `PlanReadyData`, `AgentCorePlanReadyData`, `ContainerAgentPlanReadyEvent`, `AgentPlanReadyData`, and the in-flight `handlePlanReady` callback shapes on both `container-agent.service.ts` and `container-exec.service.ts`. The SDK's own `task_started` subagent spawning continues to provide concurrency. CLAUDE.md "Team Mode" documentation is out of scope for this worktree; flagged as a follow-up doc fix.
+**Observation (archived):** `ExitPlanModeOptions` (`stream-handler.ts:92`) declared `launchSwarm` and `teammateCount`; `PlanReadyData`/`PlanData`/`AgentCorePlanReadyData` propagated them. Plan approval logged them but passed only `prompt`, `phase`, `sdkSessionId` to `startAgentFn`. `runAgentExecution` never read these fields. Nothing in `container-exec.service.ts` spawned multiple `agent-runner` processes.
 
 ### F4 — `allowedPrompts` are captured but never added to the execution `allowedTools`
 

--- a/specs/arch_review_april/03-agent-execution.md
+++ b/specs/arch_review_april/03-agent-execution.md
@@ -41,20 +41,14 @@ AgentPane runs Claude agents through two nearly-parallel pipelines: a **host-mod
 ### F1 — AgentCore path is dead code but still present in two packages
 
 **Priority:** P1
-**Observation:** `ContainerAgentService.setAgentCoreProvider` (`container-agent.service.ts:153`) is invoked only from tests; nothing in `server-bootstrap.ts` or `sandbox-init.ts` calls it. Migration `src/db/migrations/0011_drop_agentcore_columns.sql` removed the storage that previously drove configuration. Meanwhile the entire AgentCore stack is still shipped: `src/lib/agents/agentcore-bridge.ts`, `src/services/container-agent/agentcore-bridge.service.ts`, `src/lib/sandbox/providers/agentcore-sandbox-*.ts`, and `agent-runner/src/agentcore-handler.ts` (577 LOC) all compile into the build. `agent-runner/package.json:16` still ships `bedrock-agentcore@^0.2.2` as a runtime dep.
-**Risk:** Dual runtimes to test and maintain for a feature users cannot enable. Fresh changes to plan-approval, skill-chaining, team-mode, event shapes must be mirrored to the AgentCore branch by contributors who cannot exercise it. `'agentcore'` enum member (`src/db/schema/shared/enums.ts:62`) keeps the concept "real" to type-checks while there is no boot path.
-**Recommendation:** Either (a) archive AgentCore behind a feature flag and delete the bridge/handler/provider from the default build; or (b) restore a configuration surface (settings table + UI) and add at least one functional test that starts an AgentCore agent end-to-end. Document the decision in `specs/diagrams/02-agent-execution-flow.md`.
-**Effort:** M (1–2 d) to excise; L to restore parity.
-**Links:** `specs/application/state-machines/agent-lifecycle.md`, `specs/sandbox/` (provider matrix).
+**Status:** Resolved (pre-existing — theme-04 PR #166). `ContainerAgentService.setAgentCoreProvider` is now gated behind `AGENTCORE_ENABLED=true` and the `agentcore-sandbox-provider` module (the one that pulls the AWS SDK into the graph) is loaded via dynamic import only when the flag is set. The remaining `agentcore-bridge.ts`, `agentcore-bridge.service.ts`, and `agent-runner/src/agentcore-handler.ts` files contain only pure-JS bridge logic with `import type` references to the provider, so they do not force the AWS SDK into the default module graph. Full removal of the scaffolding and the `bedrock-agentcore` runtime dep in `agent-runner/package.json` is deferred — low-risk dead code behind a flag, not a correctness issue.
+**Observation (archived):** AgentCore stack was always compiled into the build; `bedrock-agentcore@^0.2.2` still ships as an `agent-runner/` runtime dep.
 
 ### F2 — Tool-use hooks are registered but never installed in the SDK session
 
 **Priority:** P1
-**Observation:** `AgentExecutionService` maintains `preToolHooks` and `postToolHooks` maps (`agent-execution.service.ts:82-83`), exposes `registerPreToolUseHook`/`registerPostToolUseHook` (`agent-execution.service.ts:1328,1337`), and deletes the entries on six cleanup paths. `src/lib/agents/hooks/index.ts` constructs a `createAgentHooks({ PreToolUse: [whitelist, streaming], PostToolUse: [audit, streaming] })`. `stream-handler.ts` contains **zero** references to either map — `runAgentPlanning`/`runAgentExecution` only wire a local `canUseTool` callback and never accept hooks through `StreamHandlerOptions`.
-**Risk:** Silent security regression. The tool-whitelist hook, audit hook, and streaming hook are not enforcing or recording anything for host-mode runs. `allowedTools` passed via config is honoured by the SDK's own permission layer, but any richer logic added to `createToolWhitelistHook` (e.g. deny-list, per-skill allow lists, path scoping) is inert. No caller notices because the hook registration API returns `void`.
-**Recommendation:** Either thread the hook arrays through `StreamHandlerOptions` into `canUseTool` (run PreToolUse before `{behavior:'allow'}`, PostToolUse on `tool:result`), or remove the dead registration API. Add a unit test that asserts a registered PreToolUse hook is invoked when a tool fires in planning/execution.
-**Effort:** M.
-**Links:** `specs/application/security/` (tool permission model), `specs/events_review/` (event ordering).
+**Status:** Resolved (theme-03). `StreamHandlerOptions` now carries `preToolUseHooks` and `postToolUseHooks`. `runAgentExecution.canUseTool` invokes pre-hooks in order before returning `{behavior:'allow'}`; the first hook returning `{deny:true}` produces `{behavior:'deny', message, interrupt:false}` and emits a `tool:result{isError:true}` event. The `tool_use_summary` handler runs post-hooks for each tracked tool with the captured tool_input. `AgentExecutionService.executeAgentExecution` forwards per-agent hooks from the `preToolHooks`/`postToolHooks` maps.
+**Tests:** `tests/lib/agents/stream-handler.test.ts` F2-a..d.
 
 ### F3 — Plan-option fields (`launchSwarm`, `teammateCount`) are carried end-to-end but never acted on
 
@@ -74,20 +68,14 @@ AgentPane runs Claude agents through two nearly-parallel pipelines: a **host-mod
 ### F5 — Host-mode cannot resume an SDK session across plan approval
 
 **Priority:** P1
-**Observation:** The container-runner supports `AGENT_SDK_SESSION_ID` and calls `unstable_v2_resumeSession` so the execution phase inherits the planning conversation (`agent-runner/src/index.ts:914`). Host-mode `runAgentExecution` has no analogue — it calls `unstable_v2_createSession` unconditionally with a freshly-built "Execute the following approved plan: …" prompt (`agent-execution.service.ts:932`, `stream-handler.ts:947`). There is no `sdkSessionId` plumbing in `StreamHandlerOptions`.
-**Risk:** Host mode pays full context cost (plan restatement) and loses the planning-phase reasoning/tool-use history. Behaviour is semantically different from container mode, invalidating shared functional tests. The CLAUDE.md "Functional Tests" rule that plan approval must pass `sdkSessionId` describes container-mode only.
-**Recommendation:** Either thread `sdkSessionId` into host-mode (capture it from the SDK `init` message the same way agent-runner does, persist it on the agent row or task plan options, resume on approval) or document host-mode as a compatibility layer with explicit behavioural differences.
-**Effort:** M.
-**Links:** `specs/application/state-machines/agent-lifecycle.md` (plan → execute edge).
+**Status:** Resolved (theme-03). `runAgentPlanning` captures `session.sessionId` once it's available and returns it on `AgentRunResult.sdkSessionId` + the `agent:plan_ready` event. `AgentExecutionService.executeAgentAsync` merges it into `tasks.planOptions`; `executeAgentExecution` reads it back and passes it into `runAgentExecution`, which attempts `unstable_v2_resumeSession` first and falls back to `unstable_v2_createSession` on any failure — mirroring the agent-runner defense-in-depth flow.
+**Tests:** `tests/lib/agents/stream-handler.test.ts` 5 new F5 tests.
 
 ### F6 — `rejectPlan` has no host-mode fallback
 
 **Priority:** P1
-**Observation:** `TaskService.approvePlan` (`task.service.ts:196-236`) has both a container path and a host-mode path (`agentExecutionService.resume`). `TaskService.rejectPlan` (`task.service.ts:242-250`) short-circuits with `CONTAINER_AGENT_SERVICE_UNAVAILABLE` status 503 when the container service is not wired.
-**Risk:** In a deployment running host-mode agents (no Docker/K8s), users hit an un-rejectable plan. Tasks sit in `waiting_approval` forever and the worktree leaks. The state machine's `plan → backlog` edge is unreachable.
-**Recommendation:** Add a host-mode reject path that (a) updates `task.column='backlog'`, clears `plan`/`planOptions`/`lastAgentStatus`, and (b) calls `agentExecutionService.stop(agentId)` or sets agent back to idle and removes the worktree via `worktreeService.remove`. Mirror the atomic CAS (`where lastAgentStatus='planning'`) from container mode.
-**Effort:** S.
-**Links:** `specs/application/state-machines/agent-lifecycle.md`, `specs/application/state-machines/task-workflow.md`.
+**Status:** Resolved (theme-03). `AgentExecutionTrigger` gained optional `rejectPlanForTask`; `TaskService.rejectPlan` delegates to container mode when wired, falls back to the host-mode implementation, and returns `NO_EXECUTION_SERVICE` (503) when neither is configured. `AgentExecutionService.rejectPlanForTask` aborts any running host-mode agent, resets the agent row to idle, CAS-updates the task back to backlog where `lastAgentStatus='planning'` (clearing `plan`/`planOptions`/`worktreeId`/`branch`, storing `rejectionReason`), and best-effort removes the worktree.
+**Tests:** `tests/integration/agent-execution-service.test.ts` IT-F6-a..e and `tests/integration/task-plan-approval.test.ts` F6-a..c.
 
 ### F7 — Orphan sweep timer silently dies if any one iteration throws
 
@@ -128,11 +116,8 @@ AgentPane runs Claude agents through two nearly-parallel pipelines: a **host-mod
 ### F11 — `agent-runner` mints fake OAuth `expiresAt` and a null `refreshToken`
 
 **Priority:** P1
-**Observation:** `writeCredentialsFile` (`agent-runner/src/index.ts:303`) writes `expiresAt: Date.now() + 86_400_000` and `refreshToken: null` regardless of the actual token lifetime. The host supplies only `CLAUDE_OAUTH_TOKEN`; there is no mechanism to refresh a rotated token mid-run. Multiple agents per host share the same container-user credentials file (`~/.claude/.credentials.json`) under the node user.
-**Risk:** A token revoked externally still appears "valid for 24 h" to the SDK; actual 401s surface as opaque "assistant errors" mid-stream. Concurrent agents racing on the credentials file (two container starts within the same per-project container) can interleave writes — the 0o600 file is not atomic on overwrite. No mechanism to refresh a short-lived token (future OAuth PKCE rotation).
-**Recommendation:** (a) carry real `expiresAt` from the host token registry and emit a pre-run validation event when the token is expired/near-expiry; (b) write the credentials file under a unique `HOME` per agent-runner (set `HOME=/tmp/agents/<taskId>` at container start) to isolate writers; (c) if refresh tokens ever become available, plumb them in.
-**Effort:** M.
-**Links:** CLAUDE.md "Authentication Configuration"; `specs/application/security/`.
+**Status:** Resolved (theme-03). `agent-runner` now reads `CLAUDE_OAUTH_EXPIRES_AT` and `CLAUDE_OAUTH_REFRESH_TOKEN` from env (index.ts) and the invocation payload (agentcore-handler.ts). When absent, a far-future sentinel replaces the old 24h fiction. `shared-session.writeCredentialsFile` accepts optional `expiresAt`/`refreshToken` for a shared write path. Host-side `resolveOAuthExpiresAtMs` reads the existing `api_keys.expires_at` ISO column, and both `container-exec.service` and `agentcore-bridge.service` pass the parsed ms through to the runner. Per-agent HOME isolation is left to the container layout (`homedir()` already reads `HOME`) — unchanged; future follow-up can set `HOME=/tmp/agents/<taskId>` for concurrent-shared-container deployments.
+**Tests:** IT-304F-a..d cover `resolveOAuthExpiresAtMs`.
 
 ### F12 — Two stream handlers evolved in parallel and drifted
 

--- a/src/lib/agents/agentcore-bridge.ts
+++ b/src/lib/agents/agentcore-bridge.ts
@@ -35,8 +35,6 @@ export interface AgentCorePlanReadyData {
   turnCount: number;
   sdkSessionId: string;
   allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  launchSwarm?: boolean;
-  teammateCount?: number;
 }
 
 /**

--- a/src/lib/agents/container-bridge.ts
+++ b/src/lib/agents/container-bridge.ts
@@ -48,8 +48,6 @@ export interface PlanReadyData {
   turnCount: number;
   sdkSessionId: string;
   allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  launchSwarm?: boolean;
-  teammateCount?: number;
 }
 
 import type { AgentCompleteMetrics } from '../../services/container-agent/types.js';

--- a/src/lib/agents/stream-handler.ts
+++ b/src/lib/agents/stream-handler.ts
@@ -94,12 +94,9 @@ export interface StreamHandlerOptions {
 
 export interface ExitPlanModeOptions {
   allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  pushToRemote?: boolean;
   remoteSessionId?: string;
   remoteSessionUrl?: string;
   remoteSessionTitle?: string;
-  launchSwarm?: boolean;
-  teammateCount?: number;
 }
 
 export interface SkillCallRecord {

--- a/src/lib/agents/stream-handler.ts
+++ b/src/lib/agents/stream-handler.ts
@@ -1,4 +1,8 @@
-import { type CanUseTool, unstable_v2_createSession } from '@anthropic-ai/claude-agent-sdk';
+import {
+  type CanUseTool,
+  unstable_v2_createSession,
+  unstable_v2_resumeSession,
+} from '@anthropic-ai/claude-agent-sdk';
 import { createId } from '@paralleldrive/cuid2';
 import { createLogger } from '../../lib/logging/logger.js';
 import { createSessionEventWithMetadata } from '../../services/session/event-metadata.js';
@@ -78,6 +82,13 @@ export interface StreamHandlerOptions {
   /** Skill identity from the task — threaded into session events for replay context. */
   skillId?: string | null;
   skillName?: string | null;
+  /**
+   * theme-03 F5: When provided, `runAgentExecution` tries to resume the given
+   * Claude SDK session id via `unstable_v2_resumeSession`. On any failure the
+   * handler falls back to a fresh session with the full plan prompt — same
+   * defense-in-depth pattern the agent-runner uses.
+   */
+  sdkSessionId?: string;
   sessionService: {
     publish: (sessionId: string, event: SessionEvent) => Promise<unknown>;
     persistOnly?: (sessionId: string, event: SessionEvent) => Promise<unknown>;
@@ -112,6 +123,12 @@ export interface AgentRunResult {
   result?: string;
   plan?: string;
   planOptions?: ExitPlanModeOptions;
+  /**
+   * theme-03 F5: Claude SDK session id captured during planning so the
+   * execution phase can resume the same conversation rather than paying the
+   * full-context cost of a fresh session.
+   */
+  sdkSessionId?: string;
   error?: string;
   metrics?: {
     totalCostUsd?: number;
@@ -468,6 +485,9 @@ export async function runAgentPlanning(options: StreamHandlerOptions): Promise<A
   let turn = 0;
   let planContent = '';
   let exitPlanModeOptions: ExitPlanModeOptions | undefined;
+  // theme-03 F5: capture the SDK session id once the session is initialized
+  // so PlanApprovalService / TaskService.approvePlan can resume it on execute.
+  let capturedSdkSessionId: string | undefined;
 
   // Topology tracker for subagent lifecycle events during planning.
   // Skills can spawn subagents via the Agent tool, which emit task_started/progress/notification.
@@ -611,6 +631,19 @@ export async function runAgentPlanning(options: StreamHandlerOptions): Promise<A
 
     // Stream the planning response
     for await (const msg of session.stream()) {
+      // theme-03 F5: capture SDK session id as soon as it becomes available
+      // so it can be persisted in plan options and used to resume on approval.
+      if (!capturedSdkSessionId) {
+        try {
+          const sid = session.sessionId;
+          if (typeof sid === 'string' && sid.length > 0) {
+            capturedSdkSessionId = sid;
+          }
+        } catch {
+          // sessionId throws until the first message is received — retry on next iteration.
+        }
+      }
+
       // Check if abort signal or runtime timeout has been triggered
       if (signal?.aborted || timeoutController.signal.aborted) {
         clearTimeout(timeoutId);
@@ -888,6 +921,7 @@ export async function runAgentPlanning(options: StreamHandlerOptions): Promise<A
               runId,
               plan: planContent || accumulated,
               allowedPrompts: exitPlanModeOptions?.allowedPrompts,
+              sdkSessionId: capturedSdkSessionId,
             },
           })
         );
@@ -898,6 +932,7 @@ export async function runAgentPlanning(options: StreamHandlerOptions): Promise<A
           turnCount: turn,
           plan: planContent || accumulated,
           planOptions: exitPlanModeOptions,
+          sdkSessionId: capturedSdkSessionId,
           metrics: extractResultMetrics(result),
           skillCalls: skillCalls.length > 0 ? skillCalls : undefined,
           fileChanges:
@@ -926,6 +961,7 @@ export async function runAgentPlanning(options: StreamHandlerOptions): Promise<A
           runId,
           plan: planContent || accumulated,
           allowedPrompts: exitPlanModeOptions?.allowedPrompts,
+          sdkSessionId: capturedSdkSessionId,
         },
       })
     );
@@ -936,6 +972,7 @@ export async function runAgentPlanning(options: StreamHandlerOptions): Promise<A
       turnCount: turn,
       plan: planContent || accumulated || 'No plan generated',
       planOptions: exitPlanModeOptions,
+      sdkSessionId: capturedSdkSessionId,
       skillCalls: skillCalls.length > 0 ? skillCalls : undefined,
       fileChanges:
         modifiedFiles.size > 0
@@ -1115,15 +1152,41 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
     return { behavior: 'allow' as const, toolUseID: toolOptions.toolUseID };
   };
 
-  // Create Claude Agent SDK session for execution
-  const session = unstable_v2_createSession({
+  // theme-03 F5: try to resume the planning-phase SDK session when the
+  // caller supplied one. Mirrors the agent-runner flow: on resume failure
+  // (stale session, SDK error) we fall back to a fresh session with the
+  // full plan prompt. The fresh-session branch is the status quo behavior.
+  const sdkSessionOptions = {
     model,
     env: buildSdkEnv(),
     allowedTools,
-    permissionMode: 'acceptEdits', // Auto-accept edits for execution
+    permissionMode: 'acceptEdits' as const, // Auto-accept edits for execution
     executableArgs: ['--add-dir', cwd],
     canUseTool,
-  });
+  };
+
+  let session: ReturnType<typeof unstable_v2_createSession>;
+  let sessionResumed = false;
+  if (options.sdkSessionId) {
+    try {
+      session = unstable_v2_resumeSession(options.sdkSessionId, sdkSessionOptions);
+      sessionResumed = true;
+      log.info('SDK session resumed for execution', {
+        data: { agentId, sdkSessionId: options.sdkSessionId },
+      });
+    } catch (resumeErr) {
+      const msg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+      log.warn('SDK session resume failed, falling back to fresh session', {
+        data: { agentId, sdkSessionId: options.sdkSessionId, error: msg },
+      });
+      session = unstable_v2_createSession(sdkSessionOptions);
+    }
+  } else {
+    session = unstable_v2_createSession(sdkSessionOptions);
+  }
+  // Suppress unused-var warning in builds that don't strip it; sessionResumed
+  // is retained for possible future telemetry / tests.
+  void sessionResumed;
 
   const batcher = createChunkBatcher(sessionId, agentId, 'execution', sessionService);
 

--- a/src/lib/agents/stream-handler.ts
+++ b/src/lib/agents/stream-handler.ts
@@ -68,6 +68,28 @@ function createMetadataEvent(params: {
   };
 }
 
+/**
+ * theme-03 F2: pre-tool-use hook signature used by the host-mode stream
+ * handler. Returning `{deny:true, reason?}` blocks the tool invocation —
+ * the SDK is told via `canUseTool` that the tool is not permitted and the
+ * reason (if any) is surfaced on a `tool:result` event with `isError:true`.
+ */
+export type StreamPreToolUseHook = (input: {
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+}) => Promise<{ deny?: boolean; reason?: string }>;
+
+/**
+ * theme-03 F2: post-tool-use hook signature. Runs after the SDK emits the
+ * `tool_use_summary` for a tracked tool. Errors are logged and do not
+ * propagate — hook failures must never abort the agent.
+ */
+export type StreamPostToolUseHook = (input: {
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_response: { summary: string; is_error: boolean };
+}) => Promise<void>;
+
 export interface StreamHandlerOptions {
   agentId: string;
   sessionId: string;
@@ -89,6 +111,15 @@ export interface StreamHandlerOptions {
    * defense-in-depth pattern the agent-runner uses.
    */
   sdkSessionId?: string;
+  /**
+   * theme-03 F2: pre/post tool-use hooks. Registered on the service per-agent
+   * and threaded through the options here. Pre-hooks run before each
+   * `canUseTool` decision and can block the tool. Post-hooks run after the
+   * SDK returns a `tool_use_summary` for that tool. All hook errors are
+   * logged and swallowed.
+   */
+  preToolUseHooks?: StreamPreToolUseHook[];
+  postToolUseHooks?: StreamPostToolUseHook[];
   sessionService: {
     publish: (sessionId: string, event: SessionEvent) => Promise<unknown>;
     persistOnly?: (sessionId: string, event: SessionEvent) => Promise<unknown>;
@@ -1082,10 +1113,18 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
     })
   );
 
-  // Track active tools by toolUseID for correlating with tool_use_summary
+  // Track active tools by toolUseID for correlating with tool_use_summary.
+  // theme-03 F2: `toolInput` is retained alongside the other tracking state
+  // so post-tool-use hooks can receive the original input when the summary
+  // arrives.
   const activeTools = new Map<
     string,
-    { toolName: string; startTime: number; skillName?: string }
+    {
+      toolName: string;
+      startTime: number;
+      skillName?: string;
+      toolInput: Record<string, unknown>;
+    }
   >();
 
   // Accumulate Skill tool calls for AgentRunResult
@@ -1095,14 +1134,67 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
   const modifiedFiles = new Set<string>();
 
   const canUseTool: CanUseTool = async (toolName, input, toolOptions) => {
-    const toolEntry: { toolName: string; startTime: number; skillName?: string } = {
+    const toolInputRecord = (input ?? {}) as Record<string, unknown>;
+
+    // theme-03 F2: run each registered pre-tool-use hook. First hook that
+    // returns {deny:true} blocks the tool. Hook exceptions are logged and
+    // treated as "no opinion" so a buggy hook cannot silently allow/deny.
+    if (options.preToolUseHooks && options.preToolUseHooks.length > 0) {
+      for (const hook of options.preToolUseHooks) {
+        let hookResult: { deny?: boolean; reason?: string } = {};
+        try {
+          hookResult = await hook({ tool_name: toolName, tool_input: toolInputRecord });
+        } catch (hookErr) {
+          log.warn('Pre-tool-use hook threw, ignoring verdict', {
+            error: hookErr instanceof Error ? hookErr.message : String(hookErr),
+            data: { agentId, toolName },
+          });
+          continue;
+        }
+        if (hookResult.deny) {
+          const reason = hookResult.reason ?? `Tool "${toolName}" blocked by pre-tool-use hook`;
+          await sessionService.publish(
+            sessionId,
+            createMetadataEvent({
+              sessionId,
+              type: 'tool:result',
+              partType: 'tool_result',
+              blockId: toolOptions.toolUseID,
+              data: {
+                agentId,
+                toolId: toolOptions.toolUseID,
+                tool: toolName,
+                output: reason,
+                isError: true,
+              },
+            })
+          );
+          log.info('Pre-tool-use hook denied tool', {
+            data: { agentId, toolName, reason },
+          });
+          return {
+            behavior: 'deny' as const,
+            message: reason,
+            interrupt: false,
+          };
+        }
+      }
+    }
+
+    const toolEntry: {
+      toolName: string;
+      startTime: number;
+      skillName?: string;
+      toolInput: Record<string, unknown>;
+    } = {
       toolName,
       startTime: Date.now(),
+      toolInput: toolInputRecord,
     };
 
     // Enrich Skill tool calls with the invoked skill name for downstream tracking
     if (toolName === 'Skill') {
-      const skillInput = input as Record<string, unknown>;
+      const skillInput = toolInputRecord;
       const invokedSkillName = typeof skillInput.skill === 'string' ? skillInput.skill : undefined;
       if (invokedSkillName) {
         toolEntry.skillName = invokedSkillName;
@@ -1115,7 +1207,7 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
 
     // Capture subagent_type from Agent tool calls for topology grouping
     if (toolName === 'Agent') {
-      const agentInput = input as Record<string, unknown>;
+      const agentInput = toolInputRecord;
       const subagentType =
         typeof agentInput.subagent_type === 'string' ? agentInput.subagent_type : null;
       if (subagentType) {
@@ -1128,8 +1220,8 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
     // Track file-modifying tools for file change metrics
     if (toolName === 'Write' || toolName === 'Edit' || toolName === 'NotebookEdit') {
       const filePath =
-        ((input as Record<string, unknown>).file_path as string | undefined) ??
-        ((input as Record<string, unknown>).notebook_path as string | undefined);
+        (toolInputRecord.file_path as string | undefined) ??
+        (toolInputRecord.notebook_path as string | undefined);
       if (filePath) modifiedFiles.add(filePath);
     }
 
@@ -1144,7 +1236,7 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
           agentId,
           toolId: toolOptions.toolUseID,
           tool: toolName,
-          input: input as Record<string, unknown>,
+          input: toolInputRecord,
         },
       })
     );
@@ -1402,6 +1494,30 @@ export async function runAgentExecution(options: StreamHandlerOptions): Promise<
               },
             })
           );
+
+          // theme-03 F2: run post-tool-use hooks for this tool. Hooks are
+          // fire-and-forget — any thrown error is logged but never aborts
+          // the stream or replaces the already-published tool:result event.
+          if (options.postToolUseHooks && options.postToolUseHooks.length > 0) {
+            const hookPayload = {
+              tool_name: tracked.toolName,
+              tool_input: tracked.toolInput,
+              tool_response: {
+                summary: toolSummary.summary ?? '',
+                is_error: summaryIsError,
+              },
+            };
+            for (const hook of options.postToolUseHooks) {
+              try {
+                await hook(hookPayload);
+              } catch (hookErr) {
+                log.warn('Post-tool-use hook threw', {
+                  error: hookErr instanceof Error ? hookErr.message : String(hookErr),
+                  data: { agentId, toolName: tracked.toolName },
+                });
+              }
+            }
+          }
 
           // Accumulate Skill tool calls for metrics
           if (tracked.skillName) {

--- a/src/services/agent.service.ts
+++ b/src/services/agent.service.ts
@@ -169,6 +169,17 @@ export class AgentService {
   }
 
   /**
+   * theme-03 F6: host-mode plan rejection fallback for TaskService.rejectPlan.
+   * Delegates to AgentExecutionService.rejectPlanForTask.
+   */
+  async rejectPlanForTask(
+    taskId: string,
+    reason?: string
+  ): Promise<Result<void, { code: string; message: string; status: number }>> {
+    return this.executionService.rejectPlanForTask(taskId, reason);
+  }
+
+  /**
    * Check if a codespace has availability for a new running agent.
    */
   async checkAvailability(codespaceId: string): Promise<Result<boolean, never>> {

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -1183,6 +1183,13 @@ export class AgentExecutionService {
         (taskRow?.planOptions as { sdkSessionId?: string } | null | undefined)?.sdkSessionId ??
         undefined;
 
+      // theme-03 F2: forward any hooks registered for this agent into the
+      // stream handler. `agent/types.PreToolUseHook` and its post-hook
+      // sibling are structurally compatible with the stream-handler's
+      // StreamPre/PostToolUseHook — both accept {tool_name, tool_input}.
+      const preHooks = this.preToolHooks.get(agentId);
+      const postHooks = this.postToolHooks.get(agentId);
+
       const result = await runAgentExecution({
         agentId,
         sessionId,
@@ -1196,6 +1203,27 @@ export class AgentExecutionService {
         skillId: task.skillId,
         skillName: task.skillName,
         sdkSessionId: storedSdkSessionId,
+        preToolUseHooks: preHooks && preHooks.length > 0 ? preHooks : undefined,
+        // Service-level PostToolUseHook returns Promise<void>; the stream
+        // handler only cares about fire-and-forget semantics, so adapt on
+        // the fly to StreamPostToolUseHook's tool_response shape.
+        postToolUseHooks:
+          postHooks && postHooks.length > 0
+            ? postHooks.map(
+                (hook) =>
+                  async (input: {
+                    tool_name: string;
+                    tool_input: Record<string, unknown>;
+                    tool_response: { summary: string; is_error: boolean };
+                  }) => {
+                    await hook({
+                      tool_name: input.tool_name,
+                      tool_input: input.tool_input,
+                      tool_response: input.tool_response,
+                    });
+                  }
+              )
+            : undefined,
         sessionService: this.sessionService,
         onMessage: this.buildOnMessageCallback(memoryRef, this.memoryService),
       });

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -731,12 +731,19 @@ export class AgentExecutionService {
           ...(result.sdkSessionId ? { sdkSessionId: result.sdkSessionId } : {}),
         };
 
-        // Store the plan and options on the task
+        // Store the plan and options on the task, and flip to the
+        // waiting_approval state. Without this the kanban UI would not
+        // surface the plan and the theme-03 F6 rejectPlanForTask guard
+        // (which requires lastAgentStatus === 'planning') would never
+        // match, rendering host-mode reject non-functional. Mirrors
+        // PlanApprovalService.handlePlanReady for container-mode.
         await this.db
           .update(tasks)
           .set({
             plan: result.plan,
             planOptions: mergedPlanOptions,
+            lastAgentStatus: 'planning',
+            column: 'waiting_approval',
           })
           .where(eq(tasks.id, taskId));
 

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -1,5 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import { and, asc, count, eq, inArray } from 'drizzle-orm';
+import type { TaskColumn } from '../../db/schema';
 import { agentRuns, agents, codespaces, sessions, tasks, worktrees } from '../../db/schema';
 import { handleAgentError } from '../../lib/agents/recovery.js';
 import { runAgentExecution, runAgentPlanning } from '../../lib/agents/stream-handler.js';
@@ -1400,6 +1401,116 @@ export class AgentExecutionService {
         )
       );
     return ok(result?.count ?? 0);
+  }
+
+  /**
+   * theme-03 F6: host-mode plan rejection.
+   *
+   * Atomically:
+   *   1. Stop the running agent (abort controller + status → idle),
+   *   2. CAS-move the task to backlog where `lastAgentStatus='planning'`,
+   *      clearing plan/planOptions/worktreeId/branch,
+   *   3. Remove the worktree (best-effort).
+   *
+   * Returns `PLAN_NOT_FOUND` when the task is not in a rejectable state so
+   * the API layer can mirror the container-mode 404. Mirrors the CAS from
+   * PlanApprovalService.rejectPlan — both paths refuse to reject a task
+   * that has already moved on.
+   */
+  async rejectPlanForTask(
+    taskId: string,
+    reason?: string
+  ): Promise<Result<void, { code: string; message: string; status: number }>> {
+    const task = await this.db.query.tasks.findFirst({
+      where: eq(tasks.id, taskId),
+    });
+
+    if (!task || !task.plan || task.lastAgentStatus !== 'planning') {
+      return err({
+        code: 'PLAN_NOT_FOUND',
+        message: `No pending plan for task ${taskId}`,
+        status: 404,
+      });
+    }
+
+    const worktreeIdToClean = task.worktreeId ?? null;
+    const agentId = task.agentId ?? null;
+
+    // Stop the host-mode agent first so its background executeAgentAsync does
+    // not race with the DB update. stop() is best-effort — if the agent is
+    // already gone (crashed / never started) we proceed with cleanup anyway.
+    if (agentId && this.runningAgents.has(agentId)) {
+      const controller = this.runningAgents.get(agentId);
+      controller?.abort();
+      this.runningAgents.delete(agentId);
+      this.agentStartTimes.delete(agentId);
+      this.preToolHooks.delete(agentId);
+      this.postToolHooks.delete(agentId);
+      try {
+        await this.db
+          .update(agents)
+          .set({
+            status: 'idle',
+            currentTaskId: null,
+            currentSessionId: null,
+            updatedAt: new Date().toISOString(),
+          })
+          .where(eq(agents.id, agentId));
+      } catch (agentErr) {
+        log.warn('Failed to reset agent state on plan reject (continuing)', {
+          error: agentErr instanceof Error ? agentErr.message : String(agentErr),
+          data: { agentId, taskId },
+        });
+      }
+    }
+
+    // CAS-move: only reject if the task is still in the `planning` status.
+    try {
+      const [updated] = await this.db
+        .update(tasks)
+        .set({
+          column: 'backlog' as TaskColumn,
+          plan: null,
+          planOptions: null,
+          lastAgentStatus: null,
+          rejectionReason: reason ?? null,
+          worktreeId: null,
+          branch: null,
+        })
+        .where(and(eq(tasks.id, taskId), eq(tasks.lastAgentStatus, 'planning')))
+        .returning();
+
+      if (!updated) {
+        return err({
+          code: 'PLAN_NOT_FOUND',
+          message: `Plan rejection failed — task ${taskId} no longer in planning state`,
+          status: 404,
+        });
+      }
+    } catch (dbErr) {
+      const errorMsg = dbErr instanceof Error ? dbErr.message : String(dbErr);
+      log.error('Failed to reject plan (host-mode)', { data: { taskId, error: errorMsg } });
+      return err({
+        code: 'PLAN_REJECTION_FAILED',
+        message: `Failed to reject plan for task ${taskId}: ${errorMsg}`,
+        status: 500,
+      });
+    }
+
+    // Remove the worktree (best-effort, fire-and-forget)
+    if (worktreeIdToClean) {
+      this.worktreeService.remove(worktreeIdToClean, true).catch((rmErr) => {
+        log.warn('Failed to remove worktree on host-mode plan reject', {
+          error: rmErr instanceof Error ? rmErr.message : String(rmErr),
+          data: { taskId, worktreeId: worktreeIdToClean },
+        });
+      });
+    }
+
+    log.info('Plan rejected (host-mode)', {
+      data: { taskId, reason: reason ?? null, worktreeRemoved: !!worktreeIdToClean },
+    });
+    return ok(undefined);
   }
 
   /**

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -722,16 +722,26 @@ export class AgentExecutionService {
           })
           .where(eq(agents.id, agentId));
 
+        // theme-03 F5: persist the captured SDK session id alongside the plan
+        // options so host-mode execution (TaskService.approvePlan → resume)
+        // can resume the same conversation rather than reseeding full context.
+        const mergedPlanOptions = {
+          ...(result.planOptions ?? {}),
+          ...(result.sdkSessionId ? { sdkSessionId: result.sdkSessionId } : {}),
+        };
+
         // Store the plan and options on the task
         await this.db
           .update(tasks)
           .set({
             plan: result.plan,
-            planOptions: result.planOptions,
+            planOptions: mergedPlanOptions,
           })
           .where(eq(tasks.id, taskId));
 
-        log.info('Agent planning complete, awaiting approval', { data: { agentId } });
+        log.info('Agent planning complete, awaiting approval', {
+          data: { agentId, hasSdkSessionId: !!result.sdkSessionId },
+        });
       } else if (result.status === 'completed') {
         await this.db
           .update(agents)
@@ -1161,6 +1171,17 @@ export class AgentExecutionService {
 
       const maxRuntimeMs = await getAgentMaxRuntimeMs(this.db);
 
+      // theme-03 F5: recover the SDK session id captured during planning so
+      // the execution phase can resume the same conversation. Falls back to
+      // a fresh session when absent (mirrors agent-runner behaviour).
+      const taskRow = await this.db.query.tasks.findFirst({
+        where: eq(tasks.id, task.id),
+        columns: { planOptions: true },
+      });
+      const storedSdkSessionId =
+        (taskRow?.planOptions as { sdkSessionId?: string } | null | undefined)?.sdkSessionId ??
+        undefined;
+
       const result = await runAgentExecution({
         agentId,
         sessionId,
@@ -1173,6 +1194,7 @@ export class AgentExecutionService {
         maxRuntimeMs,
         skillId: task.skillId,
         skillName: task.skillName,
+        sdkSessionId: storedSdkSessionId,
         sessionService: this.sessionService,
         onMessage: this.buildOnMessageCallback(memoryRef, this.memoryService),
       });

--- a/src/services/container-agent/agentcore-bridge.service.ts
+++ b/src/services/container-agent/agentcore-bridge.service.ts
@@ -54,8 +54,6 @@ export class AgentCoreBridgeService {
         turnCount: number;
         sdkSessionId: string;
         allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-        launchSwarm?: boolean;
-        teammateCount?: number;
       }
     ) => Promise<void>,
     private onAgentCompleteCallback?: () =>

--- a/src/services/container-agent/agentcore-bridge.service.ts
+++ b/src/services/container-agent/agentcore-bridge.service.ts
@@ -25,6 +25,7 @@ import { getAgentMaxRuntimeMs, getGlobalDefaultModel } from '../settings.service
 import type { ContainerExecService } from './container-exec.service.js';
 import type { SandboxStateManager } from './sandbox-state.js';
 import {
+  resolveOAuthExpiresAtMs,
   resolveOAuthToken,
   updateAgentStatus,
   updateTaskOnAgentComplete,
@@ -232,6 +233,10 @@ export class AgentCoreBridgeService {
       return err(SandboxErrors.API_KEY_NOT_CONFIGURED);
     }
 
+    // theme-03 F11: resolve real OAuth expiry alongside the token so AgentCore
+    // does not write a fabricated 24h lifetime into the credentials file.
+    const oauthExpiresAtMs = await resolveOAuthExpiresAtMs(db);
+
     // Build invocation payload
     const payload: Record<string, unknown> = {
       prompt,
@@ -241,6 +246,7 @@ export class AgentCoreBridgeService {
       maxTurns: agentConfig.maxTurns,
       phase,
       oauthToken,
+      ...(oauthExpiresAtMs ? { oauthExpiresAt: oauthExpiresAtMs } : {}),
       cwd: '/workspace',
       ...(sdkSessionId ? { sdkSessionId } : {}),
     };

--- a/src/services/container-agent/container-agent.service.ts
+++ b/src/services/container-agent/container-agent.service.ts
@@ -116,8 +116,6 @@ export class ContainerAgentService {
         turnCount: number;
         sdkSessionId: string;
         allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-        launchSwarm?: boolean;
-        teammateCount?: number;
       }
     ) => this.planApproval.handlePlanReady(taskId, sessionId, codespaceId, planData);
 

--- a/src/services/container-agent/container-exec.service.ts
+++ b/src/services/container-agent/container-exec.service.ts
@@ -29,6 +29,7 @@ import { getAgentMaxRuntimeMs, getGlobalDefaultModel } from '../settings.service
 import { TemplateService } from '../template.service.js';
 import type { SandboxStateManager } from './sandbox-state.js';
 import {
+  resolveOAuthExpiresAtMs,
   resolveOAuthToken,
   updateAgentStatus,
   updateTaskOnAgentComplete,
@@ -118,6 +119,10 @@ export class ContainerExecService {
     worktreePath: string;
     stopFilePath: string;
     oauthToken: string;
+    /** theme-03 F11: real OAuth expiry ms since epoch (null when host has no record). */
+    oauthExpiresAtMs?: number | null;
+    /** theme-03 F11: OAuth refresh token when the host registry carries one. */
+    oauthRefreshToken?: string | null;
   }): { env: Record<string, string>; bridge: ContainerBridge } {
     const {
       taskId,
@@ -129,6 +134,8 @@ export class ContainerExecService {
       agentConfig,
       worktreePath,
       stopFilePath,
+      oauthExpiresAtMs,
+      oauthRefreshToken,
     } = params;
 
     const env: Record<string, string> = {
@@ -145,6 +152,11 @@ export class ContainerExecService {
       AGENT_STOP_FILE: stopFilePath,
       AGENT_PHASE: phase,
       ...(sdkSessionId ? { AGENT_SDK_SESSION_ID: sdkSessionId } : {}),
+      // theme-03 F11: pass real OAuth metadata through to the agent-runner when
+      // the host registry has it. Omitted entries leave the agent-runner to use
+      // its far-future sentinel rather than a fabricated 24h expiry.
+      ...(oauthExpiresAtMs ? { CLAUDE_OAUTH_EXPIRES_AT: String(oauthExpiresAtMs) } : {}),
+      ...(oauthRefreshToken ? { CLAUDE_OAUTH_REFRESH_TOKEN: oauthRefreshToken } : {}),
     };
     log.debug('Env vars prepared', {
       data: {
@@ -482,6 +494,8 @@ export class ContainerExecService {
     log.info('Retrieving OAuth credentials', { data: { taskId } });
 
     const oauthToken = await resolveOAuthToken(apiKeyService);
+    // theme-03 F11: look up real token expiry alongside the token itself.
+    const oauthExpiresAtMs = oauthToken ? await resolveOAuthExpiresAtMs(db) : null;
 
     if (!oauthToken) {
       log.info('No OAuth token available');
@@ -693,6 +707,10 @@ export class ContainerExecService {
       worktreePath,
       stopFilePath,
       oauthToken,
+      oauthExpiresAtMs,
+      // refreshToken storage is not yet wired through the registry;
+      // agent-runner treats absence as "no refresh token".
+      oauthRefreshToken: null,
     });
 
     // Merge project-level env vars (sandbox.env setting) into container env.

--- a/src/services/container-agent/container-exec.service.ts
+++ b/src/services/container-agent/container-exec.service.ts
@@ -60,8 +60,6 @@ export class ContainerExecService {
         turnCount: number;
         sdkSessionId: string;
         allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-        launchSwarm?: boolean;
-        teammateCount?: number;
       }
     ) => Promise<void>,
     private onAgentCompleteCallback?: () =>

--- a/src/services/container-agent/plan-approval.service.ts
+++ b/src/services/container-agent/plan-approval.service.ts
@@ -47,8 +47,6 @@ export class PlanApprovalService {
       turnCount: number;
       sdkSessionId: string;
       allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-      launchSwarm?: boolean;
-      teammateCount?: number;
     }
   ): Promise<void> {
     // Idempotency guard: if a plan is already pending, a duplicate plan_ready
@@ -94,8 +92,6 @@ export class PlanApprovalService {
       turnCount: planData.turnCount,
       sdkSessionId: planData.sdkSessionId,
       allowedPrompts: planData.allowedPrompts,
-      launchSwarm: planData.launchSwarm,
-      teammateCount: planData.teammateCount,
       sandboxId: planningSandboxId,
       createdAt: new Date(),
     });

--- a/src/services/container-agent/shared-helpers.ts
+++ b/src/services/container-agent/shared-helpers.ts
@@ -297,6 +297,32 @@ export async function resolveOAuthToken(apiKeyService: ApiKeyService): Promise<s
 }
 
 /**
+ * theme-03 F11: Resolve the persisted OAuth token expiry in ms since epoch.
+ *
+ * Reads `expiresAt` from the `api_keys` row for the `anthropic` service (stored
+ * as an ISO-8601 string per F06-09). Returns null when the row is missing or
+ * the column is null (legacy rows), in which case the agent-runner falls back
+ * to a far-future sentinel rather than fabricating a 24h expiry.
+ */
+export async function resolveOAuthExpiresAtMs(db: Database): Promise<number | null> {
+  try {
+    const { apiKeys } = await import('../../db/schema');
+    const row = await db.query.apiKeys.findFirst({
+      where: eq(apiKeys.service, 'anthropic'),
+    });
+    if (!row?.expiresAt) return null;
+    const ms = Date.parse(row.expiresAt);
+    if (!Number.isFinite(ms) || ms <= 0) return null;
+    return ms;
+  } catch (err) {
+    log.info('Failed to resolve OAuth expiresAt from database', {
+      data: { error: err instanceof Error ? err.message : String(err) },
+    });
+    return null;
+  }
+}
+
+/**
  * Update agent record status after completion or error.
  */
 export async function updateAgentStatus(

--- a/src/services/container-agent/types.ts
+++ b/src/services/container-agent/types.ts
@@ -90,8 +90,6 @@ export interface PlanData {
   createdAt: Date;
   /** Sandbox ID at the time planning completed -- used to detect container changes before execution */
   sandboxId?: string;
-  launchSwarm?: boolean;
-  teammateCount?: number;
 }
 
 /**

--- a/src/services/durable-streams.service.ts
+++ b/src/services/durable-streams.service.ts
@@ -216,8 +216,6 @@ export interface ContainerAgentPlanReadyEvent {
   turnCount: number;
   sdkSessionId: string;
   allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  launchSwarm?: boolean;
-  teammateCount?: number;
 }
 
 export interface ContainerAgentTaskUpdateFailedEvent {

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -106,6 +106,15 @@ export interface ContainerAgentTrigger {
  */
 export interface AgentExecutionTrigger {
   resume: (agentId: string, feedback?: string) => Promise<Result<unknown, unknown>>;
+  /**
+   * theme-03 F6: host-mode plan rejection. Stops any host-mode agent running
+   * for the task, moves the task back to backlog, clears plan state, and
+   * removes the worktree.
+   */
+  rejectPlanForTask?: (
+    taskId: string,
+    reason?: string
+  ) => Promise<Result<void, { code: string; message: string; status: number }>>;
 }
 
 export class TaskService {
@@ -296,28 +305,46 @@ export class TaskService {
 
   /**
    * Reject a pending plan for a task and move it back to backlog.
+   *
+   * theme-03 F6: falls back to host-mode rejection (agentExecutionService)
+   * when the container agent service is not configured, so deployments
+   * running host-mode agents can still reach the `plan → backlog` edge of
+   * the state machine.
    */
   async rejectPlan(taskId: string, reason?: string): Promise<Result<void, TaskError>> {
-    if (!this.containerAgentService) {
-      return err({
-        code: 'CONTAINER_AGENT_SERVICE_UNAVAILABLE',
-        message: 'Container agent service is not configured',
-        status: 503,
-      });
+    // Container mode: delegate to the container agent service.
+    if (this.containerAgentService) {
+      const result = await this.containerAgentService.rejectPlan(taskId, reason);
+      if (!result.ok) {
+        // Propagate the actual error — distinguish PLAN_NOT_FOUND from PLAN_REJECTION_FAILED
+        const errorObj = result.error;
+        return err({
+          code: errorObj?.code ?? 'PLAN_REJECTION_FAILED',
+          message: errorObj?.message ?? `Failed to reject plan for task ${taskId}`,
+          status: errorObj?.status ?? 500,
+        });
+      }
+      return ok(undefined);
     }
 
-    const result = await this.containerAgentService.rejectPlan(taskId, reason);
-    if (!result.ok) {
-      // Propagate the actual error — distinguish PLAN_NOT_FOUND from PLAN_REJECTION_FAILED
-      const errorObj = result.error;
-      return err({
-        code: errorObj?.code ?? 'PLAN_REJECTION_FAILED',
-        message: errorObj?.message ?? `Failed to reject plan for task ${taskId}`,
-        status: errorObj?.status ?? 500,
-      });
+    // theme-03 F6: host-mode fallback.
+    if (this.agentExecutionService?.rejectPlanForTask) {
+      const result = await this.agentExecutionService.rejectPlanForTask(taskId, reason);
+      if (!result.ok) {
+        return err({
+          code: result.error.code,
+          message: result.error.message,
+          status: result.error.status,
+        });
+      }
+      return ok(undefined);
     }
 
-    return ok(undefined);
+    return err({
+      code: 'NO_EXECUTION_SERVICE',
+      message: 'No execution service available for plan rejection',
+      status: 503,
+    });
   }
 
   /**

--- a/tests/functional/prove-plan-approval-bugs.test.ts
+++ b/tests/functional/prove-plan-approval-bugs.test.ts
@@ -75,8 +75,6 @@ function makePlanData(overrides: Record<string, unknown> = {}) {
     turnCount: (overrides.turnCount as number) ?? 3,
     sdkSessionId: (overrides.sdkSessionId as string) ?? 'sdk-session-1',
     allowedPrompts: overrides.allowedPrompts as Array<{ tool: 'Bash'; prompt: string }> | undefined,
-    launchSwarm: overrides.launchSwarm as boolean | undefined,
-    teammateCount: overrides.teammateCount as number | undefined,
   };
 }
 

--- a/tests/integration/agent-execution-service.test.ts
+++ b/tests/integration/agent-execution-service.test.ts
@@ -517,4 +517,142 @@ describe('AgentExecutionService (IT-200)', () => {
       expect(() => service.registerPostToolUseHook('agent-1', postHook)).not.toThrow();
     });
   });
+
+  // theme-03 F6: host-mode plan rejection.
+  describe('rejectPlanForTask (IT-F6)', () => {
+    it('IT-F6-a: returns PLAN_NOT_FOUND when task has no pending plan', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, { column: 'in_progress' });
+
+      const result = await service.rejectPlanForTask(task.id, 'wrong task');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('PLAN_NOT_FOUND');
+      expect(result.error.status).toBe(404);
+    });
+
+    it('IT-F6-b: moves task to backlog, clears plan state, and stores rejectionReason', async () => {
+      const codespace = await createTestProject();
+      const worktree = await createTestWorktree(codespace.id);
+      const task = await createTestTask(codespace.id, {
+        column: 'in_progress',
+        worktreeId: worktree.id,
+        branch: worktree.branch,
+      });
+
+      // Put the task into the planning state the way handlePlanReady would.
+      await db
+        .update(tasks)
+        .set({
+          column: 'waiting_approval' as const,
+          plan: 'Plan step 1\nStep 2',
+          planOptions: { sdkSessionId: 'sdk-42' },
+          lastAgentStatus: 'planning',
+        })
+        .where(eq(tasks.id, task.id));
+
+      const result = await service.rejectPlanForTask(task.id, 'stale plan');
+      expect(result.ok).toBe(true);
+
+      const after = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+      expect(after?.column).toBe('backlog');
+      expect(after?.plan).toBeNull();
+      expect(after?.planOptions).toBeNull();
+      expect(after?.lastAgentStatus).toBeNull();
+      expect(after?.rejectionReason).toBe('stale plan');
+      expect(after?.worktreeId).toBeNull();
+      expect(after?.branch).toBeNull();
+    });
+
+    it('IT-F6-c: calls worktreeService.remove when worktreeId was set', async () => {
+      const codespace = await createTestProject();
+      const worktree = await createTestWorktree(codespace.id);
+      const task = await createTestTask(codespace.id, {
+        column: 'in_progress',
+        worktreeId: worktree.id,
+        branch: worktree.branch,
+      });
+
+      await db
+        .update(tasks)
+        .set({
+          column: 'waiting_approval' as const,
+          plan: 'Plan',
+          planOptions: {},
+          lastAgentStatus: 'planning',
+        })
+        .where(eq(tasks.id, task.id));
+
+      const result = await service.rejectPlanForTask(task.id, 'no good');
+      expect(result.ok).toBe(true);
+
+      // remove() is fire-and-forget so give the microtask queue a tick to run.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockWorktreeService.remove).toHaveBeenCalledWith(worktree.id, true);
+    });
+
+    it('IT-F6-d: CAS-protected — refuses to reject a task whose status moved on', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, {
+        column: 'in_progress',
+      });
+
+      // Task has plan text but lastAgentStatus is NOT 'planning' (already approved).
+      await db
+        .update(tasks)
+        .set({
+          plan: 'Plan',
+          planOptions: {},
+          lastAgentStatus: 'running',
+        })
+        .where(eq(tasks.id, task.id));
+
+      const result = await service.rejectPlanForTask(task.id, 'late reject');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('PLAN_NOT_FOUND');
+    });
+
+    it('IT-F6-e: resets the agent row to idle when one was running in memory', async () => {
+      const codespace = await createTestProject();
+      const agent = await createTestAgent(codespace.id, {
+        status: 'planning',
+      });
+      const task = await createTestTask(codespace.id, {
+        column: 'in_progress',
+        agentId: agent.id,
+      });
+
+      await db
+        .update(tasks)
+        .set({
+          column: 'waiting_approval' as const,
+          plan: 'Plan',
+          planOptions: {},
+          lastAgentStatus: 'planning',
+        })
+        .where(eq(tasks.id, task.id));
+
+      // Register a running agent controller so the stop branch executes.
+      const controller = new AbortController();
+      (service as unknown as { runningAgents: Map<string, AbortController> }).runningAgents.set(
+        agent.id,
+        controller
+      );
+      (service as unknown as { agentStartTimes: Map<string, number> }).agentStartTimes.set(
+        agent.id,
+        Date.now()
+      );
+
+      const result = await service.rejectPlanForTask(task.id, 'tear it down');
+      expect(result.ok).toBe(true);
+
+      // Agent should be idle and controller aborted.
+      const after = await db.query.agents.findFirst({ where: eq(agents.id, agent.id) });
+      expect(after?.status).toBe('idle');
+      expect(after?.currentTaskId).toBeNull();
+      expect(controller.signal.aborted).toBe(true);
+    });
+  });
 });

--- a/tests/integration/container-agent-service.test.ts
+++ b/tests/integration/container-agent-service.test.ts
@@ -143,7 +143,7 @@ describe('ContainerAgentService — DB-level integration tests', () => {
       .update(tasks)
       .set({
         plan: 'Step 1: Implement feature\nStep 2: Write tests',
-        planOptions: { allowedPrompts: [], launchSwarm: false },
+        planOptions: { allowedPrompts: [] },
         lastAgentStatus: 'planning',
       })
       .where(eq(tasks.id, task.id));

--- a/tests/integration/container-agent-services.test.ts
+++ b/tests/integration/container-agent-services.test.ts
@@ -1619,7 +1619,6 @@ describe('Cross-service: State Manager + DB consistency (IT-309)', () => {
       sdkSessionId: 'sdk-1',
       createdAt: new Date(),
       allowedPrompts: [{ tool: 'Bash', prompt: 'npm test' }],
-      launchSwarm: false,
     };
 
     // Store plan

--- a/tests/integration/container-agent-services.test.ts
+++ b/tests/integration/container-agent-services.test.ts
@@ -8,6 +8,7 @@ import type {} from '../../src/services/container-agent/agentcore-bridge.service
 import type {} from '../../src/services/container-agent/container-exec.service';
 import { SandboxStateManager } from '../../src/services/container-agent/sandbox-state';
 import {
+  resolveOAuthExpiresAtMs,
   resolveOAuthToken,
   updateAgentStatus,
   updateTaskOnAgentComplete,
@@ -303,6 +304,77 @@ describe('Shared Helpers — resolveOAuthToken (IT-304)', () => {
       if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
       else delete process.env.ANTHROPIC_API_KEY;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// theme-03 F11: resolveOAuthExpiresAtMs (IT-304F)
+// ---------------------------------------------------------------------------
+
+describe('Shared Helpers — resolveOAuthExpiresAtMs (IT-304F)', () => {
+  beforeEach(async () => {
+    await setupTestDatabase();
+    // clearTestDatabase does not truncate api_keys (stable test fixture);
+    // delete the row ourselves so each F11 test sees a clean slate.
+    const db = getTestDb();
+    const { apiKeys } = await import('../../src/db/schema');
+    await db.delete(apiKeys).where(eq(apiKeys.service, 'anthropic'));
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+  });
+
+  it('IT-304F-a: returns null when no anthropic api key row exists', async () => {
+    const db = getTestDb();
+    const result = await resolveOAuthExpiresAtMs(db);
+    expect(result).toBeNull();
+  });
+
+  it('IT-304F-b: returns null when row exists but expiresAt is null (legacy)', async () => {
+    const db = getTestDb();
+    const { apiKeys } = await import('../../src/db/schema');
+    await db.insert(apiKeys).values({
+      id: createId(),
+      service: 'anthropic',
+      encryptedKey: 'enc',
+      maskedKey: 'sk-ant-...abc',
+      expiresAt: null,
+    });
+
+    const result = await resolveOAuthExpiresAtMs(db);
+    expect(result).toBeNull();
+  });
+
+  it('IT-304F-c: returns ms since epoch when expiresAt is a valid ISO string', async () => {
+    const db = getTestDb();
+    const { apiKeys } = await import('../../src/db/schema');
+    const iso = '2027-06-15T12:00:00.000Z';
+    await db.insert(apiKeys).values({
+      id: createId(),
+      service: 'anthropic',
+      encryptedKey: 'enc',
+      maskedKey: 'sk-ant-...abc',
+      expiresAt: iso,
+    });
+
+    const result = await resolveOAuthExpiresAtMs(db);
+    expect(result).toBe(Date.parse(iso));
+  });
+
+  it('IT-304F-d: returns null when expiresAt is unparseable', async () => {
+    const db = getTestDb();
+    const { apiKeys } = await import('../../src/db/schema');
+    await db.insert(apiKeys).values({
+      id: createId(),
+      service: 'anthropic',
+      encryptedKey: 'enc',
+      maskedKey: 'sk-ant-...abc',
+      expiresAt: 'not-a-date',
+    });
+
+    const result = await resolveOAuthExpiresAtMs(db);
+    expect(result).toBeNull();
   });
 });
 

--- a/tests/integration/plan-approval-flow.test.ts
+++ b/tests/integration/plan-approval-flow.test.ts
@@ -171,7 +171,9 @@ describe('PlanApprovalService — full service integration (IT-220)', () => {
       expect(dbTask?.plan).toBeNull();
     });
 
-    it('IT-221d: stores launchSwarm and teammateCount for team mode', async () => {
+    it('IT-221d: accepts allowedPrompts from ExitPlanMode options', async () => {
+      // theme-03 F3: launchSwarm/teammateCount removed as they were dead data.
+      // allowedPrompts remains a live field used by downstream permission logic.
       const project = await createTestProject();
       const task = await createTestTask(project.id, { column: 'in_progress' });
       const session = await createTestSession(project.id, { taskId: task.id });
@@ -189,17 +191,16 @@ describe('PlanApprovalService — full service integration (IT-220)', () => {
         phase: 'plan',
       });
 
+      const allowedPrompts = [{ tool: 'Bash' as const, prompt: 'ls -la' }];
       await service.handlePlanReady(task.id, session.id, project.id, {
         plan: 'Multi-agent plan',
         turnCount: 8,
         sdkSessionId: 'sdk-team',
-        launchSwarm: true,
-        teammateCount: 4,
+        allowedPrompts,
       });
 
       const plan = state.getPendingPlan(task.id);
-      expect(plan?.launchSwarm).toBe(true);
-      expect(plan?.teammateCount).toBe(4);
+      expect(plan?.allowedPrompts).toEqual(allowedPrompts);
     });
   });
 

--- a/tests/integration/plan-approval-service.test.ts
+++ b/tests/integration/plan-approval-service.test.ts
@@ -22,8 +22,6 @@ describe('PlanApprovalService — DB-level integration tests', () => {
     const planText = '## Implementation Plan\n1. Create module\n2. Add tests\n3. Deploy';
     const planOptions = {
       allowedPrompts: [{ tool: 'Bash' as const, prompt: 'npm test' }],
-      launchSwarm: false,
-      teammateCount: 0,
       sdkSessionId: 'sdk-session-123',
       planningSandboxId: 'sandbox-456',
     };
@@ -175,9 +173,6 @@ describe('PlanApprovalService — DB-level integration tests', () => {
         { tool: 'Bash' as const, prompt: 'npm install' },
         { tool: 'Bash' as const, prompt: 'npm test' },
       ],
-      launchSwarm: true,
-      teammateCount: 3,
-      pushToRemote: true,
       sdkSessionId: 'sdk-abc-def',
       planningSandboxId: 'sandbox-xyz',
     };
@@ -193,8 +188,10 @@ describe('PlanApprovalService — DB-level integration tests', () => {
 
     const dbTask = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
     expect(dbTask?.planOptions).toEqual(complexPlanOptions);
-    expect((dbTask?.planOptions as typeof complexPlanOptions)?.launchSwarm).toBe(true);
-    expect((dbTask?.planOptions as typeof complexPlanOptions)?.teammateCount).toBe(3);
+    expect((dbTask?.planOptions as typeof complexPlanOptions)?.sdkSessionId).toBe('sdk-abc-def');
+    expect((dbTask?.planOptions as typeof complexPlanOptions)?.planningSandboxId).toBe(
+      'sandbox-xyz'
+    );
     expect((dbTask?.planOptions as typeof complexPlanOptions)?.allowedPrompts).toHaveLength(2);
   });
 

--- a/tests/integration/task-plan-approval.test.ts
+++ b/tests/integration/task-plan-approval.test.ts
@@ -32,9 +32,13 @@ function createMockContainerAgent(): ContainerAgentTrigger {
   };
 }
 
-function createMockAgentExecution(): AgentExecutionTrigger {
+function createMockAgentExecution(
+  overrides: Partial<AgentExecutionTrigger> = {}
+): AgentExecutionTrigger {
   return {
     resume: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+    rejectPlanForTask: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+    ...overrides,
   };
 }
 
@@ -128,21 +132,64 @@ describe('IT-041–045: Task Plan Approval and Rejection', () => {
       expect(containerAgent.rejectPlan).toHaveBeenCalledWith(task.id, 'bad plan');
     });
 
-    it('returns CONTAINER_AGENT_SERVICE_UNAVAILABLE when no containerAgentService is set', async () => {
+    // theme-03 F6: host-mode fallback for rejectPlan.
+    it('F6-a: falls back to agentExecutionService.rejectPlanForTask when container service is not set', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, { column: 'in_progress' });
+
+      const worktreeService = createMockWorktreeService();
+      const agentExecution = createMockAgentExecution();
+      const taskService = new TaskService(db as any, worktreeService);
+      // Do NOT set containerAgentService; set host-mode fallback only
+      taskService.setAgentExecutionService(agentExecution);
+
+      const result = await taskService.rejectPlan(task.id, 'stale plan');
+
+      expect(result.ok).toBe(true);
+      expect(agentExecution.rejectPlanForTask).toHaveBeenCalledWith(task.id, 'stale plan');
+    });
+
+    it('F6-b: returns NO_EXECUTION_SERVICE when neither service is set', async () => {
       const codespace = await createTestProject();
       const task = await createTestTask(codespace.id, { column: 'in_progress' });
 
       const worktreeService = createMockWorktreeService();
       const taskService = new TaskService(db as any, worktreeService);
-      // No containerAgentService set
+      // Neither containerAgentService nor agentExecutionService set
 
       const result = await taskService.rejectPlan(task.id, 'bad plan');
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
 
-      expect(result.error.code).toBe('CONTAINER_AGENT_SERVICE_UNAVAILABLE');
+      expect(result.error.code).toBe('NO_EXECUTION_SERVICE');
       expect(result.error.status).toBe(503);
+    });
+
+    it('F6-c: propagates host-mode rejectPlanForTask errors to caller', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, { column: 'in_progress' });
+
+      const worktreeService = createMockWorktreeService();
+      const agentExecution = createMockAgentExecution({
+        rejectPlanForTask: vi.fn().mockResolvedValue({
+          ok: false,
+          error: {
+            code: 'PLAN_NOT_FOUND',
+            message: 'No pending plan for task',
+            status: 404,
+          },
+        }),
+      });
+      const taskService = new TaskService(db as any, worktreeService);
+      taskService.setAgentExecutionService(agentExecution);
+
+      const result = await taskService.rejectPlan(task.id, 'mistake');
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe('PLAN_NOT_FOUND');
+      expect(result.error.status).toBe(404);
     });
   });
 

--- a/tests/integration/transaction-cascade.test.ts
+++ b/tests/integration/transaction-cascade.test.ts
@@ -211,8 +211,6 @@ describe('Transaction & Cascade (IT-196 to IT-200)', () => {
     const plan = '## Implementation Plan\n1. Parse input\n2. Validate\n3. Transform\n4. Output';
     const planOptions = {
       allowedPrompts: [{ tool: 'Bash' as const, prompt: 'npm test' }],
-      launchSwarm: false,
-      teammateCount: 1,
     };
 
     await db

--- a/tests/lib/agents/stream-handler.test.ts
+++ b/tests/lib/agents/stream-handler.test.ts
@@ -1491,4 +1491,262 @@ describe('F5: host-mode SDK session resume', () => {
   });
 });
 
+// =============================================================================
+// theme-03 F2: pre/post tool-use hooks
+// =============================================================================
+
+describe('F2: tool-use hooks wired into runAgentExecution.canUseTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('invokes registered pre-tool-use hook before allowing a tool', async () => {
+    let capturedCanUseTool: ((...args: unknown[]) => unknown) | null = null;
+    const messages: Array<Record<string, unknown>> = [];
+    async function* controlledStream() {
+      while (messages.length === 0) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      for (const m of messages) yield m;
+    }
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockImplementation(() => controlledStream()),
+      close: vi.fn(),
+      sessionId: 'exec-pre',
+    };
+    mockSessionCreate.mockImplementation((opts: Record<string, unknown>) => {
+      capturedCanUseTool = opts.canUseTool as (...args: unknown[]) => unknown;
+      return mockSession;
+    });
+
+    const preHook = vi.fn().mockResolvedValue({ deny: false });
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    const promise = runAgentExecution(
+      createDefaultOptions(sessionService, { preToolUseHooks: [preHook] })
+    );
+    for (let i = 0; i < 100 && !capturedCanUseTool; i++) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(capturedCanUseTool).not.toBeNull();
+
+    const verdict = await capturedCanUseTool!(
+      'Read',
+      { file_path: '/x.ts' },
+      {
+        toolUseID: 'tu-pre-1',
+      }
+    );
+
+    // Close the stream
+    messages.push({
+      type: 'result',
+      total_cost_usd: 0,
+      duration_ms: 1,
+      num_turns: 0,
+      stop_reason: 'end_turn',
+    });
+
+    await promise;
+
+    expect(preHook).toHaveBeenCalledWith({
+      tool_name: 'Read',
+      tool_input: { file_path: '/x.ts' },
+    });
+    expect(verdict).toEqual(expect.objectContaining({ behavior: 'allow', toolUseID: 'tu-pre-1' }));
+  });
+
+  it('denies the tool when a pre-tool-use hook returns {deny:true}', async () => {
+    let capturedCanUseTool: ((...args: unknown[]) => unknown) | null = null;
+    const messages: Array<Record<string, unknown>> = [];
+    async function* controlledStream() {
+      while (messages.length === 0) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      for (const m of messages) yield m;
+    }
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockImplementation(() => controlledStream()),
+      close: vi.fn(),
+      sessionId: 'exec-deny',
+    };
+    mockSessionCreate.mockImplementation((opts: Record<string, unknown>) => {
+      capturedCanUseTool = opts.canUseTool as (...args: unknown[]) => unknown;
+      return mockSession;
+    });
+
+    const denyHook = vi.fn().mockResolvedValue({ deny: true, reason: 'tool disallowed by policy' });
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    const promise = runAgentExecution(
+      createDefaultOptions(sessionService, { preToolUseHooks: [denyHook] })
+    );
+    for (let i = 0; i < 100 && !capturedCanUseTool; i++) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(capturedCanUseTool).not.toBeNull();
+
+    const verdict = await capturedCanUseTool!(
+      'Bash',
+      { command: 'rm -rf /' },
+      {
+        toolUseID: 'tu-deny-1',
+      }
+    );
+
+    messages.push({
+      type: 'result',
+      total_cost_usd: 0,
+      duration_ms: 1,
+      num_turns: 0,
+      stop_reason: 'end_turn',
+    });
+
+    await promise;
+
+    expect(denyHook).toHaveBeenCalled();
+    expect(verdict).toEqual({
+      behavior: 'deny',
+      message: 'tool disallowed by policy',
+      interrupt: false,
+    });
+    // Denying should emit a tool:result with isError:true
+    const resultCall = findPublishedEvent(sessionService, 'tool:result');
+    expect(resultCall).toBeDefined();
+    const evt = resultCall![1] as { data: Record<string, unknown> };
+    expect(evt.data.isError).toBe(true);
+    expect(evt.data.output).toBe('tool disallowed by policy');
+  });
+
+  it('invokes post-tool-use hook after tool_use_summary', async () => {
+    // Pre-seed the activeTools map by invoking canUseTool BEFORE the stream
+    // yields the tool_use_summary. We build a stream that starts empty, then
+    // yield messages after the canUseTool call has registered the tool.
+    let capturedCanUseTool: ((...args: unknown[]) => unknown) | null = null;
+    const messages: Array<Record<string, unknown>> = [];
+    async function* controlledStream() {
+      // Wait until the test has registered the tool before yielding the summary.
+      while (messages.length === 0) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      for (const m of messages) yield m;
+    }
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockImplementation(() => controlledStream()),
+      close: vi.fn(),
+      sessionId: 'exec-post',
+    };
+    mockSessionCreate.mockImplementation((opts: Record<string, unknown>) => {
+      capturedCanUseTool = opts.canUseTool as (...args: unknown[]) => unknown;
+      return mockSession;
+    });
+
+    const postHook = vi.fn().mockResolvedValue(undefined);
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    const promise = runAgentExecution(
+      createDefaultOptions(sessionService, { postToolUseHooks: [postHook] })
+    );
+
+    // Poll until canUseTool has been captured from the session factory.
+    for (let i = 0; i < 100 && !capturedCanUseTool; i++) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(capturedCanUseTool).not.toBeNull();
+
+    // Register the tool via canUseTool so activeTools has the entry
+    await capturedCanUseTool!('Read', { file_path: '/a.ts' }, { toolUseID: 'tu-post-1' });
+
+    // Now provide the tool_use_summary + end-of-stream messages.
+    messages.push(
+      {
+        type: 'tool_use_summary',
+        summary: 'File read complete',
+        preceding_tool_use_ids: ['tu-post-1'],
+      },
+      {
+        type: 'result',
+        total_cost_usd: 0,
+        duration_ms: 1,
+        num_turns: 0,
+        stop_reason: 'end_turn',
+      }
+    );
+
+    await promise;
+
+    expect(postHook).toHaveBeenCalledWith({
+      tool_name: 'Read',
+      tool_input: { file_path: '/a.ts' },
+      tool_response: { summary: 'File read complete', is_error: false },
+    });
+  });
+
+  it('does not abort the stream if a post-tool-use hook throws', async () => {
+    let capturedCanUseTool: ((...args: unknown[]) => unknown) | null = null;
+    const messages: Array<Record<string, unknown>> = [];
+    async function* controlledStream() {
+      while (messages.length === 0) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
+      for (const m of messages) yield m;
+    }
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockImplementation(() => controlledStream()),
+      close: vi.fn(),
+      sessionId: 'exec-throw',
+    };
+    mockSessionCreate.mockImplementation((opts: Record<string, unknown>) => {
+      capturedCanUseTool = opts.canUseTool as (...args: unknown[]) => unknown;
+      return mockSession;
+    });
+
+    const throwHook = vi.fn().mockRejectedValue(new Error('hook boom'));
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    const promise = runAgentExecution(
+      createDefaultOptions(sessionService, { postToolUseHooks: [throwHook] })
+    );
+
+    for (let i = 0; i < 100 && !capturedCanUseTool; i++) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(capturedCanUseTool).not.toBeNull();
+
+    await capturedCanUseTool!('Read', { file_path: '/a.ts' }, { toolUseID: 'tu-throw-1' });
+
+    messages.push(
+      {
+        type: 'tool_use_summary',
+        summary: 'done',
+        preceding_tool_use_ids: ['tu-throw-1'],
+      },
+      {
+        type: 'result',
+        total_cost_usd: 0,
+        duration_ms: 1,
+        num_turns: 0,
+        stop_reason: 'end_turn',
+      }
+    );
+
+    const result = await promise;
+    expect(throwHook).toHaveBeenCalled();
+    // Hook failure must not fail the run
+    expect(result.status).toBe('completed');
+  });
+});
+
 // executeToolWithHooks tests removed (AE-006: dead code deleted)

--- a/tests/lib/agents/stream-handler.test.ts
+++ b/tests/lib/agents/stream-handler.test.ts
@@ -14,11 +14,28 @@ const mockSessionCreate = vi.hoisted(() =>
       })()
     ),
     close: vi.fn(),
+    sessionId: 'sdk-session-mock-id',
+  })
+);
+
+// theme-03 F5: host-mode stream-handler now calls unstable_v2_resumeSession
+// when the caller supplies an sdkSessionId (mirroring the agent-runner).
+const mockSessionResume = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    send: vi.fn(),
+    stream: vi.fn().mockReturnValue(
+      (async function* () {
+        // empty stream
+      })()
+    ),
+    close: vi.fn(),
+    sessionId: 'sdk-session-mock-resumed-id',
   })
 );
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   unstable_v2_createSession: mockSessionCreate,
+  unstable_v2_resumeSession: mockSessionResume,
 }));
 
 vi.mock('@/lib/topology/map-agent-role', () => ({
@@ -39,8 +56,10 @@ function createMockSession() {
       })()
     ),
     close: vi.fn(),
+    sessionId: 'sdk-session-mock-id',
   };
   mockSessionCreate.mockReturnValue(session);
+  mockSessionResume.mockReturnValue(session);
   return session;
 }
 
@@ -1307,6 +1326,168 @@ describe('runAgentExecution', () => {
     expect(result.status).toBe('completed');
     expect(result.turnCount).toBe(1);
     expect(result.result).toBe('Implementation done');
+  });
+});
+
+// =============================================================================
+// theme-03 F5: host-mode SDK session resume across plan approval
+// =============================================================================
+
+describe('F5: host-mode SDK session resume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMockSession();
+  });
+
+  it('runAgentPlanning captures sdkSessionId from the session and returns it', async () => {
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockReturnValue(
+        yieldMessages([
+          {
+            type: 'result',
+            total_cost_usd: 0.01,
+            duration_ms: 1000,
+            num_turns: 1,
+            stop_reason: 'end_turn',
+          },
+        ])
+      ),
+      close: vi.fn(),
+      sessionId: 'captured-sdk-session-42',
+    };
+    mockSessionCreate.mockReturnValue(mockSession);
+
+    const sessionService = createMockSessionService();
+    const { runAgentPlanning } = await import('@/lib/agents/stream-handler');
+
+    const result = await runAgentPlanning(createDefaultOptions(sessionService));
+
+    expect(result.sdkSessionId).toBe('captured-sdk-session-42');
+  });
+
+  it('runAgentPlanning emits plan_ready event carrying captured sdkSessionId', async () => {
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockReturnValue(
+        yieldMessages([
+          {
+            type: 'result',
+            total_cost_usd: 0.01,
+            duration_ms: 1000,
+            num_turns: 1,
+            stop_reason: 'end_turn',
+          },
+        ])
+      ),
+      close: vi.fn(),
+      sessionId: 'planning-sdk-session-xyz',
+    };
+    mockSessionCreate.mockReturnValue(mockSession);
+
+    const sessionService = createMockSessionService();
+    const { runAgentPlanning } = await import('@/lib/agents/stream-handler');
+
+    await runAgentPlanning(createDefaultOptions(sessionService));
+
+    const call = findPublishedEvent(sessionService, 'agent:plan_ready');
+    expect(call).toBeDefined();
+    const event = call![1] as { data: Record<string, unknown> };
+    expect(event.data.sdkSessionId).toBe('planning-sdk-session-xyz');
+  });
+
+  it('runAgentExecution calls unstable_v2_resumeSession when sdkSessionId is provided', async () => {
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockReturnValue(
+        yieldMessages([
+          {
+            type: 'result',
+            total_cost_usd: 0.01,
+            duration_ms: 1000,
+            num_turns: 1,
+            stop_reason: 'end_turn',
+          },
+        ])
+      ),
+      close: vi.fn(),
+      sessionId: 'resumed-123',
+    };
+    mockSessionResume.mockReturnValue(mockSession);
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    await runAgentExecution(createDefaultOptions(sessionService, { sdkSessionId: 'plan-sdk-77' }));
+
+    expect(mockSessionResume).toHaveBeenCalledWith(
+      'plan-sdk-77',
+      expect.objectContaining({ permissionMode: 'acceptEdits' })
+    );
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('runAgentExecution skips resume and calls createSession when no sdkSessionId is provided', async () => {
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockReturnValue(
+        yieldMessages([
+          {
+            type: 'result',
+            total_cost_usd: 0.01,
+            duration_ms: 1000,
+            num_turns: 1,
+            stop_reason: 'end_turn',
+          },
+        ])
+      ),
+      close: vi.fn(),
+      sessionId: 'fresh-123',
+    };
+    mockSessionCreate.mockReturnValue(mockSession);
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    await runAgentExecution(createDefaultOptions(sessionService));
+
+    expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+    expect(mockSessionResume).not.toHaveBeenCalled();
+  });
+
+  it('runAgentExecution falls back to createSession when resume throws', async () => {
+    const mockSession = {
+      send: vi.fn(),
+      stream: vi.fn().mockReturnValue(
+        yieldMessages([
+          {
+            type: 'result',
+            total_cost_usd: 0.01,
+            duration_ms: 1000,
+            num_turns: 1,
+            stop_reason: 'end_turn',
+          },
+        ])
+      ),
+      close: vi.fn(),
+      sessionId: 'fallback-123',
+    };
+    mockSessionResume.mockImplementationOnce(() => {
+      throw new Error('session expired');
+    });
+    mockSessionCreate.mockReturnValue(mockSession);
+
+    const sessionService = createMockSessionService();
+    const { runAgentExecution } = await import('@/lib/agents/stream-handler');
+
+    const result = await runAgentExecution(
+      createDefaultOptions(sessionService, { sdkSessionId: 'stale-sdk' })
+    );
+
+    expect(mockSessionResume).toHaveBeenCalledWith('stale-sdk', expect.any(Object));
+    // Fallback to fresh session on resume failure
+    expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('completed');
   });
 });
 

--- a/tests/services/agent-execution.service.test.ts
+++ b/tests/services/agent-execution.service.test.ts
@@ -280,7 +280,7 @@ describe('AgentExecutionService', () => {
         status: 'planning',
         turnCount: 5,
         plan: 'Step 1: Refactor module\nStep 2: Add tests',
-        planOptions: { launchSwarm: false },
+        planOptions: { allowedPrompts: [] },
       });
 
       const { agent, task } = await setupStartPrerequisites();

--- a/tests/services/task-plan-approval.test.ts
+++ b/tests/services/task-plan-approval.test.ts
@@ -107,11 +107,14 @@ describe('TaskService plan approval/rejection', () => {
   });
 
   describe('rejectPlan', () => {
-    it('returns 503 when no container agent service is configured', async () => {
+    it('returns NO_EXECUTION_SERVICE 503 when neither container nor host-mode service is configured', async () => {
+      // theme-03 F6: the error code is now NO_EXECUTION_SERVICE (was
+      // CONTAINER_AGENT_SERVICE_UNAVAILABLE) because rejectPlan now also
+      // supports a host-mode fallback via agentExecutionService.rejectPlanForTask.
       const result = await taskService.rejectPlan('any-task-id');
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error.code).toBe('CONTAINER_AGENT_SERVICE_UNAVAILABLE');
+        expect(result.error.code).toBe('NO_EXECUTION_SERVICE');
         expect(result.error.status).toBe(503);
       }
     });


### PR DESCRIPTION
## Summary

Theme 03 of the April 2026 architecture review — six P1 findings on the agent execution subsystem (`specs/arch_review_april/03-agent-execution.md`).

### Findings addressed

| Finding | Priority | Status |
|---|---|---|
| F1 — AgentCore dead code in two packages | P1 | **Resolved (pre-existing via theme-04 #166)**. The AWS SDK is already gated behind `AGENTCORE_ENABLED=true` via dynamic import in `ContainerAgentService.setAgentCoreProvider`. The remaining `agentcore-bridge.ts`, `agentcore-bridge.service.ts`, and `agent-runner/src/agentcore-handler.ts` contain only pure-JS bridge logic with `import type` references — they do not force the AWS SDK into the default module graph. Full deletion is deferred. |
| F2 — Tool-use hooks registered but never installed | P1 | **Fixed**. `StreamHandlerOptions` now carries `preToolUseHooks`/`postToolUseHooks`; `runAgentExecution.canUseTool` invokes pre-hooks (first `{deny:true}` blocks the tool with `behavior:'deny'`), and the `tool_use_summary` handler invokes post-hooks with the captured tool_input. Hook throws are logged and swallowed. `AgentExecutionService.executeAgentExecution` forwards per-agent hooks into the stream handler. |
| F3 — `launchSwarm`, `teammateCount`, `pushToRemote` carried but dead | P1 | **Fixed**. Fields deleted from `ExitPlanModeOptions`, `PlanData`, `PlanReadyData`, `AgentCorePlanReadyData`, `ContainerAgentPlanReadyEvent`, `AgentPlanReadyData`, and all `handlePlanReady` callback shapes (`container-agent.service`, `container-exec.service`, `agentcore-bridge.service`). Tests updated. |
| F5 — Host-mode cannot resume SDK session across plan approval | P1 | **Fixed**. `runAgentPlanning` captures `session.sessionId` and returns it on `AgentRunResult.sdkSessionId` + the `agent:plan_ready` event. `executeAgentAsync` merges it into `tasks.planOptions`; `executeAgentExecution` reads it back and threads into `runAgentExecution`, which tries `unstable_v2_resumeSession` first and falls back to `unstable_v2_createSession` on failure. |
| F6 — `rejectPlan` has no host-mode fallback | P1 | **Fixed**. `AgentExecutionTrigger` gains `rejectPlanForTask`; `TaskService.rejectPlan` falls back to it when container mode is absent, returning `NO_EXECUTION_SERVICE` (503) only when neither is wired. `AgentExecutionService.rejectPlanForTask` aborts any running host-mode agent, resets the agent to idle, CAS-moves the task to backlog (`lastAgentStatus='planning'` guard, mirrors container mode), clears plan state, and best-effort removes the worktree. |
| F11 — agent-runner mints fake OAuth `expiresAt` | P1 | **Fixed**. `agent-runner/src/index.ts` and `agentcore-handler.ts` now accept real `CLAUDE_OAUTH_EXPIRES_AT` + `CLAUDE_OAUTH_REFRESH_TOKEN` from env/payload; absent values fall back to a far-future sentinel instead of the 24h fiction. `shared-session.writeCredentialsFile` accepts optional `expiresAt`/`refreshToken`. Host-side `resolveOAuthExpiresAtMs` reads the existing `api_keys.expires_at` ISO column; `container-exec.service` and `agentcore-bridge.service` pass the parsed ms through. Per-agent HOME isolation is unchanged (`homedir()` already reads `HOME`) — deferred to container-layout work. |

### Commits

- `d0e11f46` F3 — delete dead team-mode plan-option fields
- `892a249d` F11 — stop minting fake OAuth expiresAt in agent-runner
- `8742329b` F5 — host-mode SDK session resume across plan approval
- `2db21b87` F6 — add host-mode rejectPlan fallback
- `9e9a20bd` F2 — install tool-use hooks in host-mode SDK session
- `86d507a1` docs + stale test fix

### Test delta

| Area | New | Failing→Passing |
|---|---|---|
| F11 `resolveOAuthExpiresAtMs` | IT-304F-a..d | 0 |
| F5 host-mode resume | 5 cases in `tests/lib/agents/stream-handler.test.ts` | 0 |
| F6 `rejectPlanForTask` (unit) | IT-F6-a..e | 0 |
| F6 `TaskService.rejectPlan` host-mode | F6-a..c | 0 |
| F2 hooks | 4 cases | 0 |
| Stale test updated | — | `tests/services/task-plan-approval.test.ts` |

Full suite: **9204 passed, 1 skipped, 0 failed** (`npx vitest run`).

### Follow-ups (out of scope)

- `.claude/CLAUDE.md` "Team Mode" section documents the now-deleted `launchSwarm`/`teammateCount` fields. Out of scope for this worktree; flagged for a follow-up doc PR on `main`.
- F11 per-agent HOME isolation (`HOME=/tmp/agents/<taskId>`) for concurrent-shared-container deployments is left for a container-layout change; this PR only fixes the credential-content fiction and wires host-to-agent expiresAt plumbing.
- Deleting `bedrock-agentcore` from `agent-runner/package.json` and the remaining `agentcore-*` scaffold files is deferred (F1 is not a correctness issue after the theme-04 gate).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build` (includes `agent-runner && bun install && tsc`)
- [x] `npx vitest run` — 9204 passing
- [ ] Manual: host-mode reject → task returns to backlog, worktree removed
- [ ] Manual: container-mode plan approval still works end-to-end (unchanged paths)
- [ ] Manual: set `anthropic` api_keys.expires_at in the future → verify agent-runner credentials file reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
