### PR TITLE
fix(arch-review): theme 07 — API surface (P1s)

### DIFF
--- a/specs/application/api/pagination.md
+++ b/specs/application/api/pagination.md
@@ -1,2054 +1,249 @@
 # API Pagination Specification
 
+> **April 2026 update (theme 07 — F07-01):** This spec was rewritten to
+> describe what the code actually does. Cursor pagination is the
+> *canonical* style for new list endpoints. Three high-traffic routes
+> (`/api/tasks`, `/api/sessions` global list, `/api/events/log`) have been
+> migrated. The remaining list endpoints use offset pagination and are
+> documented as the legacy style below; they can migrate opportunistically
+> when their service methods are next touched.
+
 ## Overview
 
-This specification defines cursor-based pagination for all list endpoints in the AgentPane API. Cursor pagination provides consistent, performant navigation through datasets, especially for real-time data that may change between requests.
+AgentPane uses two pagination styles. Endpoints pick one up front:
+
+| Style | Default for | Envelope | Helper |
+|-------|-------------|----------|--------|
+| **Cursor** (canonical) | new list endpoints, real-time data, infinite scroll | `{ items, nextCursor, hasMore, totalCount? }` | `paginate<T>` in `src/lib/api/pagination.ts` |
+| **Offset** (legacy) | admin reports, page jumping, static data | `{ items, limit, offset, total?, hasMore }` | `parseLimit` / `parseOffset` in `src/server/shared.ts` |
+
+### When to use each
+
+**Use cursor-based (default for anything new):**
+
+- Real-time data streams (sessions, events)
+- Infinite-scroll UIs
+- Datasets >1000 rows
+- Stable navigation through data that inserts/deletes mid-scroll
+
+**Offset is acceptable when:**
+
+- The client actually needs a `total` (filter-count badges)
+- The client needs page-jumping (admin reports, export)
+- The dataset is small and rarely changes
 
 ---
 
-## Pagination Strategy
+## Cursor style (canonical)
 
-### Cursor-Based vs Offset-Based
+### Cursor format
 
-| Aspect | Cursor-Based | Offset-Based |
-|--------|-------------|--------------|
-| **Performance** | O(1) for any page | O(n) for deep pages |
-| **Consistency** | Stable during modifications | Skips/duplicates on insert/delete |
-| **Real-time data** | Excellent | Poor |
-| **Random access** | Not supported | Supported |
-| **Cacheability** | URL-based caching works | Page 5 may change |
-| **Implementation** | More complex | Simple |
+Cursors are **opaque** base64-encoded JSON. Clients MUST treat them as
+opaque strings. The server decodes, validates the embedded `sortField` and
+`order`, and extracts the `(sortValue, id)` tuple for a compound tuple
+comparison.
 
-### Why Cursor-Based for AgentPane
-
-AgentPane uses cursor-based pagination as the primary strategy for several reasons:
-
-1. **Real-time data streams**: Agent sessions emit events continuously; offset pagination would cause missed or duplicate events during playback
-2. **Data consistency**: Tasks move between Kanban columns; cursor pagination ensures users see consistent views during navigation
-3. **Performance at scale**: Projects may have thousands of tasks and sessions; cursor pagination maintains constant-time queries regardless of page depth
-4. **Infinite scroll UX**: Cursor pagination aligns naturally with infinite scroll patterns used throughout the UI
-
-### When to Use Each Approach
-
-**Use cursor-based (default):**
-
-- List endpoints with real-time updates
-- Infinite scroll UIs
-- Large datasets (>1000 items)
-- Data that changes frequently
-
-**Consider offset-based (special cases only):**
-
-- Admin reports requiring page jumping
-- Export functionality with known total count
-- Static datasets that rarely change
-
----
-
-## Cursor Format
-
-### Encoding Strategy
-
-Cursors are **Base64-encoded JSON objects** that contain the information needed to resume pagination from a specific point.
-
-```typescript
+```ts
 interface CursorPayload {
-  /** Primary ID of the last item */
   id: string;
-  /** Value of the sort field for the last item */
   sortValue: string | number | null;
-  /** Name of the sort field */
   sortField: string;
-  /** Sort direction */
   order: 'asc' | 'desc';
-  /** Version for future cursor format changes */
   version: 1;
 }
 ```
 
-### Cursor Encoding/Decoding
+See `src/lib/api/cursor.ts` for the encoder/decoder.
 
-```typescript
-// lib/api/cursor.ts
-import { z } from 'zod';
+### Request
 
-const CURSOR_VERSION = 1;
+Clients send:
 
-const cursorPayloadSchema = z.object({
-  id: z.string(),
-  sortValue: z.union([z.string(), z.number(), z.null()]),
-  sortField: z.string(),
-  order: z.enum(['asc', 'desc']),
-  version: z.literal(CURSOR_VERSION),
+- `cursor` (optional) — opaque string returned by the previous response.
+  Omit for the first page.
+- `limit` (optional, default 50, max 100) — page size.
+- any route-specific filters (`codespaceId`, `column`, `status`, …).
+
+### Response
+
+The canonical envelope:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "items": [...],
+    "nextCursor": "…opaque…" | null,
+    "hasMore": true | false,
+    "totalCount": 123   // optional
+  }
+}
+```
+
+`nextCursor` is `null` when `hasMore === false`.
+
+### Server-side helper
+
+`src/lib/api/pagination.ts` exports:
+
+```ts
+import {
+  decodeRequestCursor,
+  paginate,
+  type ListResponse,
+} from '@/lib/api/pagination';
+
+// 1. Decode — returns { ok: false, error: 'INVALID_CURSOR' } on
+//    malformed/mismatched cursors.
+const cursorResult = decodeRequestCursor(c.req.query('cursor'), {
+  sortField: 'updatedAt',
+  order: 'desc',
+});
+if (!cursorResult.ok) {
+  return json({ ok: false, error: { code: 'INVALID_CURSOR', ... } }, 400);
+}
+
+// 2. Query `limit + 1` rows ordered by (sortField, id). When a cursor is
+//    present, apply a compound tuple comparison.
+const rows = await svc.list({
+  limit: limit + 1,
+  orderBy: 'updatedAt',
+  orderDirection: 'desc',
+  ...(cursorResult.value
+    ? { cursor: { sortValue: cursorResult.value.sortValue, id: cursorResult.value.id } }
+    : {}),
 });
 
-type CursorPayload = z.infer<typeof cursorPayloadSchema>;
-
-export type CursorResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: 'INVALID_CURSOR' | 'CURSOR_EXPIRED' };
-
-/**
- * Encode a cursor payload to a URL-safe Base64 string
- */
-export function encodeCursor(payload: Omit<CursorPayload, 'version'>): string {
-  const fullPayload: CursorPayload = {
-    ...payload,
-    version: CURSOR_VERSION,
-  };
-  const json = JSON.stringify(fullPayload);
-  // Use URL-safe Base64 encoding
-  return btoa(json)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-}
-
-/**
- * Decode a cursor string back to a payload
- * Returns a Result type for safe error handling
- */
-export function decodeCursor(cursor: string): CursorResult<CursorPayload> {
-  try {
-    // Restore standard Base64 from URL-safe encoding
-    const standardBase64 = cursor
-      .replace(/-/g, '+')
-      .replace(/_/g, '/');
-
-    // Add padding if needed
-    const padded = standardBase64 + '=='.slice(0, (4 - (standardBase64.length % 4)) % 4);
-
-    const json = atob(padded);
-    const parsed = JSON.parse(json);
-
-    const validated = cursorPayloadSchema.safeParse(parsed);
-    if (!validated.success) {
-      return { ok: false, error: 'INVALID_CURSOR' };
-    }
-
-    return { ok: true, value: validated.data };
-  } catch {
-    return { ok: false, error: 'INVALID_CURSOR' };
-  }
-}
-
-/**
- * Create a cursor from an item and sort configuration
- */
-export function createCursor<T extends { id: string }>(
-  item: T,
-  sortField: keyof T & string,
-  order: 'asc' | 'desc'
-): string {
-  return encodeCursor({
-    id: item.id,
-    sortValue: item[sortField] as string | number | null,
-    sortField,
-    order,
-  });
-}
+// 3. Build the canonical envelope.
+const body = paginate(rows, { limit, sortField: 'updatedAt', order: 'desc' });
+return json({ ok: true, data: body });
 ```
 
-### Cursor Validation
+### Service-side query
 
-Cursors should be validated on every request:
+Both `TaskService.list()` and `SessionCrudService.list()` accept an
+optional `cursor: { sortValue, id }` field. When a cursor is present,
+they:
 
-```typescript
-// lib/api/pagination.ts
-import { decodeCursor, type CursorResult, type CursorPayload } from './cursor';
+1. Fetch `limit + 1` rows (so the route handler can detect `hasMore`).
+2. Apply a compound tuple comparison:
+   - **DESC:** `(sortCol < sortValue) OR (sortCol = sortValue AND id < cursorId)`
+   - **ASC:**  `(sortCol > sortValue) OR (sortCol = sortValue AND id > cursorId)`
+3. Order by `(sortCol, id)` matching the direction.
 
-interface ValidateCursorOptions {
-  /** Expected sort field (must match cursor) */
-  sortField: string;
-  /** Expected sort order (must match cursor) */
-  order: 'asc' | 'desc';
-  /** Maximum cursor age in milliseconds (optional) */
-  maxAgeMs?: number;
-}
+This guarantees stable ordering even when multiple rows share a
+`sortValue` (e.g. duplicate timestamps).
 
-export function validateCursor(
-  cursor: string,
-  options: ValidateCursorOptions
-): CursorResult<CursorPayload> {
-  const decoded = decodeCursor(cursor);
+### Migrated endpoints
 
-  if (!decoded.ok) {
-    return decoded;
-  }
+| Endpoint | Sort field | Order |
+|----------|-----------|-------|
+| `GET /api/tasks` | `position` | `asc` |
+| `GET /api/sessions` (no `codespaceId`) | `updatedAt` | `desc` |
+| `GET /api/events/log` | `receivedAt` | `desc` |
 
-  const payload = decoded.value;
+`GET /api/sessions` with `codespaceId` keeps its offset shape because
+the UI reads `total` for filter-count badges — see the Offset style
+section below.
 
-  // Validate sort field matches
-  if (payload.sortField !== options.sortField) {
-    return { ok: false, error: 'INVALID_CURSOR' };
-  }
+### Error: `INVALID_CURSOR`
 
-  // Validate order matches
-  if (payload.order !== options.order) {
-    return { ok: false, error: 'INVALID_CURSOR' };
-  }
+Returned as 400 when:
 
-  // Optional: Check cursor expiration
-  // Note: This requires embedding a timestamp in the cursor
-  // Uncomment if implementing cursor expiration
-  // if (options.maxAgeMs && payload.createdAt) {
-  //   const age = Date.now() - payload.createdAt;
-  //   if (age > options.maxAgeMs) {
-  //     return { ok: false, error: 'CURSOR_EXPIRED' };
-  //   }
-  // }
+- The cursor is not valid base64 / JSON
+- The cursor payload fails schema validation
+- The cursor version is incompatible
+- The cursor's `sortField` / `order` does not match the route's fixed
+  sort (e.g. a `position` cursor passed to the `updatedAt` route)
 
-  return { ok: true, value: payload };
-}
-```
-
-### Opaqueness Principle
-
-Cursors are **opaque to clients**. The API documentation should never describe the internal cursor format. Clients must:
-
-- Treat cursors as opaque strings
-- Never parse or construct cursors manually
-- Only use cursors returned from the API
-- Not assume cursor stability across API versions
+Client handling: reset pagination and start from the first page.
 
 ---
 
-## Request Parameters
+## Offset style (legacy)
 
-### Standard Pagination Parameters
+Most existing list endpoints still use offset pagination. The envelope is
+less uniform (some return `data: T[]` with a sibling `pagination`; others
+nest everything under `data: { items, ... }`) but the standard accessors
+are:
 
-All paginated endpoints accept these query parameters:
+- `parseLimit(c, defaultLimit, maxLimit)` — `src/server/shared.ts`
+- `parseOffset(c, defaultOffset)` — `src/server/shared.ts`
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `cursor` | string | (none) | Opaque cursor from previous response. Omit for first page. |
-| `limit` | number | 20 | Items per page (1-100) |
-| `sort` | string | varies | Sort field name (endpoint-specific) |
-| `order` | 'asc' \| 'desc' | 'desc' | Sort direction |
-
-### Zod Schema
-
-```typescript
-// db/schema/validation.ts
-import { z } from 'zod';
-
-export const paginationSchema = z.object({
-  cursor: z.string().optional(),
-  limit: z.coerce.number().min(1).max(100).default(20),
-  sort: z.string().optional(),
-  order: z.enum(['asc', 'desc']).default('desc'),
-});
-
-export type PaginationParams = z.infer<typeof paginationSchema>;
+```json
+{
+  "ok": true,
+  "data": [...],
+  "pagination": {
+    "limit": 50,
+    "offset": 0,
+    "total": 123,    // optional
+    "hasMore": true
+  }
+}
 ```
 
-### Parameter Validation
+### Known divergences (documented, not broken)
 
-```typescript
-// lib/api/pagination.ts
-import { z } from 'zod';
+- `GET /api/memory/insights` returns `data: Insight[]` with no pagination
+  envelope (small, finite list).
+- `GET /api/teams/:id/members` returns `data: { items }` (non-paginated).
+- `GET /api/codespaces` returns `data: { items, nextCursor: null,
+  hasMore: false, totalCount }` — the cursor fields are present as a
+  forward-compatibility placeholder but the endpoint does not yet fetch
+  `limit + 1` rows.
 
-interface EndpointPaginationConfig {
-  /** Default sort field for this endpoint */
-  defaultSort: string;
-  /** Allowed sort fields */
-  allowedSorts: string[];
-  /** Default sort order */
-  defaultOrder: 'asc' | 'desc';
-  /** Default limit */
-  defaultLimit: number;
-  /** Maximum allowed limit */
-  maxLimit: number;
-}
-
-export function createPaginationSchema(config: EndpointPaginationConfig) {
-  return z.object({
-    cursor: z.string().optional(),
-    limit: z.coerce
-      .number()
-      .min(1)
-      .max(config.maxLimit)
-      .default(config.defaultLimit),
-    sort: z
-      .enum(config.allowedSorts as [string, ...string[]])
-      .default(config.defaultSort),
-    order: z.enum(['asc', 'desc']).default(config.defaultOrder),
-  });
-}
-
-// Example: Projects endpoint schema
-export const projectsPaginationSchema = createPaginationSchema({
-  defaultSort: 'updatedAt',
-  allowedSorts: ['updatedAt', 'createdAt', 'name'],
-  defaultOrder: 'desc',
-  defaultLimit: 20,
-  maxLimit: 100,
-});
-```
+These can migrate to cursor style when their service methods are next
+touched; the canonical envelope is what new endpoints SHOULD emit.
 
 ---
 
-## Response Format
-
-### Type Definition
-
-```typescript
-// lib/api/types.ts
-
-/**
- * Pagination metadata in API responses
- */
-interface PaginationMeta {
-  /** Cursor to fetch next page, null if no more pages */
-  nextCursor: string | null;
-  /** Cursor to fetch previous page, null if on first page */
-  prevCursor: string | null;
-  /** Whether there are more items after this page */
-  hasMore: boolean;
-  /**
-   * Total count of items matching the query.
-   * Optional - may be omitted for performance on large datasets.
-   */
-  totalCount?: number;
-}
-
-/**
- * Standard paginated API response
- */
-interface PaginatedResponse<T> {
-  ok: true;
-  data: {
-    items: T[];
-    pagination: PaginationMeta;
-  };
-}
-
-/**
- * Full API response type (success or error)
- */
-type ApiResponse<T> =
-  | PaginatedResponse<T>
-  | { ok: false; error: { code: string; message: string; details?: unknown } };
-```
-
-### Response Builder
-
-```typescript
-// lib/api/pagination.ts
-
-interface BuildPaginatedResponseParams<T extends { id: string }> {
-  items: T[];
-  limit: number;
-  sortField: keyof T & string;
-  order: 'asc' | 'desc';
-  /** Cursor from request (for generating prevCursor) */
-  requestCursor?: string;
-  /** Whether to include total count */
-  includeTotalCount?: boolean;
-  /** Total count if already computed */
-  totalCount?: number;
-}
-
-export function buildPaginatedResponse<T extends { id: string }>(
-  params: BuildPaginatedResponseParams<T>
-): PaginatedResponse<T>['data'] {
-  const { items, limit, sortField, order, requestCursor, totalCount } = params;
-
-  // Check if there are more items
-  // We fetch limit + 1 items to detect if there are more
-  const hasMore = items.length > limit;
-  const pageItems = hasMore ? items.slice(0, limit) : items;
-
-  // Generate next cursor from last item
-  const nextCursor = hasMore && pageItems.length > 0
-    ? createCursor(pageItems[pageItems.length - 1], sortField, order)
-    : null;
-
-  // Generate prev cursor from first item (if not first page)
-  const prevCursor = requestCursor && pageItems.length > 0
-    ? createCursor(pageItems[0], sortField, invertOrder(order))
-    : null;
-
-  return {
-    items: pageItems,
-    pagination: {
-      nextCursor,
-      prevCursor,
-      hasMore,
-      ...(totalCount !== undefined && { totalCount }),
-    },
-  };
-}
-
-function invertOrder(order: 'asc' | 'desc'): 'asc' | 'desc' {
-  return order === 'asc' ? 'desc' : 'asc';
-}
-```
-
----
-
-## Cursor Generation
-
-### Complete Implementation
-
-```typescript
-// lib/api/cursor.ts
-import { z } from 'zod';
-
-const CURSOR_VERSION = 1;
-
-// Re-export types
-export interface CursorPayload {
-  id: string;
-  sortValue: string | number | null;
-  sortField: string;
-  order: 'asc' | 'desc';
-  version: number;
-}
-
-export type CursorResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: 'INVALID_CURSOR' | 'CURSOR_EXPIRED' };
-
-const cursorPayloadSchema = z.object({
-  id: z.string(),
-  sortValue: z.union([z.string(), z.number(), z.null()]),
-  sortField: z.string(),
-  order: z.enum(['asc', 'desc']),
-  version: z.number(),
-});
-
-/**
- * Encode a cursor payload to a URL-safe Base64 string.
- *
- * @example
- * const cursor = encodeCursor({
- *   id: 'clx1234567890',
- *   sortValue: '2026-01-15T10:00:00Z',
- *   sortField: 'createdAt',
- *   order: 'desc'
- * });
- * // => 'eyJpZCI6ImNseDEyMzQ1Njc4OTAiLC...'
- */
-export function encodeCursor(payload: Omit<CursorPayload, 'version'>): string {
-  const fullPayload: CursorPayload = {
-    ...payload,
-    version: CURSOR_VERSION,
-  };
-
-  const json = JSON.stringify(fullPayload);
-
-  // URL-safe Base64: replace +/ with -_, strip padding
-  return btoa(json)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-}
-
-/**
- * Decode a cursor string back to a payload.
- * Returns a Result type for safe error handling.
- *
- * @example
- * const result = decodeCursor('eyJpZCI6ImNseDEyMzQ1Njc4OTAiLC...');
- * if (result.ok) {
- *   console.log(result.value.id); // 'clx1234567890'
- * }
- */
-export function decodeCursor(cursor: string): CursorResult<CursorPayload> {
-  try {
-    // Restore standard Base64 from URL-safe encoding
-    let standardBase64 = cursor
-      .replace(/-/g, '+')
-      .replace(/_/g, '/');
-
-    // Add padding if needed (Base64 length must be multiple of 4)
-    const paddingNeeded = (4 - (standardBase64.length % 4)) % 4;
-    standardBase64 += '='.repeat(paddingNeeded);
-
-    const json = atob(standardBase64);
-    const parsed = JSON.parse(json);
-
-    const validated = cursorPayloadSchema.safeParse(parsed);
-    if (!validated.success) {
-      return { ok: false, error: 'INVALID_CURSOR' };
-    }
-
-    // Check version compatibility
-    if (validated.data.version > CURSOR_VERSION) {
-      // Future cursor version - client should refresh
-      return { ok: false, error: 'INVALID_CURSOR' };
-    }
-
-    return { ok: true, value: validated.data };
-  } catch {
-    return { ok: false, error: 'INVALID_CURSOR' };
-  }
-}
-
-/**
- * Create a cursor from an item and sort configuration.
- * Convenience function for building response cursors.
- *
- * @example
- * const cursor = createCursor(project, 'updatedAt', 'desc');
- */
-export function createCursor<T extends { id: string }>(
-  item: T,
-  sortField: keyof T & string,
-  order: 'asc' | 'desc'
-): string {
-  const sortValue = item[sortField];
-
-  // Normalize sort value for consistent encoding
-  let normalizedValue: string | number | null;
-  if (sortValue === null || sortValue === undefined) {
-    normalizedValue = null;
-  } else if (sortValue instanceof Date) {
-    normalizedValue = sortValue.toISOString();
-  } else if (typeof sortValue === 'string' || typeof sortValue === 'number') {
-    normalizedValue = sortValue;
-  } else {
-    normalizedValue = String(sortValue);
-  }
-
-  return encodeCursor({
-    id: item.id,
-    sortValue: normalizedValue,
-    sortField,
-    order,
-  });
-}
-
-/**
- * Extract sort value from cursor for use in queries.
- * Handles type conversion based on expected field type.
- */
-export function getSortValueFromCursor(
-  cursor: CursorPayload,
-  asType: 'string' | 'number' | 'date' = 'string'
-): string | number | Date | null {
-  const { sortValue } = cursor;
-
-  if (sortValue === null) {
-    return null;
-  }
-
-  switch (asType) {
-    case 'number':
-      return typeof sortValue === 'number' ? sortValue : Number(sortValue);
-    case 'date':
-      return new Date(sortValue);
-    default:
-      return String(sortValue);
-  }
-}
-```
-
----
-
-## Database Queries
-
-### Drizzle ORM Pagination Patterns
-
-```typescript
-// lib/db/pagination.ts
-import { and, or, gt, lt, gte, lte, eq, asc, desc, sql, SQL } from 'drizzle-orm';
-import type { PgColumn, PgTableWithColumns } from 'drizzle-orm/pg-core';
-import { decodeCursor, type CursorPayload } from '../api/cursor';
-
-interface CursorPaginationOptions {
-  /** Decoded cursor payload */
-  cursor?: CursorPayload;
-  /** Sort column */
-  sortColumn: PgColumn;
-  /** ID column for tie-breaking */
-  idColumn: PgColumn;
-  /** Sort direction */
-  order: 'asc' | 'desc';
-  /** Number of items to fetch */
-  limit: number;
-}
-
-/**
- * Build WHERE clause for cursor pagination.
- *
- * Uses (sortValue, id) compound comparison for stable ordering:
- * - For ASC:  WHERE (sortCol > cursorVal) OR (sortCol = cursorVal AND id > cursorId)
- * - For DESC: WHERE (sortCol < cursorVal) OR (sortCol = cursorVal AND id < cursorId)
- */
-export function buildCursorWhere(options: CursorPaginationOptions): SQL | undefined {
-  const { cursor, sortColumn, idColumn, order } = options;
-
-  if (!cursor) {
-    return undefined;
-  }
-
-  const sortValue = cursor.sortValue;
-  const cursorId = cursor.id;
-
-  // Determine comparison operators based on order
-  const primaryOp = order === 'asc' ? gt : lt;
-  const secondaryOp = order === 'asc' ? gt : lt;
-
-  // Handle null sort values
-  if (sortValue === null) {
-    // For null values, only compare by ID
-    return secondaryOp(idColumn, cursorId);
-  }
-
-  // Compound comparison: (sortCol > val) OR (sortCol = val AND id > cursorId)
-  return or(
-    primaryOp(sortColumn, sortValue),
-    and(
-      eq(sortColumn, sortValue),
-      secondaryOp(idColumn, cursorId)
-    )
-  );
-}
-
-/**
- * Build ORDER BY clause for cursor pagination.
- * Always includes ID as secondary sort for stable ordering.
- */
-export function buildCursorOrderBy(options: Pick<CursorPaginationOptions, 'sortColumn' | 'idColumn' | 'order'>): SQL[] {
-  const { sortColumn, idColumn, order } = options;
-  const orderFn = order === 'asc' ? asc : desc;
-
-  return [
-    orderFn(sortColumn),
-    orderFn(idColumn),
-  ];
-}
-```
-
-### Complete Query Builder
-
-```typescript
-// lib/services/pagination-query.ts
-import { db } from '@/db';
-import { and, count, sql, type SQL } from 'drizzle-orm';
-import type { PgColumn, PgTableWithColumns } from 'drizzle-orm/pg-core';
-import { decodeCursor, createCursor } from '@/lib/api/cursor';
-import { buildCursorWhere, buildCursorOrderBy } from '@/lib/db/pagination';
-
-interface PaginatedQueryOptions<TTable extends PgTableWithColumns<any>> {
-  table: TTable;
-  sortColumn: PgColumn;
-  idColumn: PgColumn;
-  order: 'asc' | 'desc';
-  limit: number;
-  cursor?: string;
-  /** Additional WHERE conditions */
-  where?: SQL;
-  /** Whether to compute total count */
-  includeTotalCount?: boolean;
-}
-
-interface PaginatedQueryResult<T> {
-  items: T[];
-  pagination: {
-    nextCursor: string | null;
-    prevCursor: string | null;
-    hasMore: boolean;
-    totalCount?: number;
-  };
-}
-
-export async function paginatedQuery<
-  TTable extends PgTableWithColumns<any>,
-  TResult = TTable['$inferSelect']
->(
-  options: PaginatedQueryOptions<TTable>
-): Promise<PaginatedQueryResult<TResult>> {
-  const {
-    table,
-    sortColumn,
-    idColumn,
-    order,
-    limit,
-    cursor,
-    where: additionalWhere,
-    includeTotalCount,
-  } = options;
-
-  // Decode cursor if provided
-  let decodedCursor: ReturnType<typeof decodeCursor>['value'] | undefined;
-  if (cursor) {
-    const decoded = decodeCursor(cursor);
-    if (!decoded.ok) {
-      throw new Error(decoded.error);
-    }
-    decodedCursor = decoded.value;
-  }
-
-  // Build WHERE clause
-  const cursorWhere = buildCursorWhere({
-    cursor: decodedCursor,
-    sortColumn,
-    idColumn,
-    order,
-  });
-
-  const whereClause = and(additionalWhere, cursorWhere);
-
-  // Build ORDER BY clause
-  const orderByClause = buildCursorOrderBy({ sortColumn, idColumn, order });
-
-  // Fetch limit + 1 to detect if there are more items
-  const query = db
-    .select()
-    .from(table)
-    .where(whereClause)
-    .orderBy(...orderByClause)
-    .limit(limit + 1);
-
-  // Optionally fetch total count in parallel
-  const [items, countResult] = await Promise.all([
-    query as Promise<TResult[]>,
-    includeTotalCount
-      ? db.select({ count: count() }).from(table).where(additionalWhere)
-      : Promise.resolve(null),
-  ]);
-
-  // Determine if there are more items
-  const hasMore = items.length > limit;
-  const pageItems = hasMore ? items.slice(0, limit) : items;
-
-  // Get sort field name from column
-  const sortField = sortColumn.name as keyof TResult & string;
-
-  // Generate cursors
-  const nextCursor = hasMore && pageItems.length > 0
-    ? createCursor(pageItems[pageItems.length - 1] as any, sortField, order)
-    : null;
-
-  const prevCursor = cursor && pageItems.length > 0
-    ? createCursor(pageItems[0] as any, sortField, order === 'asc' ? 'desc' : 'asc')
-    : null;
-
-  return {
-    items: pageItems,
-    pagination: {
-      nextCursor,
-      prevCursor,
-      hasMore,
-      ...(countResult && { totalCount: countResult[0].count }),
-    },
-  };
-}
-```
-
-### Index Requirements
-
-For efficient cursor pagination, ensure compound indexes exist:
-
-```sql
--- Projects: sorted by updatedAt descending
-CREATE INDEX idx_projects_updated_at_id ON projects (updated_at DESC, id DESC);
-
--- Tasks: sorted by position within column
-CREATE INDEX idx_tasks_column_position_id ON tasks (project_id, column, position ASC, id ASC);
-
--- Session history: sorted by timestamp
-CREATE INDEX idx_session_events_session_timestamp ON session_events (session_id, timestamp ASC, id ASC);
-
--- Agents: sorted by status then name
-CREATE INDEX idx_agents_project_status_name ON agents (project_id, status, name ASC, id ASC);
-```
-
-Drizzle schema definition:
-
-```typescript
-// db/schema/indexes.ts
-import { index } from 'drizzle-orm/pg-core';
-import { projects, tasks, sessionEvents, agents } from './tables';
-
-export const projectIndexes = {
-  updatedAtIdx: index('idx_projects_updated_at_id')
-    .on(projects.updatedAt, projects.id)
-    .desc(),
-};
-
-export const taskIndexes = {
-  columnPositionIdx: index('idx_tasks_column_position_id')
-    .on(tasks.projectId, tasks.column, tasks.position, tasks.id),
-};
-
-export const sessionEventIndexes = {
-  sessionTimestampIdx: index('idx_session_events_session_timestamp')
-    .on(sessionEvents.sessionId, sessionEvents.timestamp, sessionEvents.id),
-};
-
-export const agentIndexes = {
-  projectStatusNameIdx: index('idx_agents_project_status_name')
-    .on(agents.projectId, agents.status, agents.name, agents.id),
-};
-```
-
----
-
-## Endpoint-Specific Details
-
-### GET /api/projects
-
-**Sort Configuration:**
-
-- Default sort: `updatedAt` DESC
-- Allowed sorts: `updatedAt`, `createdAt`, `name`
-
-```typescript
-// app/routes/api/projects/index.ts
-import { createServerFileRoute } from '@tanstack/react-start/server';
-import { paginatedQuery } from '@/lib/services/pagination-query';
-import { projects } from '@/db/schema';
-import { eq } from 'drizzle-orm';
-
-const projectsListSchema = z.object({
-  cursor: z.string().optional(),
-  limit: z.coerce.number().min(1).max(100).default(20),
-  sort: z.enum(['updatedAt', 'createdAt', 'name']).default('updatedAt'),
-  order: z.enum(['asc', 'desc']).default('desc'),
-  search: z.string().optional(),
-});
-
-export const ServerRoute = createServerFileRoute().methods({
-  GET: async ({ request }) => {
-    const url = new URL(request.url);
-    const params = Object.fromEntries(url.searchParams);
-
-    const parsed = projectsListSchema.safeParse(params);
-    if (!parsed.success) {
-      return Response.json({
-        ok: false,
-        error: { code: 'VALIDATION_ERROR', message: 'Invalid parameters' },
-      }, { status: 400 });
-    }
-
-    const { cursor, limit, sort, order, search } = parsed.data;
-
-    // Map sort field to column
-    const sortColumnMap = {
-      updatedAt: projects.updatedAt,
-      createdAt: projects.createdAt,
-      name: projects.name,
-    };
-
-    try {
-      const result = await paginatedQuery({
-        table: projects,
-        sortColumn: sortColumnMap[sort],
-        idColumn: projects.id,
-        order,
-        limit,
-        cursor,
-        where: search ? ilike(projects.name, `%${search}%`) : undefined,
-        includeTotalCount: true,
-      });
-
-      return Response.json({ ok: true, data: result });
-    } catch (error) {
-      if (error instanceof Error && error.message === 'INVALID_CURSOR') {
-        return Response.json({
-          ok: false,
-          error: { code: 'INVALID_CURSOR', message: 'Invalid or malformed cursor' },
-        }, { status: 400 });
-      }
-      throw error;
-    }
+## Client usage
+
+### Cursor pagination with `useInfiniteQuery`
+
+```ts
+useInfiniteQuery({
+  queryKey: ['tasks', codespaceId, column],
+  queryFn: async ({ pageParam }) => {
+    const qs = new URLSearchParams({ codespaceId, limit: '50' });
+    if (column) qs.set('column', column);
+    if (pageParam) qs.set('cursor', pageParam as string);
+    const res = await fetch(`/api/tasks?${qs.toString()}`);
+    return (await res.json()).data; // { items, nextCursor, hasMore }
   },
+  initialPageParam: undefined,
+  getNextPageParam: (last) => (last.hasMore ? last.nextCursor : undefined),
 });
 ```
 
-### GET /api/tasks
+### Offset pagination
 
-**Sort Configuration:**
-
-- Default sort: `position` ASC (within column)
-- Allowed sorts: `position`, `createdAt`, `updatedAt`
-- Always filtered by `projectId`
-
-```typescript
-// app/routes/api/tasks/index.ts
-const tasksListSchema = z.object({
-  projectId: z.string().cuid2(),
-  column: z.enum(['backlog', 'in_progress', 'waiting_approval', 'verified']).optional(),
-  agentId: z.string().cuid2().optional(),
-  cursor: z.string().optional(),
-  limit: z.coerce.number().min(1).max(100).default(50),
-  sort: z.enum(['position', 'createdAt', 'updatedAt']).default('position'),
-  order: z.enum(['asc', 'desc']).default('asc'),
-});
-
-// Query with position-based cursor for Kanban ordering
-const result = await paginatedQuery({
-  table: tasks,
-  sortColumn: tasks.position,
-  idColumn: tasks.id,
-  order: 'asc',
-  limit,
-  cursor,
-  where: and(
-    eq(tasks.projectId, projectId),
-    column ? eq(tasks.column, column) : undefined,
-    agentId ? eq(tasks.agentId, agentId) : undefined
-  ),
-});
-```
-
-### GET /api/agents
-
-**Sort Configuration:**
-
-- Default sort: `status`, then `name` ASC
-- Complex multi-field sorting
-
-```typescript
-// For agents, we use a compound cursor with status priority
-const agentStatusPriority = {
-  running: 0,
-  starting: 1,
-  paused: 2,
-  error: 3,
-  idle: 4,
-  completed: 5,
-};
-
-// Custom sort using computed column
-const result = await paginatedQuery({
-  table: agents,
-  sortColumn: agents.name, // Primary visible sort
-  idColumn: agents.id,
-  order: 'asc',
-  limit,
-  cursor,
-  where: and(
-    eq(agents.projectId, projectId),
-    status ? eq(agents.status, status) : undefined
-  ),
-});
-```
-
-### GET /api/sessions/:id/history
-
-**Sort Configuration:**
-
-- Default sort: `timestamp` ASC (chronological playback)
-- Supports filtering by event type and time range
-
-```typescript
-// app/routes/api/sessions/$id/history.ts
-const historySchema = z.object({
-  startTime: z.coerce.number().optional(),
-  endTime: z.coerce.number().optional(),
-  eventTypes: z.string().transform(s => s.split(',')).optional(),
-  cursor: z.string().optional(),
-  limit: z.coerce.number().min(1).max(1000).default(100),
-});
-
-// Time-bounded pagination for session replay
-const result = await paginatedQuery({
-  table: sessionEvents,
-  sortColumn: sessionEvents.timestamp,
-  idColumn: sessionEvents.id,
-  order: 'asc',
-  limit,
-  cursor,
-  where: and(
-    eq(sessionEvents.sessionId, sessionId),
-    startTime ? gte(sessionEvents.timestamp, startTime) : undefined,
-    endTime ? lte(sessionEvents.timestamp, endTime) : undefined,
-    eventTypes ? inArray(sessionEvents.type, eventTypes) : undefined
-  ),
-});
-```
-
----
-
-## Edge Cases
-
-### Empty Results
-
-When a query returns no items:
-
-```typescript
-{
-  ok: true,
-  data: {
-    items: [],
-    pagination: {
-      nextCursor: null,
-      prevCursor: null,
-      hasMore: false,
-      totalCount: 0
-    }
-  }
-}
-```
-
-### Single Item
-
-```typescript
-{
-  ok: true,
-  data: {
-    items: [{ id: 'clx123', name: 'Only Project' }],
-    pagination: {
-      nextCursor: null,
-      prevCursor: null,
-      hasMore: false,
-      totalCount: 1
-    }
-  }
-}
-```
-
-### Deleted Items (Cursor Points to Deleted Record)
-
-When the cursor's reference item has been deleted:
-
-```typescript
-// lib/db/pagination.ts
-export function buildCursorWhere(options: CursorPaginationOptions): SQL | undefined {
-  const { cursor, sortColumn, idColumn, order } = options;
-
-  if (!cursor) {
-    return undefined;
-  }
-
-  // Use >= / <= instead of > / < to handle deleted items gracefully
-  // This means if the cursor item is deleted, we still get items after that position
-  const primaryOp = order === 'asc' ? gte : lte;
-
-  return or(
-    primaryOp(sortColumn, cursor.sortValue),
-    and(
-      eq(sortColumn, cursor.sortValue),
-      order === 'asc' ? gt(idColumn, cursor.id) : lt(idColumn, cursor.id)
-    )
-  );
-}
-```
-
-**Alternative approach: Validate cursor item exists**
-
-```typescript
-async function validateCursorItem(
-  table: PgTableWithColumns<any>,
-  idColumn: PgColumn,
-  cursorId: string
-): Promise<boolean> {
-  const result = await db
-    .select({ id: idColumn })
-    .from(table)
-    .where(eq(idColumn, cursorId))
-    .limit(1);
-
-  return result.length > 0;
-}
-```
-
-### Sort Field Changes Between Requests
-
-If the client requests a different sort field than the cursor was generated with:
-
-```typescript
-// Validate cursor matches requested sort
-if (cursor) {
-  const decoded = decodeCursor(cursor);
-  if (decoded.ok && decoded.value.sortField !== requestedSort) {
-    // Option 1: Return error
-    return Response.json({
-      ok: false,
-      error: {
-        code: 'INVALID_CURSOR',
-        message: 'Cursor sort field does not match requested sort. Please start pagination from the beginning.',
-      },
-    }, { status: 400 });
-
-    // Option 2: Ignore cursor and start fresh (less strict)
-    // cursor = undefined;
-  }
-}
-```
-
-### Concurrent Modifications
-
-When items are added/removed during pagination:
-
-**Behavior guarantees:**
-
-- Items added before current cursor position: Will NOT appear
-- Items added after current cursor position: Will appear when reached
-- Items deleted before cursor: No effect (cursor still valid)
-- Items deleted at cursor: Next page starts from next valid item
-- Items moved (e.g., task position change): May appear multiple times or be skipped
-
-**Mitigation strategies:**
-
-1. **Accept eventual consistency**: For most UIs, minor inconsistencies are acceptable
-2. **Use optimistic updates**: Client-side state management handles immediate feedback
-3. **Implement versioned cursors**: Include a data version in cursor, reject if stale
-
-```typescript
-// Versioned cursor approach (optional)
-interface VersionedCursorPayload extends CursorPayload {
-  dataVersion: number; // Increment on any data change
-}
-
-// Check version on decode
-if (cursor.dataVersion !== currentDataVersion) {
-  return { ok: false, error: 'CURSOR_EXPIRED' };
-}
-```
-
----
-
-## Performance Considerations
-
-### Index Requirements
-
-**Critical indexes for each paginated endpoint:**
-
-```sql
--- Required indexes for efficient cursor pagination
--- Each index should include (sort_column, id) at minimum
-
--- Projects
-CREATE INDEX CONCURRENTLY idx_projects_updated_id
-  ON projects (updated_at DESC, id DESC);
-CREATE INDEX CONCURRENTLY idx_projects_created_id
-  ON projects (created_at DESC, id DESC);
-CREATE INDEX CONCURRENTLY idx_projects_name_id
-  ON projects (name ASC, id ASC);
-
--- Tasks (within project scope)
-CREATE INDEX CONCURRENTLY idx_tasks_project_column_position
-  ON tasks (project_id, column, position ASC, id ASC);
-CREATE INDEX CONCURRENTLY idx_tasks_project_created
-  ON tasks (project_id, created_at DESC, id DESC);
-
--- Session events (high volume, time-series)
-CREATE INDEX CONCURRENTLY idx_session_events_session_time
-  ON session_events (session_id, timestamp ASC, id ASC);
-
--- Agents
-CREATE INDEX CONCURRENTLY idx_agents_project_status_name
-  ON agents (project_id, status, name ASC, id ASC);
-```
-
-### Total Count Trade-offs
-
-Computing `totalCount` requires a full table scan:
-
-```typescript
-// lib/services/pagination-query.ts
-
-interface TotalCountOptions {
-  /** Always include total count */
-  always: boolean;
-  /** Include only if estimated row count is below threshold */
-  threshold?: number;
-  /** Use estimated count from statistics for large tables */
-  useEstimate?: boolean;
-}
-
-async function getTotalCount(
-  table: PgTableWithColumns<any>,
-  where: SQL | undefined,
-  options: TotalCountOptions
-): Promise<number | undefined> {
-  if (!options.always && !options.useEstimate) {
-    return undefined;
-  }
-
-  if (options.useEstimate) {
-    // Use PostgreSQL statistics for fast estimate
-    const result = await db.execute(sql`
-      SELECT reltuples::bigint AS estimate
-      FROM pg_class
-      WHERE relname = ${table._.name}
-    `);
-
-    const estimate = result.rows[0]?.estimate ?? 0;
-
-    if (options.threshold && estimate > options.threshold) {
-      return undefined; // Skip exact count for large tables
-    }
-  }
-
-  // Exact count
-  const [{ count: exactCount }] = await db
-    .select({ count: count() })
-    .from(table)
-    .where(where);
-
-  return exactCount;
-}
-```
-
-**Recommendations:**
-
-- Include `totalCount` for small datasets (<10,000 rows)
-- Use estimated count for large datasets
-- Omit entirely for time-series data (session events)
-
-### Caching Strategies
-
-```typescript
-// lib/api/cache.ts
-import { createHash } from 'crypto';
-
-interface CacheConfig {
-  /** Cache TTL in seconds */
-  ttl: number;
-  /** Whether to use stale-while-revalidate */
-  swr?: boolean;
-  /** SWR window in seconds */
-  swrWindow?: number;
-}
-
-function buildCacheKey(
-  endpoint: string,
-  params: Record<string, unknown>
-): string {
-  const sortedParams = Object.keys(params)
-    .sort()
-    .map(k => `${k}=${params[k]}`)
-    .join('&');
-
-  return createHash('sha256')
-    .update(`${endpoint}?${sortedParams}`)
-    .digest('hex')
-    .slice(0, 16);
-}
-
-function buildCacheHeaders(config: CacheConfig): Headers {
-  const headers = new Headers();
-
-  if (config.swr && config.swrWindow) {
-    headers.set(
-      'Cache-Control',
-      `public, max-age=${config.ttl}, stale-while-revalidate=${config.swrWindow}`
-    );
-  } else {
-    headers.set('Cache-Control', `public, max-age=${config.ttl}`);
-  }
-
-  return headers;
-}
-
-// Per-endpoint cache configuration
-const endpointCacheConfig: Record<string, CacheConfig> = {
-  '/api/projects': { ttl: 60, swr: true, swrWindow: 300 },
-  '/api/tasks': { ttl: 30, swr: true, swrWindow: 60 },
-  '/api/agents': { ttl: 10, swr: true, swrWindow: 30 },
-  '/api/sessions/:id/history': { ttl: 3600 }, // Historical data is stable
-};
-```
-
-### Rate Limiting Interaction
-
-Pagination requests count toward rate limits. Configure limits appropriately:
-
-```typescript
-// Rate limit configuration from endpoints.md
-const rateLimits = {
-  read: { limit: 1000, windowMs: 60_000 },   // 1000 reads/min
-  write: { limit: 100, windowMs: 60_000 },    // 100 writes/min
-};
-
-// Pagination doesn't require special rate limit handling
-// But consider: deep pagination (many sequential requests)
-// could hit limits during infinite scroll
-
-// Solution: Encourage larger page sizes for bulk operations
-const recommendedLimits = {
-  infiniteScroll: 20,    // Interactive browsing
-  bulkFetch: 100,        // Data export, sync
-  sessionReplay: 1000,   // Event replay (high volume)
-};
-```
-
----
-
-## Client Usage
-
-### React Query Infinite Scroll Pattern
-
-```typescript
-// hooks/use-paginated-query.ts
-import { useInfiniteQuery, type UseInfiniteQueryOptions } from '@tanstack/react-query';
-
-interface UsePaginatedQueryOptions<T> {
-  queryKey: unknown[];
-  endpoint: string;
-  params?: Record<string, string | number>;
-  limit?: number;
-  enabled?: boolean;
-}
-
-interface PaginatedResponse<T> {
-  ok: true;
-  data: {
-    items: T[];
-    pagination: {
-      nextCursor: string | null;
-      hasMore: boolean;
-      totalCount?: number;
-    };
-  };
-}
-
-export function usePaginatedQuery<T>({
-  queryKey,
-  endpoint,
-  params = {},
-  limit = 20,
-  enabled = true,
-}: UsePaginatedQueryOptions<T>) {
-  return useInfiniteQuery({
-    queryKey: [...queryKey, params, limit],
-    queryFn: async ({ pageParam }): Promise<PaginatedResponse<T>> => {
-      const searchParams = new URLSearchParams({
-        ...Object.fromEntries(
-          Object.entries(params).map(([k, v]) => [k, String(v)])
-        ),
-        limit: String(limit),
-        ...(pageParam && { cursor: pageParam }),
-      });
-
-      const response = await fetch(`${endpoint}?${searchParams}`);
-      if (!response.ok) {
-        throw new Error('Failed to fetch');
-      }
-
-      return response.json();
-    },
-    initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage) =>
-      lastPage.data.pagination.hasMore
-        ? lastPage.data.pagination.nextCursor
-        : undefined,
-    enabled,
-  });
-}
-```
-
-### useInfiniteQuery Hook Example
-
-```typescript
-// components/project-list.tsx
-import { usePaginatedQuery } from '@/hooks/use-paginated-query';
-import { useInView } from 'react-intersection-observer';
-import { useEffect } from 'react';
-
-interface Project {
-  id: string;
-  name: string;
-  path: string;
-  updatedAt: string;
-}
-
-export function ProjectList() {
-  const {
-    data,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    error,
-  } = usePaginatedQuery<Project>({
-    queryKey: ['projects'],
-    endpoint: '/api/projects',
-    params: { sort: 'updatedAt', order: 'desc' },
-    limit: 20,
-  });
-
-  // Intersection observer for infinite scroll
-  const { ref: loadMoreRef, inView } = useInView({
-    threshold: 0,
-    rootMargin: '100px', // Trigger before reaching end
-  });
-
-  // Auto-load more when sentinel comes into view
-  useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  if (isLoading) {
-    return <ProjectListSkeleton />;
-  }
-
-  if (error) {
-    return <ErrorState error={error} />;
-  }
-
-  // Flatten pages into single array
-  const projects = data?.pages.flatMap(page => page.data.items) ?? [];
-  const totalCount = data?.pages[0]?.data.pagination.totalCount;
-
-  return (
-    <div className="space-y-4">
-      <header className="flex justify-between items-center">
-        <h2 className="text-lg font-semibold">Projects</h2>
-        {totalCount !== undefined && (
-          <span className="text-sm text-muted-foreground">
-            {totalCount} total
-          </span>
-        )}
-      </header>
-
-      <div className="grid gap-4">
-        {projects.map((project) => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
-
-      {/* Load more sentinel */}
-      <div ref={loadMoreRef} className="h-10 flex items-center justify-center">
-        {isFetchingNextPage && <Spinner />}
-        {!hasNextPage && projects.length > 0 && (
-          <span className="text-sm text-muted-foreground">
-            No more projects
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-```
-
-### Intersection Observer for Auto-Load
-
-```typescript
-// hooks/use-infinite-scroll.ts
-import { useEffect, useRef, useCallback } from 'react';
-
-interface UseInfiniteScrollOptions {
-  /** Whether there are more items to load */
-  hasMore: boolean;
-  /** Whether currently loading */
-  isLoading: boolean;
-  /** Function to load more items */
-  onLoadMore: () => void;
-  /** Root margin for early trigger */
-  rootMargin?: string;
-  /** Threshold for intersection */
-  threshold?: number;
-}
-
-export function useInfiniteScroll({
-  hasMore,
-  isLoading,
-  onLoadMore,
-  rootMargin = '200px',
-  threshold = 0,
-}: UseInfiniteScrollOptions) {
-  const sentinelRef = useRef<HTMLDivElement>(null);
-
-  const handleIntersection = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      const [entry] = entries;
-      if (entry.isIntersecting && hasMore && !isLoading) {
-        onLoadMore();
-      }
-    },
-    [hasMore, isLoading, onLoadMore]
-  );
-
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-
-    const observer = new IntersectionObserver(handleIntersection, {
-      rootMargin,
-      threshold,
-    });
-
-    observer.observe(sentinel);
-
-    return () => observer.disconnect();
-  }, [handleIntersection, rootMargin, threshold]);
-
-  return sentinelRef;
-}
-
-// Usage
-function TaskList() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    usePaginatedQuery<Task>({ ... });
-
-  const sentinelRef = useInfiniteScroll({
-    hasMore: hasNextPage ?? false,
-    isLoading: isFetchingNextPage,
-    onLoadMore: fetchNextPage,
-  });
-
-  return (
-    <div>
-      {tasks.map(task => <TaskCard key={task.id} task={task} />)}
-      <div ref={sentinelRef} />
-    </div>
-  );
-}
-```
-
----
-
-## Error Responses
-
-### INVALID_CURSOR (400)
-
-Returned when the cursor is malformed, tampered with, or incompatible.
-
-```typescript
-{
-  ok: false,
-  error: {
-    code: 'INVALID_CURSOR',
-    message: 'Invalid or malformed cursor. Please restart pagination from the beginning.',
-    details: {
-      reason: 'DECODE_FAILED' | 'VERSION_MISMATCH' | 'SORT_MISMATCH'
-    }
-  }
-}
-```
-
-**Causes:**
-
-- Cursor string is not valid Base64
-- Cursor JSON structure is invalid
-- Cursor version is incompatible
-- Cursor sort field doesn't match request
-- Cursor was tampered with
-
-**Client handling:**
-
-```typescript
-if (error.code === 'INVALID_CURSOR') {
-  // Reset pagination and start fresh
-  queryClient.resetQueries({ queryKey: ['projects'] });
-}
-```
-
-### CURSOR_EXPIRED (400)
-
-Optional error for time-limited cursors.
-
-```typescript
-{
-  ok: false,
-  error: {
-    code: 'CURSOR_EXPIRED',
-    message: 'Cursor has expired. Please restart pagination.',
-    details: {
-      expiredAt: '2026-01-15T10:00:00Z',
-      maxAge: 3600
-    }
-  }
-}
-```
-
-**Implementation (optional):**
-
-```typescript
-// lib/api/cursor.ts
-const CURSOR_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
-
-interface TimestampedCursorPayload extends CursorPayload {
-  createdAt: number;
-}
-
-export function encodeCursor(payload: Omit<TimestampedCursorPayload, 'version'>): string {
-  const fullPayload: TimestampedCursorPayload = {
-    ...payload,
-    createdAt: Date.now(),
-    version: CURSOR_VERSION,
-  };
-  // ... encode
-}
-
-export function decodeCursor(cursor: string): CursorResult<CursorPayload> {
-  // ... decode
-
-  // Check expiration
-  if (payload.createdAt && Date.now() - payload.createdAt > CURSOR_MAX_AGE_MS) {
-    return { ok: false, error: 'CURSOR_EXPIRED' };
-  }
-
-  return { ok: true, value: payload };
-}
-```
+Offset endpoints remain as they were — read `pagination.offset` /
+`pagination.total` from the response and bump offset manually.
 
 ---
 
 ## Testing
 
-### Unit Tests for Cursor Encoding/Decoding
-
-```typescript
-// lib/api/__tests__/cursor.test.ts
-import { describe, it, expect } from 'vitest';
-import { encodeCursor, decodeCursor, createCursor } from '../cursor';
-
-describe('cursor encoding', () => {
-  it('should encode and decode a cursor correctly', () => {
-    const payload = {
-      id: 'clx1234567890',
-      sortValue: '2026-01-15T10:00:00Z',
-      sortField: 'createdAt',
-      order: 'desc' as const,
-    };
-
-    const encoded = encodeCursor(payload);
-    const decoded = decodeCursor(encoded);
-
-    expect(decoded.ok).toBe(true);
-    if (decoded.ok) {
-      expect(decoded.value.id).toBe(payload.id);
-      expect(decoded.value.sortValue).toBe(payload.sortValue);
-      expect(decoded.value.sortField).toBe(payload.sortField);
-      expect(decoded.value.order).toBe(payload.order);
-    }
-  });
-
-  it('should produce URL-safe Base64', () => {
-    const cursor = encodeCursor({
-      id: 'test',
-      sortValue: 'value with special chars: +/=',
-      sortField: 'field',
-      order: 'asc',
-    });
-
-    expect(cursor).not.toMatch(/[+/=]/);
-    expect(cursor).toMatch(/^[A-Za-z0-9_-]+$/);
-  });
-
-  it('should handle null sort values', () => {
-    const payload = {
-      id: 'clx123',
-      sortValue: null,
-      sortField: 'deletedAt',
-      order: 'asc' as const,
-    };
-
-    const encoded = encodeCursor(payload);
-    const decoded = decodeCursor(encoded);
-
-    expect(decoded.ok).toBe(true);
-    if (decoded.ok) {
-      expect(decoded.value.sortValue).toBe(null);
-    }
-  });
-
-  it('should handle numeric sort values', () => {
-    const payload = {
-      id: 'clx123',
-      sortValue: 42,
-      sortField: 'position',
-      order: 'asc' as const,
-    };
-
-    const encoded = encodeCursor(payload);
-    const decoded = decodeCursor(encoded);
-
-    expect(decoded.ok).toBe(true);
-    if (decoded.ok) {
-      expect(decoded.value.sortValue).toBe(42);
-    }
-  });
-
-  it('should reject invalid cursor strings', () => {
-    expect(decodeCursor('not-valid-base64!')).toEqual({
-      ok: false,
-      error: 'INVALID_CURSOR',
-    });
-
-    expect(decodeCursor('')).toEqual({
-      ok: false,
-      error: 'INVALID_CURSOR',
-    });
-
-    // Valid Base64 but invalid JSON
-    expect(decodeCursor(btoa('not json'))).toEqual({
-      ok: false,
-      error: 'INVALID_CURSOR',
-    });
-
-    // Valid JSON but wrong schema
-    expect(decodeCursor(btoa('{"foo":"bar"}'))).toEqual({
-      ok: false,
-      error: 'INVALID_CURSOR',
-    });
-  });
-
-  it('should reject future version cursors', () => {
-    const futureVersionCursor = btoa(JSON.stringify({
-      id: 'clx123',
-      sortValue: 'test',
-      sortField: 'createdAt',
-      order: 'desc',
-      version: 999,
-    }));
-
-    expect(decodeCursor(futureVersionCursor)).toEqual({
-      ok: false,
-      error: 'INVALID_CURSOR',
-    });
-  });
-});
-
-describe('createCursor', () => {
-  it('should create cursor from item', () => {
-    const item = {
-      id: 'clx123',
-      createdAt: new Date('2026-01-15T10:00:00Z'),
-      name: 'Test',
-    };
-
-    const cursor = createCursor(item, 'createdAt', 'desc');
-    const decoded = decodeCursor(cursor);
-
-    expect(decoded.ok).toBe(true);
-    if (decoded.ok) {
-      expect(decoded.value.id).toBe('clx123');
-      expect(decoded.value.sortValue).toBe('2026-01-15T10:00:00.000Z');
-      expect(decoded.value.sortField).toBe('createdAt');
-    }
-  });
-});
-```
-
-### Integration Tests for Pagination Flow
-
-```typescript
-// lib/services/__tests__/pagination-query.test.ts
-import { describe, it, expect, beforeEach } from 'vitest';
-import { db } from '@/db';
-import { projects } from '@/db/schema';
-import { paginatedQuery } from '../pagination-query';
-import { decodeCursor } from '@/lib/api/cursor';
-
-describe('paginatedQuery', () => {
-  beforeEach(async () => {
-    // Seed test data
-    await db.delete(projects);
-    await db.insert(projects).values(
-      Array.from({ length: 25 }, (_, i) => ({
-        id: `proj_${String(i).padStart(3, '0')}`,
-        name: `Project ${i}`,
-        path: `/projects/${i}`,
-        updatedAt: new Date(Date.now() - i * 86400000), // Each day older
-      }))
-    );
-  });
-
-  it('should return first page with correct pagination', async () => {
-    const result = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-    });
-
-    expect(result.items).toHaveLength(10);
-    expect(result.pagination.hasMore).toBe(true);
-    expect(result.pagination.nextCursor).not.toBeNull();
-    expect(result.pagination.prevCursor).toBeNull();
-
-    // First item should be most recently updated
-    expect(result.items[0].id).toBe('proj_000');
-  });
-
-  it('should return second page using cursor', async () => {
-    const firstPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-    });
-
-    const secondPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-      cursor: firstPage.pagination.nextCursor!,
-    });
-
-    expect(secondPage.items).toHaveLength(10);
-    expect(secondPage.pagination.hasMore).toBe(true);
-    expect(secondPage.pagination.prevCursor).not.toBeNull();
-
-    // First item of second page should follow last item of first page
-    expect(secondPage.items[0].id).toBe('proj_010');
-  });
-
-  it('should return last page correctly', async () => {
-    // Fetch all pages
-    let cursor: string | undefined;
-    let pages: typeof result[] = [];
-    let result;
-
-    do {
-      result = await paginatedQuery({
-        table: projects,
-        sortColumn: projects.updatedAt,
-        idColumn: projects.id,
-        order: 'desc',
-        limit: 10,
-        cursor,
-      });
-      pages.push(result);
-      cursor = result.pagination.nextCursor ?? undefined;
-    } while (result.pagination.hasMore);
-
-    expect(pages).toHaveLength(3);
-    expect(pages[2].items).toHaveLength(5);
-    expect(pages[2].pagination.hasMore).toBe(false);
-    expect(pages[2].pagination.nextCursor).toBeNull();
-  });
-
-  it('should include total count when requested', async () => {
-    const result = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-      includeTotalCount: true,
-    });
-
-    expect(result.pagination.totalCount).toBe(25);
-  });
-
-  it('should handle ascending order', async () => {
-    const result = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'asc',
-      limit: 10,
-    });
-
-    // First item should be oldest
-    expect(result.items[0].id).toBe('proj_024');
-  });
-
-  it('should apply where clause', async () => {
-    // Add some projects with specific names
-    await db.insert(projects).values([
-      { id: 'special_1', name: 'Special Project', path: '/special/1', updatedAt: new Date() },
-      { id: 'special_2', name: 'Another Special', path: '/special/2', updatedAt: new Date() },
-    ]);
-
-    const result = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-      where: ilike(projects.name, '%special%'),
-    });
-
-    expect(result.items).toHaveLength(2);
-    expect(result.items.every(p => p.name.toLowerCase().includes('special'))).toBe(true);
-  });
-});
-```
-
-### Edge Case Coverage
-
-```typescript
-// lib/services/__tests__/pagination-edge-cases.test.ts
-import { describe, it, expect, beforeEach } from 'vitest';
-import { db } from '@/db';
-import { projects } from '@/db/schema';
-import { paginatedQuery } from '../pagination-query';
-import { encodeCursor } from '@/lib/api/cursor';
-
-describe('pagination edge cases', () => {
-  beforeEach(async () => {
-    await db.delete(projects);
-  });
-
-  it('should handle empty results', async () => {
-    const result = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-    });
-
-    expect(result.items).toHaveLength(0);
-    expect(result.pagination).toEqual({
-      nextCursor: null,
-      prevCursor: null,
-      hasMore: false,
-    });
-  });
-
-  it('should handle single item', async () => {
-    await db.insert(projects).values({
-      id: 'only_one',
-      name: 'Only Project',
-      path: '/only',
-      updatedAt: new Date(),
-    });
-
-    const result = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 10,
-    });
-
-    expect(result.items).toHaveLength(1);
-    expect(result.pagination.hasMore).toBe(false);
-    expect(result.pagination.nextCursor).toBeNull();
-  });
-
-  it('should handle deleted cursor item gracefully', async () => {
-    // Create items
-    await db.insert(projects).values([
-      { id: 'proj_1', name: 'Project 1', path: '/p1', updatedAt: new Date('2026-01-03') },
-      { id: 'proj_2', name: 'Project 2', path: '/p2', updatedAt: new Date('2026-01-02') },
-      { id: 'proj_3', name: 'Project 3', path: '/p3', updatedAt: new Date('2026-01-01') },
-    ]);
-
-    // Get first page
-    const firstPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 1,
-    });
-
-    // Delete the item the cursor points to
-    await db.delete(projects).where(eq(projects.id, 'proj_1'));
-
-    // Fetching next page should still work
-    const secondPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 1,
-      cursor: firstPage.pagination.nextCursor!,
-    });
-
-    // Should get remaining items
-    expect(secondPage.items.length).toBeGreaterThan(0);
-  });
-
-  it('should reject cursor with wrong sort field', async () => {
-    const wrongCursor = encodeCursor({
-      id: 'proj_1',
-      sortValue: '2026-01-01',
-      sortField: 'createdAt', // Wrong field
-      order: 'desc',
-    });
-
-    await expect(
-      paginatedQuery({
-        table: projects,
-        sortColumn: projects.updatedAt, // Expecting updatedAt
-        idColumn: projects.id,
-        order: 'desc',
-        limit: 10,
-        cursor: wrongCursor,
-      })
-    ).rejects.toThrow('INVALID_CURSOR');
-  });
-
-  it('should maintain stable ordering with duplicate sort values', async () => {
-    const sameTime = new Date('2026-01-15T10:00:00Z');
-
-    await db.insert(projects).values([
-      { id: 'aaa', name: 'Project A', path: '/a', updatedAt: sameTime },
-      { id: 'bbb', name: 'Project B', path: '/b', updatedAt: sameTime },
-      { id: 'ccc', name: 'Project C', path: '/c', updatedAt: sameTime },
-    ]);
-
-    const firstPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 1,
-    });
-
-    const secondPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 1,
-      cursor: firstPage.pagination.nextCursor!,
-    });
-
-    // Items should be different (ordered by ID as tiebreaker)
-    expect(firstPage.items[0].id).not.toBe(secondPage.items[0].id);
-
-    // Should see all items across pages
-    const allIds = [firstPage.items[0].id, secondPage.items[0].id];
-    expect(new Set(allIds).size).toBe(2);
-  });
-
-  it('should handle concurrent insertions', async () => {
-    await db.insert(projects).values([
-      { id: 'proj_1', name: 'Project 1', path: '/p1', updatedAt: new Date('2026-01-01') },
-      { id: 'proj_2', name: 'Project 2', path: '/p2', updatedAt: new Date('2026-01-02') },
-    ]);
-
-    // Get first page
-    const firstPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 1,
-    });
-
-    // Insert new item that would appear before cursor
-    await db.insert(projects).values({
-      id: 'proj_new',
-      name: 'New Project',
-      path: '/new',
-      updatedAt: new Date('2026-01-03'),
-    });
-
-    // Second page should NOT include the new item (consistent cursor)
-    const secondPage = await paginatedQuery({
-      table: projects,
-      sortColumn: projects.updatedAt,
-      idColumn: projects.id,
-      order: 'desc',
-      limit: 1,
-      cursor: firstPage.pagination.nextCursor!,
-    });
-
-    expect(secondPage.items[0].id).toBe('proj_1');
-  });
-});
-```
+- **Helper unit tests:**
+  `src/lib/api/__tests__/paginate-helper.test.ts` (round-trip) and
+  `src/lib/api/__tests__/pagination.test.ts` (`validateCursor`).
+- **Cursor encoding:** `src/lib/api/__tests__/cursor.test.ts`.
+- **Route tests:** `tests/api/tasks.test.ts` and
+  `tests/api/sessions.test.ts` cover the migrated envelopes.
+
+The helper round-trip test iterates through 100 simulated rows using
+`paginate` + `decodeRequestCursor` and asserts no duplicates and no
+skips, which is the F07-01 acceptance criterion.
 
 ---
 
-## Cross-References
+## Cross-references
 
 | Spec | Relationship |
 |------|--------------|
-| [API Endpoints](/specs/api/endpoints.md) | Endpoint definitions using pagination |
-| [Database Schema](/specs/database/schema.md) | Table structures and indexes |
-| [Error Catalog](/specs/errors/error-catalog.md) | Error code definitions |
-| [AGENTS.md](/AGENTS.md) | TanStack Query patterns |
+| [API Endpoints](/specs/application/api/endpoints.md) | Per-endpoint details |
+| [Database Schema](/specs/application/database/schema.md) | Compound indexes for `(sortCol, id)` |
+| [Error Catalog](/specs/application/errors/error-catalog.md) | `INVALID_CURSOR` |
+| [arch review F07-01](/specs/arch_review_april/07-api-surface.md#f07-01) | Remediation scope |

--- a/specs/arch_review_april/07-api-surface.md
+++ b/specs/arch_review_april/07-api-surface.md
@@ -28,12 +28,14 @@ The HTTP surface totals ~240 endpoints across **39 Hono route modules** (the "35
 
 ## Findings
 
-### F07-01 — Pagination: cursor spec vs offset reality
+### F07-01 — Pagination: cursor spec vs offset reality — **RESOLVED (April 2026, theme 07)**
 
 - **Priority:** P1
 - **Observation:** `specs/application/api/pagination.md` declares cursor-based as the primary strategy with Base64 payloads. In reality almost every list endpoint uses `parseLimit`/`parseOffset`: bare array (`/api/memory/insights`), `{items, totalCount}` without cursor (`/api/sandbox-configs`), or a degenerate `{items, nextCursor:null, hasMore:false, totalCount}` (`/api/tasks`). `memory.ts:48` even defines its own `parsePagination(page, size)` that collides with `shared.ts:40`. `events.ts:1419` is the only module with real `cursor`/`hasMore` wiring.
 - **Risk:** Deep-page offset scans degrade as data grows; insert/delete during scroll causes skip/dup; cursor-scroll UIs are unreachable.
 - **Recommendation:** Pick one strategy. Introduce a `paginate<T>()` helper emitting `{items, nextCursor, hasMore}` and migrate sessions, tasks, events.log first; or rewrite `pagination.md` to match code.
+- **Resolution:** Added `paginate<T>()` + `decodeRequestCursor()` helpers in `src/lib/api/pagination.ts`. Migrated the three highest-traffic list routes — `GET /api/tasks`, `GET /api/sessions` (global list), `GET /api/events/log` — to the canonical cursor envelope. Extended `TaskService.list()` and `SessionCrudService.list()` to accept an optional `cursor` option that translates to a compound `(sortValue, id)` tuple comparison. Rewrote `specs/application/api/pagination.md` to describe both cursor (canonical) and offset (legacy) styles and annotate which endpoints live in each camp. Added `src/lib/api/__tests__/paginate-helper.test.ts` with a round-trip test that paginates through 100 rows and asserts no duplicates and no skips.
+- **Follow-up:** Remaining offset endpoints can migrate opportunistically when their service methods are next touched.
 - **Effort:** L.
 - **Links:** [`specs/application/api/pagination.md`](../application/api/pagination.md).
 
@@ -45,29 +47,33 @@ The HTTP surface totals ~240 endpoints across **39 Hono route modules** (the "35
 - **Recommendation:** Define `ListResponse<T> = {items: T[], nextCursor: string|null, hasMore: boolean}` and enforce it for every list endpoint. Generate frontend types from schemas (F07-06).
 - **Effort:** M.
 
-### F07-03 — `{ok:true, data:[]}` used to mask infrastructure failures
+### F07-03 — `{ok:true, data:[]}` used to mask infrastructure failures — **RESOLVED (April 2026, theme 07)**
 
 - **Priority:** P1
 - **Observation:** `CLAUDE.md` explicitly warns against this pattern, yet `src/server/routes/codespaces.ts:430,434` does it in `GET /api/codespaces/:id/skills`: when `templateService.getMergedConfig` fails (repo unreachable, parse error), the handler returns an empty list instead of `{ok:false, error}`. Same shape in `events.ts:193,675,682` when plugin directories are missing.
 - **Risk:** UI cannot distinguish "no skills" from "sync broken"; users see empty state with no recovery signal.
 - **Recommendation:** Return `{data:{items:[], source:'empty'|'degraded', degradedReason?}}` or propagate `{ok:false, error}`. Audit every `ok:true, data:[]` return.
+- **Resolution:** `codespaces.ts` skills handler now propagates `templateService.getMergedConfig` failures as `{ok:false, error}` instead of masking as empty. The five `events.ts` empty-list returns (all legitimate "user has no teams / no sources" states, not failure masks) now carry `source: 'empty'` so a future `source: 'degraded'` variant can signal an upstream outage without breaking clients. Added `src/server/routes/__tests__/codespaces-skills.test.ts` to pin the non-ok response.
 - **Effort:** S.
 
-### F07-04 — Rate limit is per-IP, in-process, multiplies across instances
+### F07-04 — Rate limit is per-IP, in-process, multiplies across instances — **RESOLVED (April 2026, theme 07, partial — backend-pluggable)**
 
 - **Priority:** P1
 - **Observation:** `rate-limiter.ts:6-13` admits "each instance maintains its own counters." Global IP limit 200/min, per-token 100/min, webhooks 60/min. A corporate NAT bottlenecks all users behind one IP; distributed attackers from many IPs are unthrottled. Session-cookie auth bypasses the per-token limiter entirely.
 - **Risk:** DoS exposure, noisy-neighbour issues, throttling of legitimate teams behind proxies.
 - **Recommendation:** Swap in Redis-backed counters keyed primarily on `userId`, with IP fallback for unauthenticated endpoints. Webhook routes should key on source slug.
+- **Resolution:** Refactored `src/lib/api/rate-limiter.ts` to (a) derive keys via a pluggable `keyFrom(ctx)` function preferring `userId` → `tokenId` → trusted-proxy-aware IP, (b) expose a `RateLimitBackend` interface so the in-memory store can be swapped for Redis in one line without touching any middleware call site, (c) log a one-time startup warning when using the in-memory backend so operators running multi-instance deployments see the caveat. Did not introduce the Redis dependency — deferred to the operations-hardening workstream — but the drop-in shape is captured in the JSDoc example on `rateLimiter()`. Custom `keyFrom` lets webhook routes key on source slug (e.g. `webhook:github`) without reworking middleware. Added `F07-04` rate-limiter key-derivation tests in `src/lib/api/__tests__/rate-limiter.test.ts`.
+- **Follow-up:** Provide a Redis `RateLimitBackend` (single file, ~30 LOC) and wire it under a `REDIS_URL` env gate.
 - **Effort:** M.
 - **Links:** [`specs/release_plan/02-security-hardening.md`](../release_plan/02-security-hardening.md).
 
-### F07-05 — Request-ID never reaches services or event payloads
+### F07-05 — Request-ID never reaches services or event payloads — **RESOLVED (April 2026, theme 07)**
 
 - **Priority:** P1
 - **Observation:** `requestIdMiddleware` generates `req-{ts}-{counter}`, stores it via `requestContextStorage.run`, and echoes `X-Request-Id`. Only **7 callsites** use `getRequestId` across `src/` (router, logger×2, api/middleware×2, context file×2) — **zero in `src/services/`**. Detached tasks (`queueMicrotask`, `setImmediate`, stream handlers) lose AsyncLocalStorage. DurableStream event payloads carry no `requestId`.
 - **Risk:** No correlation between an API request and the agent run, stream event, or DB write it triggered; when a 500 is reported, the trace chain is broken.
 - **Recommendation:** Add `requestId` to the logger context unconditionally; thread it as an explicit field on service calls that publish events; add a regression test asserting `X-Request-Id` appears in at least one downstream log line.
+- **Resolution:** Theme 10 F10-03 already plumbed `correlationId` into the durable-streams envelope via `createSessionEventMetadata(...)` — which reads from `getRequestId()` (AsyncLocalStorage) when no explicit id is supplied. Theme 07 verified this end-to-end: added `src/lib/api/__tests__/request-id-propagation.test.ts` which asserts (a) `getRequestId()` picks up the ambient request id, (b) nested async boundaries keep the same id, (c) the structured logger stamps it into output, (d) `createSessionEventMetadata` defaults `correlationId` to the current request id, (e) the "full loop" — response header == logger line == event envelope `correlationId` — holds for a single request. Because `createLogger` already pulls `getRequestId()` on every `.info/.error` call, no per-service wiring is required as long as services run under the AsyncLocalStorage frame the router establishes.
 - **Effort:** M.
 - **Links:** [`specs/release_plan/03-observability.md`](../release_plan/03-observability.md).
 

--- a/src/lib/api/__tests__/paginate-helper.test.ts
+++ b/src/lib/api/__tests__/paginate-helper.test.ts
@@ -1,0 +1,173 @@
+/**
+ * F07-01: unit tests for the canonical `paginate<T>` helper.
+ *
+ * These are format-round-trip tests: they do NOT exercise the DB. A separate
+ * integration test (`tests/api/cursor-pagination.test.ts`) covers end-to-end
+ * cursor flow through the tasks/sessions/events routes against real service
+ * results and asserts no duplicates / no skips across 100 rows.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { decodeCursor } from '../cursor.js';
+import { decodeRequestCursor, paginate } from '../pagination.js';
+
+type Row = { id: string; updatedAt: string };
+
+function makeRows(n: number): Row[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `row-${String(i).padStart(3, '0')}`,
+    // Descending timestamps so newest id == row-000.
+    updatedAt: new Date(Date.UTC(2026, 0, n - i)).toISOString(),
+  }));
+}
+
+describe('F07-01 paginate<T> helper', () => {
+  describe('first page', () => {
+    it('returns { items, nextCursor, hasMore: true } when overflow exists', () => {
+      const fetched = makeRows(11); // limit+1
+      const res = paginate(fetched, { limit: 10, sortField: 'updatedAt', order: 'desc' });
+      expect(res.items).toHaveLength(10);
+      expect(res.hasMore).toBe(true);
+      expect(res.nextCursor).not.toBeNull();
+    });
+
+    it('returns hasMore: false + nextCursor: null when no overflow', () => {
+      const fetched = makeRows(7);
+      const res = paginate(fetched, { limit: 10, sortField: 'updatedAt', order: 'desc' });
+      expect(res.items).toHaveLength(7);
+      expect(res.hasMore).toBe(false);
+      expect(res.nextCursor).toBeNull();
+    });
+
+    it('returns an empty result cleanly', () => {
+      const res = paginate<Row>([], { limit: 10, sortField: 'updatedAt', order: 'desc' });
+      expect(res.items).toEqual([]);
+      expect(res.hasMore).toBe(false);
+      expect(res.nextCursor).toBeNull();
+    });
+  });
+
+  describe('cursor round-trip', () => {
+    it('nextCursor decodes to the last item in the page', () => {
+      const fetched = makeRows(11);
+      const res = paginate(fetched, { limit: 10, sortField: 'updatedAt', order: 'desc' });
+      expect(res.nextCursor).not.toBeNull();
+
+      const decoded = decodeCursor(res.nextCursor as string);
+      expect(decoded.ok).toBe(true);
+      if (decoded.ok) {
+        expect(decoded.value.id).toBe(res.items[9]?.id);
+        expect(decoded.value.sortField).toBe('updatedAt');
+        expect(decoded.value.order).toBe('desc');
+        expect(decoded.value.sortValue).toBe(res.items[9]?.updatedAt);
+      }
+    });
+
+    it('decodeRequestCursor accepts a matching sortField/order', () => {
+      const fetched = makeRows(11);
+      const first = paginate(fetched, { limit: 10, sortField: 'updatedAt', order: 'desc' });
+      const res = decodeRequestCursor(first.nextCursor ?? undefined, {
+        sortField: 'updatedAt',
+        order: 'desc',
+      });
+      expect(res.ok).toBe(true);
+    });
+
+    it('decodeRequestCursor rejects a mismatched sortField', () => {
+      const fetched = makeRows(11);
+      const first = paginate(fetched, { limit: 10, sortField: 'updatedAt', order: 'desc' });
+      const res = decodeRequestCursor(first.nextCursor ?? undefined, {
+        sortField: 'createdAt',
+        order: 'desc',
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toBe('INVALID_CURSOR');
+      }
+    });
+
+    it('decodeRequestCursor returns null value when no cursor supplied', () => {
+      const res = decodeRequestCursor(undefined, { sortField: 'updatedAt', order: 'desc' });
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.value).toBeNull();
+      }
+    });
+
+    it('decodeRequestCursor rejects malformed cursors', () => {
+      const res = decodeRequestCursor('not-a-cursor!!!', {
+        sortField: 'updatedAt',
+        order: 'desc',
+      });
+      expect(res.ok).toBe(false);
+    });
+  });
+
+  describe('paginate through 100 rows — no dupes, no skips', () => {
+    /**
+     * F07-01 acceptance test: simulate paginating through 100 rows via
+     * cursor, checking no duplicates + no skips.
+     *
+     * The "DB" is simulated by `fetchPage` which sorts by (updatedAt desc,
+     * id desc) and applies the cursor's compound comparison.
+     */
+    function fetchPage(
+      rows: Row[],
+      limit: number,
+      cursor?: { sortValue: string | number | null; id: string }
+    ): Row[] {
+      // Sort: updatedAt desc, id desc
+      const sorted = [...rows].sort((a, b) => {
+        if (a.updatedAt !== b.updatedAt) {
+          return b.updatedAt.localeCompare(a.updatedAt);
+        }
+        return b.id.localeCompare(a.id);
+      });
+      let filtered = sorted;
+      if (cursor) {
+        filtered = sorted.filter((r) => {
+          if (r.updatedAt !== cursor.sortValue) {
+            return r.updatedAt < (cursor.sortValue as string);
+          }
+          return r.id < cursor.id;
+        });
+      }
+      return filtered.slice(0, limit + 1); // limit+1 for hasMore detection
+    }
+
+    it('iterates every row exactly once', () => {
+      const rows = makeRows(100);
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+      let cursor: string | undefined;
+      let guard = 0;
+
+      // Loop safety net: at most (100 / 10) * 2 = 20 iterations.
+      while (guard++ < 25) {
+        const request = decodeRequestCursor(cursor, {
+          sortField: 'updatedAt',
+          order: 'desc',
+        });
+        expect(request.ok).toBe(true);
+        if (!request.ok) throw new Error('unreachable');
+
+        const cursorPayload = request.value
+          ? { sortValue: request.value.sortValue, id: request.value.id }
+          : undefined;
+        const fetched = fetchPage(rows, 10, cursorPayload);
+        const page = paginate(fetched, { limit: 10, sortField: 'updatedAt', order: 'desc' });
+
+        for (const item of page.items) {
+          if (seen.has(item.id)) duplicates.push(item.id);
+          seen.add(item.id);
+        }
+
+        if (!page.hasMore) break;
+        cursor = page.nextCursor ?? undefined;
+      }
+
+      expect(duplicates).toEqual([]);
+      expect(seen.size).toBe(100);
+    });
+  });
+});

--- a/src/lib/api/__tests__/rate-limiter.test.ts
+++ b/src/lib/api/__tests__/rate-limiter.test.ts
@@ -201,3 +201,114 @@ describe('rateLimiter', () => {
     expect(res.status).toBe(429);
   });
 });
+
+// ---------------------------------------------------------------------------
+// F07-04: key-derivation tests — authenticated users are rate-limited on
+// their userId, not their IP. Separate users from the same NAT get
+// separate buckets; a single user rotating IPs shares the same bucket.
+// ---------------------------------------------------------------------------
+
+describe('F07-04 rate limiter key derivation', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeAuthApp(authCtx: { userId: string } | null, opts?: { max: number }) {
+    const app = new Hono();
+    // Simulate enrichAuthContext: set `auth` on the context before the limiter.
+    app.use('/*', async (c, next) => {
+      if (authCtx) c.set('auth' as never, authCtx as never);
+      await next();
+    });
+    app.use('/*', rateLimiter({ max: opts?.max ?? 2, windowMs: 60_000 }));
+    app.get('/test', (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it('rate-limits the same authenticated user across different IPs', async () => {
+    const app = makeAuthApp({ userId: 'user-alice' });
+
+    // Alice from IP A, then IP B — same user should share the bucket.
+    const r1 = await app.request('/test', { headers: { 'x-real-ip': '10.0.0.1' } });
+    expect(r1.status).toBe(200);
+    const r2 = await app.request('/test', { headers: { 'x-real-ip': '10.0.0.2' } });
+    expect(r2.status).toBe(200);
+
+    // Third request from either IP is blocked.
+    const r3 = await app.request('/test', { headers: { 'x-real-ip': '10.0.0.3' } });
+    expect(r3.status).toBe(429);
+  });
+
+  it('rate-limits two authenticated users independently behind the same IP', async () => {
+    // Alice gets her own bucket; Bob gets his own. Both share one NAT IP
+    // but each bucket is per-user.
+    const headers = { 'x-real-ip': '10.0.0.1' };
+
+    const aliceApp = makeAuthApp({ userId: 'user-alice' });
+    await aliceApp.request('/test', { headers });
+    await aliceApp.request('/test', { headers });
+    const aliceThird = await aliceApp.request('/test', { headers });
+    expect(aliceThird.status).toBe(429);
+
+    // A fresh app instance for Bob — this simulates a different user
+    // context. In production, enrichAuthContext sets the correct userId.
+    const bobApp = makeAuthApp({ userId: 'user-bob' });
+    const bobFirst = await bobApp.request('/test', { headers });
+    expect(bobFirst.status).toBe(200);
+  });
+
+  it('falls back to IP when no auth context is present', async () => {
+    const app = makeAuthApp(null);
+
+    // Without auth, the limiter keys on IP.
+    const r1 = await app.request('/test', { headers: { 'x-real-ip': '5.5.5.5' } });
+    expect(r1.status).toBe(200);
+    const r2 = await app.request('/test', { headers: { 'x-real-ip': '5.5.5.5' } });
+    expect(r2.status).toBe(200);
+    const r3 = await app.request('/test', { headers: { 'x-real-ip': '5.5.5.5' } });
+    expect(r3.status).toBe(429);
+
+    // Different IP bypasses.
+    const r4 = await app.request('/test', { headers: { 'x-real-ip': '6.6.6.6' } });
+    expect(r4.status).toBe(200);
+  });
+
+  it('keyOnToken mode skips requests with no token (session/dev auth)', async () => {
+    // With keyOnToken, a session-authenticated request (no tokenScope)
+    // should pass through unlimited on this specific middleware.
+    const app = new Hono();
+    app.use('/*', async (c, next) => {
+      c.set('auth' as never, { userId: 'alice' } as never); // session auth: no tokenScope
+      await next();
+    });
+    app.use('/*', rateLimiter({ max: 1, windowMs: 60_000, keyOnToken: true }));
+    app.get('/test', (c) => c.json({ ok: true }));
+
+    // 10 session-auth requests all pass — the limiter skips them.
+    for (let i = 0; i < 10; i++) {
+      const r = await app.request('/test');
+      expect(r.status).toBe(200);
+    }
+  });
+
+  it('custom keyFrom can scope to a per-source slug (webhook case)', async () => {
+    const app = new Hono();
+    app.use(
+      '/hooks/:slug',
+      rateLimiter({
+        max: 2,
+        windowMs: 60_000,
+        keyFrom: (c) => `webhook:${c.req.param('slug')}`,
+      })
+    );
+    app.get('/hooks/:slug', (c) => c.json({ ok: true }));
+
+    // Two requests per slug allowed.
+    expect((await app.request('/hooks/github')).status).toBe(200);
+    expect((await app.request('/hooks/github')).status).toBe(200);
+    expect((await app.request('/hooks/github')).status).toBe(429);
+
+    // Different slug has its own bucket.
+    expect((await app.request('/hooks/stripe')).status).toBe(200);
+  });
+});

--- a/src/lib/api/__tests__/request-id-propagation.test.ts
+++ b/src/lib/api/__tests__/request-id-propagation.test.ts
@@ -1,0 +1,129 @@
+/**
+ * F07-05: requestId propagation.
+ *
+ * When a request enters the router:
+ *   1. `requestIdMiddleware` sets a requestId on AsyncLocalStorage
+ *   2. `X-Request-Id` header is echoed back on the response
+ *   3. Any logger call made while the request is in flight picks up the
+ *      same requestId without threading
+ *   4. Any service that publishes a stream event via the metadata helpers
+ *      automatically stamps `correlationId = requestId` on the envelope
+ *
+ * This file asserts each of those points end-to-end.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSessionEventMetadata,
+  createSessionEventWithMetadata,
+} from '../../../services/session/event-metadata.js';
+import { getRequestId, requestContextStorage } from '../../context/request-context.js';
+import { createLogger } from '../../logging/logger.js';
+
+describe('F07-05 — requestId propagation', () => {
+  it('getRequestId() returns the id inside requestContextStorage.run', () => {
+    requestContextStorage.run({ requestId: 'req-test-1' }, () => {
+      expect(getRequestId()).toBe('req-test-1');
+    });
+  });
+
+  it('getRequestId() returns undefined outside a request context', () => {
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it('nested async boundaries keep the same requestId', async () => {
+    await requestContextStorage.run({ requestId: 'req-nested-1' }, async () => {
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 1));
+      expect(getRequestId()).toBe('req-nested-1');
+    });
+  });
+
+  it('logger.info stamps the current requestId into log entries', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const log = createLogger('F07-05-test');
+    // Dev-mode logger truncates requestId to the first 8 chars, so use a
+    // short id whose prefix is visible in the formatted line.
+    requestContextStorage.run({ requestId: 'req-log1' }, () => {
+      log.info('hello from inside request');
+    });
+    const logLine = (spy.mock.calls[0]?.[0] as string) ?? '';
+    expect(logLine).toContain('req-log1');
+    spy.mockRestore();
+  });
+
+  it('createSessionEventMetadata stamps correlationId = requestId by default', () => {
+    requestContextStorage.run({ requestId: 'req-stream-1' }, () => {
+      const meta = createSessionEventMetadata({
+        eventId: 'evt-1',
+        sessionId: 'sess-1',
+        partType: 'chunk_delta',
+        timestamp: Date.now(),
+      });
+      expect(meta.correlationId).toBe('req-stream-1');
+    });
+  });
+
+  it('createSessionEventWithMetadata carries correlationId end-to-end', () => {
+    requestContextStorage.run({ requestId: 'req-event-1' }, () => {
+      const event = createSessionEventWithMetadata({
+        sessionId: 'sess-1',
+        type: 'chunk',
+        partType: 'chunk_delta',
+        data: { text: 'hi' },
+      });
+      const payload = event.data as Record<string, unknown>;
+      const meta = payload.meta as Record<string, unknown> | undefined;
+      expect(meta?.correlationId).toBe('req-event-1');
+    });
+  });
+
+  it('explicit correlationId overrides the AsyncLocalStorage default', () => {
+    requestContextStorage.run({ requestId: 'req-ambient' }, () => {
+      const meta = createSessionEventMetadata({
+        eventId: 'evt-1',
+        sessionId: 'sess-1',
+        partType: 'chunk_delta',
+        timestamp: Date.now(),
+        correlationId: 'req-explicit',
+      });
+      expect(meta.correlationId).toBe('req-explicit');
+    });
+  });
+
+  it('full loop — request header matches logger output AND event metadata', () => {
+    // Simulate the router:
+    //   1. Echo X-Request-Id on the response
+    //   2. Run the handler under requestContextStorage.run(...)
+    //   3. The handler logs + emits an event
+    //   4. Assert both downstream records reference the same requestId
+    //
+    // Dev-mode logger truncates requestId to the first 8 chars in the
+    // formatted prefix; the full id is still on the structured entry in
+    // production. We assert on the 8-char prefix to tolerate both modes.
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const log = createLogger('F07-05-loop');
+    const fixedReqId = 'req-loop-full-id-abcdef';
+    const prefix = fixedReqId.slice(0, 8);
+
+    const responseHeader = fixedReqId; // what the router would echo
+    const event = requestContextStorage.run({ requestId: fixedReqId }, () => {
+      log.info('handler fired');
+      return createSessionEventWithMetadata({
+        sessionId: 'sess-loop',
+        type: 'agent:turn',
+        partType: 'lifecycle',
+        data: { turn: 1 },
+      });
+    });
+
+    const logLine = (spy.mock.calls[0]?.[0] as string) ?? '';
+    const meta = (event.data as Record<string, unknown>).meta as Record<string, unknown>;
+    expect(responseHeader).toBe(fixedReqId);
+    expect(logLine).toContain(prefix);
+    // Event metadata carries the FULL id, not a truncated prefix.
+    expect(meta.correlationId).toBe(fixedReqId);
+
+    spy.mockRestore();
+  });
+});

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -436,14 +436,20 @@ export const apiClient = {
   },
 
   tasks: {
-    list: (codespaceId: string, params?: { status?: string; limit?: number }) => {
+    list: (codespaceId: string, params?: { status?: string; limit?: number; cursor?: string }) => {
       const searchParams = new URLSearchParams();
       searchParams.set('codespaceId', codespaceId);
       if (params?.status) searchParams.set('status', params.status);
       if (params?.limit) searchParams.set('limit', String(params.limit));
-      return apiServerFetch<{ items: unknown[]; totalCount: number }>(
-        `/api/tasks?${searchParams.toString()}`
-      );
+      if (params?.cursor) searchParams.set('cursor', params.cursor);
+      // F07-01: canonical cursor envelope. `totalCount` is no longer
+      // returned (it was always equal to `items.length`, which masked a
+      // true totals query).
+      return apiServerFetch<{
+        items: unknown[];
+        nextCursor: string | null;
+        hasMore: boolean;
+      }>(`/api/tasks?${searchParams.toString()}`);
     },
 
     get: (id: string) => apiServerFetch<unknown>(`/api/tasks/${id}`),

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -1,5 +1,39 @@
+/**
+ * Pagination helpers.
+ *
+ * F07-01: canonical cursor-based pagination support.
+ *
+ * Two surfaces:
+ * - `validateCursor(cursor, options)` — decode + assert sortField/order match
+ *   (kept for backwards compatibility with existing call sites).
+ * - `paginate<T>(items, options)` — given a service result already pre-fetched
+ *   with `limit + 1` (so callers can detect "more" without a count query),
+ *   produce the canonical `ListResponse<T>` envelope:
+ *
+ *     { items: T[], nextCursor: string | null, hasMore: boolean, totalCount?: number }
+ *
+ *   plus optional helpers to decode a request cursor and re-derive a sort
+ *   comparator pair `(sortValue, id)` for the DB query.
+ *
+ * Routes migrating to cursor pagination should:
+ *   1. Call `decodeRequestCursor(cursor, {sortField, order})` to get the
+ *      decoded payload or a 400 response.
+ *   2. Query `limit + 1` rows ordered by `(sortField, id)` with the tuple
+ *      comparator `(sortValue, id)` when a cursor is present.
+ *   3. Call `paginate(rows, { limit, sortField, order })` to build the
+ *      response body.
+ *
+ * Other list endpoints that still use offset pagination continue to work
+ * unchanged — they are documented as the "legacy" style in
+ * specs/application/api/pagination.md.
+ */
+
 import type { CursorPayload, CursorResult } from './cursor.js';
-import { decodeCursor } from './cursor.js';
+import { createCursor, decodeCursor } from './cursor.js';
+
+// ---------------------------------------------------------------------------
+// Legacy `validateCursor` — kept for any existing callers.
+// ---------------------------------------------------------------------------
 
 export type ValidateCursorOptions = {
   sortField: string;
@@ -24,3 +58,89 @@ export const validateCursor = (
 
   return { ok: true, value: payload };
 };
+
+// ---------------------------------------------------------------------------
+// F07-01: canonical `paginate` helper + request-cursor decoder.
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical list response envelope for cursor-paginated routes.
+ *
+ * `data` fields at the route level should match this shape so clients can
+ * share a single pagination helper regardless of endpoint.
+ */
+export interface ListResponse<T> {
+  items: T[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  /** Optional; some endpoints skip this for cost reasons. */
+  totalCount?: number;
+}
+
+export interface PaginateOptions<T extends { id: string }> {
+  /** Page size that the caller asked for. */
+  limit: number;
+  /**
+   * Field used to sort. MUST match the cursor's `sortField` (if one was
+   * supplied). The helper does not validate this — validate up front using
+   * `decodeRequestCursor`.
+   */
+  sortField: keyof T & string;
+  order: 'asc' | 'desc';
+  /**
+   * Optional total count for endpoints that can afford a count query.
+   */
+  totalCount?: number;
+}
+
+/**
+ * Build a `ListResponse<T>` from a pre-fetched item array.
+ *
+ * The caller MUST query `limit + 1` rows so the helper can detect "more
+ * pages" without a count query. Pass the array back unsliced — the helper
+ * slices off the overflow row and uses it to generate the `nextCursor`.
+ */
+export function paginate<T extends { id: string }>(
+  fetched: T[],
+  options: PaginateOptions<T>
+): ListResponse<T> {
+  const { limit, sortField, order, totalCount } = options;
+  const hasMore = fetched.length > limit;
+  const items = hasMore ? fetched.slice(0, limit) : fetched;
+  const nextCursor =
+    hasMore && items.length > 0
+      ? createCursor(items[items.length - 1] as T, sortField, order)
+      : null;
+
+  const response: ListResponse<T> = {
+    items,
+    nextCursor,
+    hasMore,
+  };
+  if (totalCount !== undefined) {
+    response.totalCount = totalCount;
+  }
+  return response;
+}
+
+/**
+ * Decode a request cursor and return either the payload or a reason.
+ * Callers can map `INVALID_CURSOR` to a 400 response.
+ *
+ * Returns `{ ok: true, value: null }` when no cursor was supplied
+ * (first page). Returns `{ ok: false, error: 'INVALID_CURSOR' }` if the
+ * cursor is malformed, tampered with, or references a different sort/order.
+ */
+export function decodeRequestCursor(
+  cursor: string | undefined,
+  options: { sortField: string; order: 'asc' | 'desc' }
+): { ok: true; value: CursorPayload | null } | { ok: false; error: 'INVALID_CURSOR' } {
+  if (!cursor) {
+    return { ok: true, value: null };
+  }
+  const validated = validateCursor(cursor, options);
+  if (!validated.ok) {
+    return { ok: false, error: 'INVALID_CURSOR' };
+  }
+  return { ok: true, value: validated.value };
+}

--- a/src/lib/api/rate-limiter.ts
+++ b/src/lib/api/rate-limiter.ts
@@ -1,24 +1,45 @@
 /**
- * Simple in-memory rate limiter middleware for Hono.
+ * Rate limiter middleware for Hono.
  *
- * Uses a fixed window counter per IP address (default) or per API token.
+ * F07-04: counters are keyed via a pluggable `keyFrom(ctx)` function that
+ * prefers the authenticated user ID, falls back to the API token ID when
+ * present, and finally falls back to the (trusted-proxy-aware) client IP
+ * for unauthenticated requests.
  *
- * IMPORTANT (AR-031): This rate limiter stores counters in process memory.
- * In a multi-instance deployment (e.g., behind a load balancer), each instance
- * maintains its own counters independently, so the effective rate limit is
- * multiplied by the number of instances. For production multi-instance
- * deployments, replace with a Redis-backed rate limiter (e.g., @upstash/ratelimit
- * or a custom Redis INCR/EXPIRE pattern) to get globally consistent limits.
+ * Storage is in-process (`Map`) for the default backend. Swapping in Redis
+ * is a drop-in change: implement the tiny `RateLimitBackend` interface and
+ * pass it in via `rateLimiter({ backend: redisBackend })`. The in-memory
+ * backend logs a one-time warning on startup so multi-instance deployments
+ * know they are running with per-instance counters until Redis is wired.
  *
- * TODO: Implement Redis-backed rate limiter for multi-instance production deployments.
+ * IMPORTANT (AR-031): When running multiple app instances behind a load
+ * balancer, the in-memory backend multiplies the effective limit by the
+ * number of instances. Use a Redis-backed `RateLimitBackend` in production.
  */
 
 import type { Context, Next } from 'hono';
+import { createLogger } from '../logging/logger.js';
 import type { AuthContext } from './auth-middleware.js';
+
+const log = createLogger('RateLimiter');
 
 interface RateLimitEntry {
   count: number;
   resetAt: number;
+}
+
+/**
+ * F07-04: pluggable rate-limit backend interface. The default backend is
+ * in-memory; a Redis backend can implement this interface verbatim using
+ * `INCR` + `PEXPIRE` for atomic counter updates.
+ */
+export interface RateLimitBackend {
+  /**
+   * Record a request for `key` within a `windowMs` window. Returns the
+   * current count within the window and the timestamp when the window
+   * resets (ms since epoch).
+   */
+  incr(key: string, windowMs: number): Promise<RateLimitEntry>;
 }
 
 /**
@@ -72,17 +93,51 @@ function extractClientIp(c: Context): string {
   return c.req.header('x-real-ip') ?? 'unknown';
 }
 
-export interface RateLimitOptions {
-  /** Max requests per window (default: 100) */
-  max?: number;
-  /** Window size in milliseconds (default: 60_000 = 1 minute) */
-  windowMs?: number;
-  /**
-   * When true, use the API token ID as the rate limiting key instead of IP.
-   * Requires the auth context to be enriched (must run after enrichAuthContext middleware).
-   * Falls back to skipping this limiter when no API token is present in the auth context.
-   */
-  keyOnToken?: boolean;
+/**
+ * F07-04: derive a rate-limit key from the request context.
+ *
+ * Preference order:
+ *  1. Authenticated user id     → `user:{userId}`
+ *  2. API token id              → `token:{tokenId}`
+ *  3. Trusted-proxy-aware IP    → `ip:{ip}`
+ *
+ * Routes can override this via `rateLimiter({ keyFrom: customFn })` to key
+ * on e.g. a webhook source slug.
+ */
+export function defaultKeyFrom(c: Context): string {
+  const auth = c.get('auth') as AuthContext | undefined;
+  if (auth?.userId && auth.userId !== '') {
+    return `user:${auth.userId}`;
+  }
+  if (auth?.tokenScope?.tokenId) {
+    return `token:${auth.tokenScope.tokenId}`;
+  }
+  return `ip:${extractClientIp(c)}`;
+}
+
+/**
+ * F07-04: token-only variant — used for the per-token limiter. Returns
+ * `null` for non-token-authenticated requests so the limiter can short-
+ * circuit (i.e. session/dev auth skip this stricter limit).
+ */
+export function tokenKeyFrom(c: Context): string | null {
+  const auth = c.get('auth') as AuthContext | undefined;
+  if (auth?.tokenScope?.tokenId) {
+    return `token:${auth.tokenScope.tokenId}`;
+  }
+  return null;
+}
+
+// F07-04: log a one-time warning at startup when using the in-memory
+// backend, so operators running multiple instances know counters don't
+// cross instances.
+let inMemoryWarningEmitted = false;
+function warnInMemoryOnce(): void {
+  if (inMemoryWarningEmitted) return;
+  inMemoryWarningEmitted = true;
+  log.warn(
+    'Rate limiter using in-memory backend. In multi-instance deployments, effective limits are multiplied by the number of instances. Provide a Redis-backed RateLimitBackend for globally consistent limits.'
+  );
 }
 
 // Module-level shared state: a single cleanup interval iterates all stores
@@ -106,56 +161,94 @@ function ensureCleanup() {
 }
 
 /**
+ * F07-04: in-memory backend. Kept as the default so local dev and tests
+ * don't require a running Redis. Export a Redis backend from this module
+ * (or a plugin) to swap in with a one-line change.
+ */
+export function createInMemoryBackend(): RateLimitBackend {
+  const store = new Map<string, RateLimitEntry>();
+  allStores.push(store);
+  ensureCleanup();
+  warnInMemoryOnce();
+  return {
+    incr: async (key, windowMs) => {
+      const now = Date.now();
+      let entry = store.get(key);
+      if (!entry || entry.resetAt <= now) {
+        entry = { count: 0, resetAt: now + windowMs };
+        store.set(key, entry);
+      }
+      entry.count += 1;
+      return entry;
+    },
+  };
+}
+
+export interface RateLimitOptions {
+  /** Max requests per window (default: 100) */
+  max?: number;
+  /** Window size in milliseconds (default: 60_000 = 1 minute) */
+  windowMs?: number;
+  /**
+   * When true, use the API token ID as the rate limiting key instead of the
+   * default (user → token → IP) chain. Requires `enrichAuthContext` to have
+   * populated `tokenScope`; session/dev auth requests are skipped so the
+   * limiter only applies to programmatic API-token traffic.
+   */
+  keyOnToken?: boolean;
+  /**
+   * F07-04: override the default key derivation. Return `null` to skip
+   * the limiter for this request (useful for auth-method-specific limits).
+   */
+  keyFrom?: (c: Context) => string | null;
+  /**
+   * F07-04: backend store. Defaults to a per-middleware in-memory map.
+   * Inject a Redis-backed `RateLimitBackend` for multi-instance
+   * deployments.
+   */
+  backend?: RateLimitBackend;
+}
+
+/**
  * Create a rate limiting middleware.
  *
  * @example
- * // IP-based rate limiting (default)
- * app.use('/api/*', rateLimiter({ max: 100, windowMs: 60_000 }));
+ * // Default: key on userId → tokenId → IP
+ * app.use('/api/*', rateLimiter({ max: 200, windowMs: 60_000 }));
  *
- * // Per-token rate limiting (must run after enrichAuthContext)
+ * @example
+ * // Per-token rate limit (session/dev auth requests are skipped)
  * app.use('/api/*', rateLimiter({ max: 100, windowMs: 60_000, keyOnToken: true }));
+ *
+ * @example
+ * // Redis backend (drop-in swap in production)
+ * const redisBackend: RateLimitBackend = {
+ *   async incr(key, windowMs) {
+ *     const count = await redis.incr(`rl:${key}`);
+ *     if (count === 1) await redis.pexpire(`rl:${key}`, windowMs);
+ *     const ttl = await redis.pttl(`rl:${key}`);
+ *     return { count, resetAt: Date.now() + ttl };
+ *   },
+ * };
+ * app.use('/api/*', rateLimiter({ max: 200, windowMs: 60_000, backend: redisBackend }));
  */
 export function rateLimiter(opts?: RateLimitOptions) {
   const max = opts?.max ?? 100;
   const windowMs = opts?.windowMs ?? 60_000;
   const keyOnToken = opts?.keyOnToken ?? false;
-
-  const store = new Map<string, RateLimitEntry>();
-  allStores.push(store);
-  ensureCleanup();
+  const backend = opts?.backend ?? createInMemoryBackend();
+  const keyFrom = opts?.keyFrom ?? (keyOnToken ? tokenKeyFrom : defaultKeyFrom);
 
   return async (c: Context, next: Next) => {
-    let rateLimitKey: string | null = null;
+    const rateLimitKey = keyFrom(c);
 
-    // When keyOnToken is enabled, try to use the API token ID as the key
-    if (keyOnToken) {
-      const auth = c.get('auth') as AuthContext | undefined;
-      if (auth?.tokenScope?.tokenId) {
-        rateLimitKey = `token:${auth.tokenScope.tokenId}`;
-      }
-    }
-
-    // Fall back to IP-based key when no token key is available
+    // F07-04: when keyFrom returns null (e.g. token-only limiter with a
+    // session auth request), skip the limiter entirely.
     if (!rateLimitKey) {
-      // If keyOnToken mode and no token present, skip this limiter entirely
-      // (the request is not token-authenticated, so per-token limiting doesn't apply)
-      if (keyOnToken) {
-        return next();
-      }
-
-      // SC-H2: Use trusted proxy-aware IP extraction
-      rateLimitKey = extractClientIp(c);
+      return next();
     }
 
-    const now = Date.now();
-    let entry = store.get(rateLimitKey);
-
-    if (!entry || entry.resetAt <= now) {
-      entry = { count: 0, resetAt: now + windowMs };
-      store.set(rateLimitKey, entry);
-    }
-
-    entry.count += 1;
+    const entry = await backend.incr(rateLimitKey, windowMs);
 
     // Set rate limit headers
     c.header('X-RateLimit-Limit', String(max));

--- a/src/server/routes/__tests__/codespaces-skills.test.ts
+++ b/src/server/routes/__tests__/codespaces-skills.test.ts
@@ -1,0 +1,101 @@
+/**
+ * F07-03: regression coverage for the `{ok:true, data:[]}` masking fix.
+ *
+ * `GET /api/codespaces/:id/skills` previously swallowed every template merge
+ * failure as an empty list. After the fix, infrastructure failures bubble
+ * up as `{ok:false, error}` with a meaningful code so the UI can show a
+ * recovery signal instead of a silent empty state.
+ */
+
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import { err, ok } from '../../../lib/utils/result.js';
+import { createCodespacesRoutes } from '../codespaces.js';
+
+function createMockCodespaceService() {
+  return {
+    list: vi.fn(),
+    create: vi.fn(),
+    getById: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function createMockTemplateService() {
+  return {
+    getMergedConfig: vi.fn(),
+  };
+}
+
+function createTestApp() {
+  const codespaceService = createMockCodespaceService();
+  const templateService = createMockTemplateService();
+  const routes = createCodespacesRoutes({
+    codespaceService: codespaceService as never,
+    templateService: templateService as never,
+    db: {} as never,
+  });
+  const app = new Hono();
+  app.route('/api/codespaces', routes);
+  return { app, codespaceService, templateService };
+}
+
+describe('F07-03 — GET /api/codespaces/:id/skills does not mask upstream failures', () => {
+  it('returns {ok:false, error} when templateService.getMergedConfig fails', async () => {
+    const { app, templateService } = createTestApp();
+    templateService.getMergedConfig.mockResolvedValue(
+      err({ code: 'TEMPLATE_CONFIG_ERROR', message: 'Upstream config unreachable', status: 500 })
+    );
+
+    const res = await app.request('/api/codespaces/cs-abc/skills');
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('TEMPLATE_CONFIG_ERROR');
+    expect(body.error.message).toContain('unreachable');
+  });
+
+  it('returns {ok:true, data:[]} when there are genuinely zero skills configured', async () => {
+    const { app, templateService } = createTestApp();
+    templateService.getMergedConfig.mockResolvedValue(
+      ok({
+        skills: [],
+        // Minimal shape — the handler only reads `skills`.
+      } as never)
+    );
+
+    const res = await app.request('/api/codespaces/cs-abc/skills');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual([]);
+  });
+
+  it('maps each skill to the wire shape when present', async () => {
+    const { app, templateService } = createTestApp();
+    templateService.getMergedConfig.mockResolvedValue(
+      ok({
+        skills: [
+          {
+            id: 'skill-1',
+            name: 'Skill 1',
+            description: 'desc',
+            tags: ['t1'],
+            sourceType: 'template',
+            sourceName: 'tpl-1',
+            executionSkill: true,
+          },
+        ],
+      } as never)
+    );
+
+    const res = await app.request('/api/codespaces/cs-abc/skills');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('skill-1');
+  });
+});

--- a/src/server/routes/__tests__/sessions.test.ts
+++ b/src/server/routes/__tests__/sessions.test.ts
@@ -71,7 +71,15 @@ describe('Sessions API Routes', () => {
 
       await request(app, 'GET', '/api/sessions?limit=10&offset=20');
 
-      expect(sessionService.list).toHaveBeenCalledWith({ limit: 10, offset: 20 });
+      // F07-01: global sessions list defaults to updatedAt desc (with id as
+      // tiebreaker) so cursor semantics are stable even when no cursor is
+      // supplied on the first page.
+      expect(sessionService.list).toHaveBeenCalledWith({
+        limit: 10,
+        offset: 20,
+        orderBy: 'updatedAt',
+        orderDirection: 'desc',
+      });
     });
 
     it('returns 500 when service fails', async () => {

--- a/src/server/routes/__tests__/sessions.test.ts
+++ b/src/server/routes/__tests__/sessions.test.ts
@@ -71,11 +71,12 @@ describe('Sessions API Routes', () => {
 
       await request(app, 'GET', '/api/sessions?limit=10&offset=20');
 
-      // F07-01: global sessions list defaults to updatedAt desc (with id as
-      // tiebreaker) so cursor semantics are stable even when no cursor is
-      // supplied on the first page.
+      // F07-01: global sessions list always runs in cursor mode — the route
+      // fetches `limit + 1` so `paginate()` can derive `hasMore`/`nextCursor`
+      // without a count query. Default sort is `updatedAt` desc with `id` as
+      // the tiebreaker.
       expect(sessionService.list).toHaveBeenCalledWith({
-        limit: 10,
+        limit: 11,
         offset: 20,
         orderBy: 'updatedAt',
         orderDirection: 'desc',
@@ -94,32 +95,44 @@ describe('Sessions API Routes', () => {
       expect(json.error.code).toBe('INTERNAL_ERROR');
     });
 
-    it('returns hasMore = true when result count equals limit', async () => {
+    it('returns hasMore = true and a nextCursor on the first page when more rows exist', async () => {
+      // Regression: previously the first page (no inbound `cursor` query
+      // param) silently fell back to the legacy offset branch and never
+      // emitted `nextCursor`, so clients had no way to advance past page 1.
+      // The route now always runs through `paginate()` and encodes a
+      // `nextCursor` whenever the service returns more than `limit` rows.
       const { app, sessionService } = createTestApp();
-      // Return exactly 5 results when limit is 5
-      const fiveSessions = Array.from({ length: 5 }, (_, i) => ({
+      const sixSessions = Array.from({ length: 6 }, (_, i) => ({
         id: `sess-${i}`,
         status: 'active',
+        updatedAt: `2026-01-0${i + 1}T00:00:00Z`,
       }));
-      sessionService.list.mockResolvedValue({ ok: true, value: fiveSessions });
+      sessionService.list.mockResolvedValue({ ok: true, value: sixSessions });
 
       const res = await request(app, 'GET', '/api/sessions?limit=5');
 
       const json = await res.json();
+      expect(Array.isArray(json.data)).toBe(true);
+      // `paginate()` slices the overflow row off the tail — only 5 rows
+      // should reach the client even though the service returned 6.
+      expect(json.data).toHaveLength(5);
       expect(json.pagination.hasMore).toBe(true);
+      expect(typeof json.pagination.nextCursor).toBe('string');
+      expect(json.pagination.nextCursor).not.toBeNull();
     });
 
-    it('returns hasMore = false when result count is less than limit', async () => {
+    it('returns hasMore = false and nextCursor=null when fewer results than limit', async () => {
       const { app, sessionService } = createTestApp();
       sessionService.list.mockResolvedValue({
         ok: true,
-        value: [{ id: 'sess-1', status: 'active' }],
+        value: [{ id: 'sess-1', status: 'active', updatedAt: '2026-01-01T00:00:00Z' }],
       });
 
       const res = await request(app, 'GET', '/api/sessions?limit=10');
 
       const json = await res.json();
       expect(json.pagination.hasMore).toBe(false);
+      expect(json.pagination.nextCursor).toBeNull();
     });
 
     it('returns error when list returns error result', async () => {

--- a/src/server/routes/__tests__/tasks.test.ts
+++ b/src/server/routes/__tests__/tasks.test.ts
@@ -63,10 +63,13 @@ describe('Tasks API Routes', () => {
       expect(json.ok).toBe(true);
       expect(json.data.items).toHaveLength(2);
       expect(json.data.items[0].id).toBe('task-1');
+      // F07-01: cursor-paginated route fetches limit+1 rows and fixes the
+      // sort direction so cursor comparison is deterministic.
       expect(taskService.list).toHaveBeenCalledWith('proj-1', {
         column: undefined,
-        limit: 50,
-        offset: 0,
+        limit: 51,
+        orderBy: 'position',
+        orderDirection: 'asc',
       });
     });
 
@@ -98,10 +101,12 @@ describe('Tasks API Routes', () => {
 
       await request(app, 'GET', '/api/tasks?codespaceId=proj-1&column=backlog');
 
+      // F07-01: cursor-paginated route fetches limit+1 rows.
       expect(taskService.list).toHaveBeenCalledWith('proj-1', {
         column: 'backlog',
-        limit: 50,
-        offset: 0,
+        limit: 51,
+        orderBy: 'position',
+        orderDirection: 'asc',
       });
     });
   });

--- a/src/server/routes/codespaces.ts
+++ b/src/server/routes/codespaces.ts
@@ -418,6 +418,11 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
   });
 
   // GET /api/codespaces/:id/skills - List available skills for a codespace
+  //
+  // F07-03: never mask an infrastructure failure as `{ok:true, data:[]}`.
+  // Template merge errors propagate as `{ok:false, error}` so the UI can
+  // distinguish "no skills configured" from "sync broken" and surface a
+  // recovery signal.
   app.get('/:id/skills', async (c) => {
     const { id: codespaceId, error } = validateIdParam(c, 'id');
     if (error) return error;
@@ -425,13 +430,22 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
     const result = await templateService.getMergedConfig(codespaceId);
 
     if (!result.ok) {
-      // No templates configured for this codespace — return empty skills list
-      // This is expected when a codespace has no template associations
-      return json({ ok: true, data: [] });
-    }
-
-    if (result.value.skills.length === 0) {
-      return json({ ok: true, data: [] });
+      // F07-03: previously this path returned `{ok:true, data:[]}` which
+      // silently hid template parse/network failures. Propagate as an error
+      // so the client can surface a degraded state.
+      logger.error('Failed to load merged template config for skills list', {
+        data: { codespaceId, error: result.error },
+      });
+      return json(
+        {
+          ok: false,
+          error: {
+            code: result.error.code ?? 'TEMPLATE_CONFIG_ERROR',
+            message: result.error.message ?? 'Failed to load skills for codespace',
+          },
+        },
+        result.error.status ?? 500
+      );
     }
 
     const skills = result.value.skills.map((skill) => ({

--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -30,6 +30,7 @@ import type { CronEventSourceConfig } from '../../db/schema/shared/cron-config.j
 import type { EventSourceStatus } from '../../db/schema/shared/enums.js';
 import { EVENT_SOURCE_STATUS, SCHEDULE_EXECUTION_STATUS } from '../../db/schema/shared/enums.js';
 import type { AuthContext } from '../../lib/api/auth-middleware.js';
+import { decodeRequestCursor, paginate } from '../../lib/api/pagination.js';
 import type { AppError } from '../../lib/errors/base.js';
 import {
   addStreamListener,
@@ -189,7 +190,14 @@ export function createEventsRoutes(deps: EventsRouteDependencies) {
     const teamIds = await getUserTeamIds(auth, db);
 
     if (teamIds.length === 0) {
-      return json({ ok: true, data: { items: [], nextCursor: null, hasMore: false } });
+      // F07-03: explicitly mark as `empty` (user has no teams) so clients
+      // can distinguish this from a `degraded` response caused by an
+      // upstream failure. This is a legitimate empty result, not a masked
+      // failure.
+      return json({
+        ok: true,
+        data: { items: [], nextCursor: null, hasMore: false, source: 'empty' as const },
+      });
     }
 
     const conditions = [];
@@ -671,14 +679,24 @@ export function createEventsRoutes(deps: EventsRouteDependencies) {
       // Scope to user's teams' sources
       const teamIds = await getUserTeamIds(auth, db);
       if (teamIds.length === 0) {
-        return json({ ok: true, data: { items: [], nextCursor: null, hasMore: false } });
+        // F07-03: `source: 'empty'` — user has no teams. Legitimate empty,
+        // not a masked failure.
+        return json({
+          ok: true,
+          data: { items: [], nextCursor: null, hasMore: false, source: 'empty' as const },
+        });
       }
       const sources = await db
         .select({ id: eventSources.id })
         .from(eventSources)
         .where(inArray(eventSources.teamId, teamIds));
       if (sources.length === 0) {
-        return json({ ok: true, data: { items: [], nextCursor: null, hasMore: false } });
+        // F07-03: `source: 'empty'` — no event sources configured for user's
+        // teams. Legitimate empty, not a masked failure.
+        return json({
+          ok: true,
+          data: { items: [], nextCursor: null, hasMore: false, source: 'empty' as const },
+        });
       }
       scopeSourceIds = sources.map((s) => s.id);
     }
@@ -904,9 +922,10 @@ export function createEventsRoutes(deps: EventsRouteDependencies) {
       // Scope to user's team sources
       const teamIds = await getUserTeamIds(auth, db);
       if (teamIds.length === 0) {
+        // F07-03: `source: 'empty'` — user has no teams. Legitimate empty.
         return json({
           ok: true,
-          data: { items: [], nextCursor: null, hasMore: false },
+          data: { items: [], nextCursor: null, hasMore: false, source: 'empty' as const },
         });
       }
 
@@ -916,9 +935,10 @@ export function createEventsRoutes(deps: EventsRouteDependencies) {
         .where(inArray(eventSources.teamId, teamIds));
 
       if (sources.length === 0) {
+        // F07-03: `source: 'empty'` — no event sources for user's teams.
         return json({
           ok: true,
-          data: { items: [], nextCursor: null, hasMore: false },
+          data: { items: [], nextCursor: null, hasMore: false, source: 'empty' as const },
         });
       }
 
@@ -952,16 +972,33 @@ export function createEventsRoutes(deps: EventsRouteDependencies) {
       conditions.push(lte(eventLog.receivedAt, until));
     }
 
-    // Composite cursor: "receivedAt|id" for stable descending pagination
-    if (cursor) {
-      const separatorIdx = cursor.lastIndexOf('|');
-      if (separatorIdx > 0) {
-        const cursorTime = cursor.slice(0, separatorIdx);
-        const cursorId = cursor.slice(separatorIdx + 1);
-        conditions.push(
-          sql`(${eventLog.receivedAt} < ${cursorTime} OR (${eventLog.receivedAt} = ${cursorTime} AND ${eventLog.id} < ${cursorId}))`
-        );
-      }
+    // F07-01: use the canonical base64 cursor format shared with
+    // /api/tasks and /api/sessions. Legacy `receivedAt|id` cursors
+    // are no longer accepted; clients must use the opaque `nextCursor`
+    // returned by the latest response.
+    const sortField = 'receivedAt' as const;
+    const order = 'desc' as const;
+    const cursorResult = decodeRequestCursor(cursor, { sortField, order });
+    if (!cursorResult.ok) {
+      return json(
+        {
+          ok: false,
+          error: {
+            code: 'INVALID_CURSOR',
+            message: 'Invalid or malformed cursor. Restart pagination from the beginning.',
+          },
+        },
+        400
+      );
+    }
+    const cursorPayload = cursorResult.value;
+
+    if (cursorPayload) {
+      const cursorTime = cursorPayload.sortValue;
+      const cursorId = cursorPayload.id;
+      conditions.push(
+        sql`(${eventLog.receivedAt} < ${cursorTime} OR (${eventLog.receivedAt} = ${cursorTime} AND ${eventLog.id} < ${cursorId}))`
+      );
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -974,17 +1011,8 @@ export function createEventsRoutes(deps: EventsRouteDependencies) {
       .orderBy(desc(eventLog.receivedAt), desc(eventLog.id))
       .limit(limit + 1);
 
-    const hasMore = entries.length > limit;
-    const items = hasMore ? entries.slice(0, limit) : entries;
-    const nextCursor =
-      hasMore && items.length > 0
-        ? `${items[items.length - 1]?.receivedAt}|${items[items.length - 1]?.id}`
-        : null;
-
-    return json({
-      ok: true,
-      data: { items, nextCursor, hasMore },
-    });
+    const body = paginate(entries, { limit, sortField, order });
+    return json({ ok: true, data: body });
   });
 
   // GET /log/:id - Get event log entry by ID

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -189,8 +189,14 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
     // Backward-compatible envelope: `data` stays a flat array (so
     // `apiServerFetch<Session[]>` keeps working) and `pagination` exposes
     // the opaque `nextCursor` + `hasMore` flags alongside the legacy
-    // `limit`/`offset`. Passing the new `cursor` query param uses cursor
-    // mode; omitting it keeps the existing offset-and-limit behaviour.
+    // `limit`/`offset`.
+    //
+    // Bug fix: previously only requests that carried an inbound `cursor`
+    // query param went through `paginate()`; the first page (no cursor) fell
+    // back to the legacy offset branch and never emitted `nextCursor`,
+    // leaving clients with no way to advance beyond page 1. We now always
+    // fetch `limit + 1` and run through `paginate()` so the first page
+    // returns a valid `nextCursor` whenever there are more rows.
     const sortField = 'updatedAt' as const;
     const order = 'desc' as const;
     const rawCursor = c.req.query('cursor') || undefined;
@@ -208,14 +214,15 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
       );
     }
     const cursorPayload = cursorResult.value;
-    const usingCursor = cursorPayload !== null;
 
     const result = await sessionService.list({
-      // F07-01: when using cursor mode, fetch limit+1 so `paginate` can
-      // detect `hasMore` without a count query. Otherwise preserve the
-      // legacy offset-and-limit semantics.
-      limit: usingCursor ? limit + 1 : limit,
-      offset: usingCursor ? 0 : offset,
+      // F07-01: fetch `limit + 1` so `paginate()` can detect `hasMore`
+      // without a count query. When a cursor is supplied we do not apply an
+      // offset (the cursor itself positions the page); when absent we keep
+      // the legacy `offset` semantics so pre-cursor clients that still pass
+      // `offset` continue to work.
+      limit: limit + 1,
+      offset: cursorPayload ? 0 : offset,
       orderBy: sortField,
       orderDirection: order,
       ...(cursorPayload
@@ -231,27 +238,15 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
       return errorResponse(result);
     }
 
-    if (usingCursor) {
-      const body = paginate(result.value, { limit, sortField, order });
-      return json({
-        ok: true,
-        data: body.items,
-        pagination: {
-          limit,
-          offset: 0,
-          nextCursor: body.nextCursor,
-          hasMore: body.hasMore,
-        },
-      });
-    }
-
+    const body = paginate(result.value, { limit, sortField, order });
     return json({
       ok: true,
-      data: result.value,
+      data: body.items,
       pagination: {
         limit,
-        offset,
-        hasMore: result.value.length === limit,
+        offset: cursorPayload ? 0 : offset,
+        nextCursor: body.nextCursor,
+        hasMore: body.hasMore,
       },
     });
   });

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -5,6 +5,7 @@
 import { Hono } from 'hono';
 import type { SessionStatus } from '../../db/schema/shared/enums.js';
 import { SESSION_STATUS } from '../../db/schema/shared/enums.js';
+import { decodeRequestCursor, paginate } from '../../lib/api/pagination.js';
 import type { SessionService } from '../../services/session.service.js';
 import { errorResponse, json, parseLimit, parseOffset, validateIdParam } from '../shared.js';
 import { createSessionSchema, exportSessionSchema, parseJsonBody } from '../validation.js';
@@ -132,6 +133,15 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
   const app = new Hono();
 
   // GET /api/sessions
+  //
+  // F07-01: two modes:
+  //   (a) Filtered mode (when `codespaceId` is supplied): keeps the existing
+  //       offset/total shape because the UI explicitly relies on `total` for
+  //       badges and filter-count readouts. This path is documented as the
+  //       legacy offset path in specs/application/api/pagination.md.
+  //   (b) Global list (no `codespaceId`): cursor-paginated, sorted by
+  //       `updatedAt` desc with `id` as tiebreaker. Returns the canonical
+  //       `{ items, nextCursor, hasMore }` envelope.
   app.get('/', async (c) => {
     const codespaceId = c.req.query('codespaceId');
     const limit = parseLimit(c);
@@ -174,10 +184,65 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
       });
     }
 
-    // Fallback: no codespaceId filter (existing behavior)
-    const result = await sessionService.list({ limit, offset });
+    // F07-01: cursor-based pagination for the global session list.
+    //
+    // Backward-compatible envelope: `data` stays a flat array (so
+    // `apiServerFetch<Session[]>` keeps working) and `pagination` exposes
+    // the opaque `nextCursor` + `hasMore` flags alongside the legacy
+    // `limit`/`offset`. Passing the new `cursor` query param uses cursor
+    // mode; omitting it keeps the existing offset-and-limit behaviour.
+    const sortField = 'updatedAt' as const;
+    const order = 'desc' as const;
+    const rawCursor = c.req.query('cursor') || undefined;
+    const cursorResult = decodeRequestCursor(rawCursor, { sortField, order });
+    if (!cursorResult.ok) {
+      return json(
+        {
+          ok: false,
+          error: {
+            code: 'INVALID_CURSOR',
+            message: 'Invalid or malformed cursor. Restart pagination from the beginning.',
+          },
+        },
+        400
+      );
+    }
+    const cursorPayload = cursorResult.value;
+    const usingCursor = cursorPayload !== null;
+
+    const result = await sessionService.list({
+      // F07-01: when using cursor mode, fetch limit+1 so `paginate` can
+      // detect `hasMore` without a count query. Otherwise preserve the
+      // legacy offset-and-limit semantics.
+      limit: usingCursor ? limit + 1 : limit,
+      offset: usingCursor ? 0 : offset,
+      orderBy: sortField,
+      orderDirection: order,
+      ...(cursorPayload
+        ? {
+            cursor: {
+              sortValue: cursorPayload.sortValue,
+              id: cursorPayload.id,
+            },
+          }
+        : {}),
+    });
     if (!result.ok) {
       return errorResponse(result);
+    }
+
+    if (usingCursor) {
+      const body = paginate(result.value, { limit, sortField, order });
+      return json({
+        ok: true,
+        data: body.items,
+        pagination: {
+          limit,
+          offset: 0,
+          nextCursor: body.nextCursor,
+          hasMore: body.hasMore,
+        },
+      });
     }
 
     return json({

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -3,16 +3,10 @@
  */
 
 import { Hono } from 'hono';
+import { decodeRequestCursor, paginate } from '../../lib/api/pagination.js';
 import { createLogger } from '../../lib/logging/logger.js';
 import type { TaskService } from '../../services/task.service.js';
-import {
-  errorResponse,
-  json,
-  parseLimit,
-  parseOffset,
-  requireQueryId,
-  validateIdParam,
-} from '../shared.js';
+import { errorResponse, json, parseLimit, requireQueryId, validateIdParam } from '../shared.js';
 import {
   createTaskSchema,
   moveTaskSchema,
@@ -31,6 +25,11 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
   const app = new Hono();
 
   // GET /api/tasks
+  //
+  // F07-01: cursor-paginated list endpoint. The canonical envelope is
+  //   { data: { items: Task[], nextCursor: string|null, hasMore: boolean } }
+  // sorted by `position` asc with `id` as the tiebreaker. Request a next page
+  // by passing the opaque `cursor` query param from the previous response.
   app.get('/', async (c) => {
     const { id: codespaceId, error: csError } = requireQueryId(c, 'codespaceId');
     if (csError) return csError;
@@ -54,23 +53,50 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
       column = parsed.data;
     }
     const limit = parseLimit(c);
-    const offset = parseOffset(c);
+    const rawCursor = c.req.query('cursor') || undefined;
 
-    const result = await taskService.list(codespaceId, { column, limit, offset });
+    // F07-01: fixed sort for cursor stability. The route always sorts by
+    // `position` asc; if we later expose a `sort` query param it must be
+    // validated against the cursor's embedded sortField.
+    const sortField = 'position' as const;
+    const order = 'asc' as const;
+
+    const cursorResult = decodeRequestCursor(rawCursor, { sortField, order });
+    if (!cursorResult.ok) {
+      return json(
+        {
+          ok: false,
+          error: {
+            code: 'INVALID_CURSOR',
+            message: 'Invalid or malformed cursor. Restart pagination from the beginning.',
+          },
+        },
+        400
+      );
+    }
+    const cursorPayload = cursorResult.value;
+
+    const result = await taskService.list(codespaceId, {
+      column,
+      limit: limit + 1, // F07-01: fetch limit+1 so `paginate` can detect hasMore.
+      orderBy: sortField,
+      orderDirection: order,
+      ...(cursorPayload
+        ? {
+            cursor: {
+              sortValue: cursorPayload.sortValue,
+              id: cursorPayload.id,
+            },
+          }
+        : {}),
+    });
 
     if (!result.ok) {
       return errorResponse(result);
     }
 
-    return json({
-      ok: true,
-      data: {
-        items: result.value,
-        nextCursor: null,
-        hasMore: false,
-        totalCount: result.value.length,
-      },
-    });
+    const body = paginate(result.value, { limit, sortField, order });
+    return json({ ok: true, data: body });
   });
 
   // POST /api/tasks

--- a/src/services/session/session-crud.service.ts
+++ b/src/services/session/session-crud.service.ts
@@ -110,10 +110,37 @@ export class SessionCrudService {
 
     const orderColumn = orderBy === 'createdAt' ? sessions.createdAt : sessions.updatedAt;
 
+    // F07-01: when a cursor is supplied, query `limit + 1` rows strictly after
+    // the cursor position using a compound `(sortValue, id)` comparison. The
+    // route handler slices the overflow row to detect `hasMore`.
+    const cursor = options?.cursor;
+    let where: ReturnType<typeof and> | undefined;
+    let fetchLimit = limit;
+    let fetchOffset = offset;
+    if (cursor) {
+      const sortVal = cursor.sortValue;
+      // Compound tuple comparison:
+      //   desc: (col, id) < (sortVal, cursorId)
+      //   asc : (col, id) > (sortVal, cursorId)
+      // SQL: `(col < v) OR (col = v AND id < cursorId)` (flip < for asc).
+      const primary =
+        direction === 'desc' ? sql`${orderColumn} < ${sortVal}` : sql`${orderColumn} > ${sortVal}`;
+      const tiebreak =
+        direction === 'desc'
+          ? sql`(${orderColumn} = ${sortVal} AND ${sessions.id} < ${cursor.id})`
+          : sql`(${orderColumn} = ${sortVal} AND ${sessions.id} > ${cursor.id})`;
+      where = and(sql`(${primary} OR ${tiebreak})`) as ReturnType<typeof and>;
+      fetchLimit = limit + 1;
+      fetchOffset = 0;
+    }
+
     const items = await this.db.query.sessions.findMany({
-      orderBy: (direction === 'asc' ? [orderColumn] : [desc(orderColumn)]) as never,
-      limit,
-      offset,
+      where,
+      orderBy: (direction === 'asc'
+        ? [orderColumn, sessions.id]
+        : [desc(orderColumn), desc(sessions.id)]) as never,
+      limit: fetchLimit,
+      offset: fetchOffset,
     });
 
     return ok(

--- a/src/services/session/session-crud.service.ts
+++ b/src/services/session/session-crud.service.ts
@@ -110,12 +110,19 @@ export class SessionCrudService {
 
     const orderColumn = orderBy === 'createdAt' ? sessions.createdAt : sessions.updatedAt;
 
-    // F07-01: when a cursor is supplied, query `limit + 1` rows strictly after
-    // the cursor position using a compound `(sortValue, id)` comparison. The
-    // route handler slices the overflow row to detect `hasMore`.
+    // F07-01: when a cursor is supplied, query strictly after the cursor
+    // position using a compound `(sortValue, id)` comparison. The route
+    // handler is responsible for passing `limit + 1` and slicing the
+    // overflow row via `paginate()` to detect `hasMore` — this method does
+    // NOT add a redundant `+ 1` on top.
+    //
+    // Precondition: sort columns (`sessions.createdAt`, `sessions.updatedAt`)
+    // are declared `.notNull()` in the SQLite and Postgres schemas, so the
+    // compound `col < v` comparison always yields a boolean (never NULL).
+    // If a nullable sort column is ever added, wrap with COALESCE or use
+    // explicit NULL ordering so pagination does not silently break.
     const cursor = options?.cursor;
     let where: ReturnType<typeof and> | undefined;
-    let fetchLimit = limit;
     let fetchOffset = offset;
     if (cursor) {
       const sortVal = cursor.sortValue;
@@ -130,7 +137,6 @@ export class SessionCrudService {
           ? sql`(${orderColumn} = ${sortVal} AND ${sessions.id} < ${cursor.id})`
           : sql`(${orderColumn} = ${sortVal} AND ${sessions.id} > ${cursor.id})`;
       where = and(sql`(${primary} OR ${tiebreak})`) as ReturnType<typeof and>;
-      fetchLimit = limit + 1;
       fetchOffset = 0;
     }
 
@@ -139,7 +145,7 @@ export class SessionCrudService {
       orderBy: (direction === 'asc'
         ? [orderColumn, sessions.id]
         : [desc(orderColumn), desc(sessions.id)]) as never,
-      limit: fetchLimit,
+      limit,
       offset: fetchOffset,
     });
 

--- a/src/services/session/types.ts
+++ b/src/services/session/types.ts
@@ -67,6 +67,16 @@ export type ListSessionsOptions = {
   offset?: number;
   orderBy?: 'createdAt' | 'updatedAt';
   orderDirection?: 'asc' | 'desc';
+  /**
+   * F07-01: cursor-based pagination. When supplied, the service queries
+   * `limit + 1` rows starting strictly after the cursor position using a
+   * `(sortValue, id)` compound comparison. `offset` is ignored when
+   * `cursor` is present.
+   */
+  cursor?: {
+    sortValue: string | number | null;
+    id: string;
+  };
 };
 
 export type PresenceUpdate = {

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
 import type { Task, TaskColumn } from '../db/schema';
 import { codespaces, sessions, settings, tasks } from '../db/schema';
 import { getFullModelId } from '../lib/constants/models.js';
@@ -59,6 +59,16 @@ export type ListTasksOptions = {
   offset?: number;
   orderBy?: 'position' | 'createdAt' | 'updatedAt';
   orderDirection?: 'asc' | 'desc';
+  /**
+   * F07-01: cursor-based pagination. When supplied, the service queries
+   * `limit + 1` rows strictly after the cursor position using a compound
+   * `(sortValue, id)` comparison. `offset` is ignored when `cursor` is
+   * present.
+   */
+  cursor?: {
+    sortValue: string | number | null;
+    id: string;
+  };
 };
 
 export type ApproveInput = {
@@ -465,11 +475,31 @@ export class TaskService {
       filters.push(eq(tasks.agentId, options.agentId));
     }
 
+    // F07-01: cursor-based pagination. When supplied, append a compound
+    // `(sortValue, id)` tuple comparison filter and fetch `limit + 1` rows.
+    const cursor = options?.cursor;
+    let fetchLimit = limit;
+    let fetchOffset = offset;
+    if (cursor) {
+      const sortVal = cursor.sortValue;
+      const primary =
+        direction === 'desc' ? sql`${orderColumn} < ${sortVal}` : sql`${orderColumn} > ${sortVal}`;
+      const tiebreak =
+        direction === 'desc'
+          ? sql`(${orderColumn} = ${sortVal} AND ${tasks.id} < ${cursor.id})`
+          : sql`(${orderColumn} = ${sortVal} AND ${tasks.id} > ${cursor.id})`;
+      filters.push(sql`(${primary} OR ${tiebreak})`);
+      fetchLimit = limit + 1;
+      fetchOffset = 0;
+    }
+
     const items = await this.db.query.tasks.findMany({
       where: filters.length > 1 ? and(...filters) : filters[0],
-      orderBy: (direction === 'asc' ? [orderColumn] : [desc(orderColumn)]) as never,
-      limit,
-      offset,
+      orderBy: (direction === 'asc'
+        ? [orderColumn, tasks.id]
+        : [desc(orderColumn), desc(tasks.id)]) as never,
+      limit: fetchLimit,
+      offset: fetchOffset,
     });
 
     return ok(items);

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -476,9 +476,18 @@ export class TaskService {
     }
 
     // F07-01: cursor-based pagination. When supplied, append a compound
-    // `(sortValue, id)` tuple comparison filter and fetch `limit + 1` rows.
+    // `(sortValue, id)` tuple comparison filter. The route handler is
+    // responsible for passing `limit + 1` and slicing the overflow row via
+    // `paginate()` to detect `hasMore` — this method does NOT add a
+    // redundant `+ 1` on top.
+    //
+    // Precondition: sort columns (`tasks.position`, `tasks.createdAt`,
+    // `tasks.updatedAt`) are declared `.notNull()` in the SQLite and
+    // Postgres schemas, so the compound `col < v` comparison always yields
+    // a boolean (never NULL). If a nullable sort column is ever added,
+    // wrap with COALESCE or use explicit NULL ordering so pagination does
+    // not silently break.
     const cursor = options?.cursor;
-    let fetchLimit = limit;
     let fetchOffset = offset;
     if (cursor) {
       const sortVal = cursor.sortValue;
@@ -489,7 +498,6 @@ export class TaskService {
           ? sql`(${orderColumn} = ${sortVal} AND ${tasks.id} < ${cursor.id})`
           : sql`(${orderColumn} = ${sortVal} AND ${tasks.id} > ${cursor.id})`;
       filters.push(sql`(${primary} OR ${tiebreak})`);
-      fetchLimit = limit + 1;
       fetchOffset = 0;
     }
 
@@ -498,7 +506,7 @@ export class TaskService {
       orderBy: (direction === 'asc'
         ? [orderColumn, tasks.id]
         : [desc(orderColumn), desc(tasks.id)]) as never,
-      limit: fetchLimit,
+      limit,
       offset: fetchOffset,
     });
 

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -85,7 +85,10 @@ describe('Task API', () => {
     });
   });
 
-  it('lists tasks with counts', async () => {
+  it('lists tasks with cursor pagination envelope', async () => {
+    // F07-01: /api/tasks now returns the canonical cursor envelope
+    //   { data: { items, nextCursor, hasMore } }
+    // instead of the legacy `totalCount` shape.
     taskServiceMocks.list.mockResolvedValue(ok([sampleTask]));
 
     const response = await tasksRoute.request(
@@ -95,12 +98,13 @@ describe('Task API', () => {
     expect(response?.status).toBe(200);
     const data = await parseJson<{
       ok: true;
-      data: { items: Task[]; totalCount: number };
+      data: { items: Task[]; nextCursor: string | null; hasMore: boolean };
     }>(response as Response);
 
     expect(data.ok).toBe(true);
     expect(data.data.items).toHaveLength(1);
-    expect(data.data.totalCount).toBe(1);
+    expect(data.data.hasMore).toBe(false);
+    expect(data.data.nextCursor).toBeNull();
   });
 
   it('validates list query', async () => {

--- a/tests/integration/cursor-pagination.test.ts
+++ b/tests/integration/cursor-pagination.test.ts
@@ -1,0 +1,214 @@
+/**
+ * F07-01: end-to-end cursor-pagination integration tests.
+ *
+ * These tests exercise the real services (SessionCrudService, TaskService)
+ * against the in-memory SQLite test database. They paginate through 100
+ * rows using the compound `(sortValue, id)` cursor and assert:
+ *   - every row appears exactly once (no skips, no duplicates)
+ *   - the final page has `hasMore: false` and `nextCursor: null`
+ *   - `INVALID_CURSOR` handling works (rejected at the decode layer)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { decodeRequestCursor, paginate } from '../../src/lib/api/pagination';
+import { SessionCrudService } from '../../src/services/session/session-crud.service';
+import { TaskService } from '../../src/services/task.service';
+import { createTestProject } from '../factories/project.factory';
+import { createTestTask } from '../factories/task.factory';
+import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
+
+const BASE_URL = 'http://localhost:3000';
+
+function createMockStreams() {
+  return {
+    createStream: vi.fn().mockResolvedValue(undefined),
+    publish: vi.fn().mockResolvedValue(0),
+    subscribe: vi.fn(),
+    deleteStream: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createMockWorktreeService() {
+  return {
+    getDiff: vi.fn(),
+    merge: vi.fn(),
+    remove: vi.fn(),
+  };
+}
+
+describe('F07-01: cursor pagination end-to-end', () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(async () => {
+    await setupTestDatabase();
+    db = getTestDb();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+  });
+
+  describe('TaskService.list() — 100 rows, page 10 at a time', () => {
+    it('iterates every task exactly once via cursor', async () => {
+      const codespace = await createTestProject();
+      const taskService = new TaskService(db as never, createMockWorktreeService() as never);
+
+      // Seed 100 tasks directly via the factory so each gets a unique
+      // `position` (the default sort field for the tasks route) without
+      // round-tripping through `TaskService.create`.
+      for (let i = 0; i < 100; i++) {
+        await createTestTask(codespace.id, {
+          column: 'backlog',
+          position: i,
+          title: `Task ${String(i).padStart(3, '0')}`,
+        });
+      }
+
+      // Walk the cursor.
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+      let cursor: string | undefined;
+      const pages: number[] = [];
+
+      for (let guard = 0; guard < 25; guard++) {
+        const cursorResult = decodeRequestCursor(cursor, {
+          sortField: 'position',
+          order: 'asc',
+        });
+        expect(cursorResult.ok).toBe(true);
+        if (!cursorResult.ok) throw new Error('unreachable');
+
+        const cursorPayload = cursorResult.value
+          ? { sortValue: cursorResult.value.sortValue, id: cursorResult.value.id }
+          : undefined;
+
+        const result = await taskService.list(codespace.id, {
+          limit: 11, // limit+1
+          orderBy: 'position',
+          orderDirection: 'asc',
+          ...(cursorPayload ? { cursor: cursorPayload } : {}),
+        });
+        expect(result.ok).toBe(true);
+        if (!result.ok) throw new Error('unreachable');
+
+        const body = paginate(result.value, {
+          limit: 10,
+          sortField: 'position',
+          order: 'asc',
+        });
+        pages.push(body.items.length);
+
+        for (const item of body.items) {
+          if (seen.has(item.id)) duplicates.push(item.id);
+          seen.add(item.id);
+        }
+
+        if (!body.hasMore) {
+          expect(body.nextCursor).toBeNull();
+          break;
+        }
+        expect(body.nextCursor).not.toBeNull();
+        cursor = body.nextCursor ?? undefined;
+      }
+
+      expect(duplicates).toEqual([]);
+      expect(seen.size).toBe(100);
+      // 10 pages of 10 rows each.
+      expect(pages).toEqual([10, 10, 10, 10, 10, 10, 10, 10, 10, 10]);
+    });
+
+    it('rejects a cursor whose sortField does not match the request', async () => {
+      // A valid cursor for a different sort field.
+      const cursor = Buffer.from(
+        JSON.stringify({
+          id: 'task-1',
+          sortValue: 0,
+          sortField: 'createdAt',
+          order: 'asc',
+          version: 1,
+        }),
+        'utf-8'
+      )
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      const res = decodeRequestCursor(cursor, { sortField: 'position', order: 'asc' });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toBe('INVALID_CURSOR');
+      }
+    });
+  });
+
+  describe('SessionCrudService.list() — 100 rows, page 10 at a time', () => {
+    it('iterates every session exactly once via cursor (updatedAt desc)', async () => {
+      const codespace = await createTestProject();
+      const mockStreams = createMockStreams();
+      const presenceStore = new Map<string, Map<string, never>>();
+      const service = new SessionCrudService(
+        db as never,
+        mockStreams as never,
+        { baseUrl: BASE_URL },
+        presenceStore
+      );
+
+      // Seed 100 sessions via the service so `updatedAt` reflects real
+      // inserts. Ties (same timestamp) are handled by the id tiebreaker.
+      for (let i = 0; i < 100; i++) {
+        const result = await service.create({
+          codespaceId: codespace.id,
+          title: `Session ${String(i).padStart(3, '0')}`,
+        });
+        expect(result.ok).toBe(true);
+      }
+
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+      let cursor: string | undefined;
+
+      for (let guard = 0; guard < 25; guard++) {
+        const cursorResult = decodeRequestCursor(cursor, {
+          sortField: 'updatedAt',
+          order: 'desc',
+        });
+        expect(cursorResult.ok).toBe(true);
+        if (!cursorResult.ok) throw new Error('unreachable');
+
+        const cursorPayload = cursorResult.value
+          ? { sortValue: cursorResult.value.sortValue, id: cursorResult.value.id }
+          : undefined;
+
+        const result = await service.list({
+          limit: 11,
+          orderBy: 'updatedAt',
+          orderDirection: 'desc',
+          ...(cursorPayload ? { cursor: cursorPayload } : {}),
+        });
+        expect(result.ok).toBe(true);
+        if (!result.ok) throw new Error('unreachable');
+
+        const body = paginate(result.value, {
+          limit: 10,
+          sortField: 'updatedAt',
+          order: 'desc',
+        });
+
+        for (const item of body.items) {
+          if (seen.has(item.id)) duplicates.push(item.id);
+          seen.add(item.id);
+        }
+
+        if (!body.hasMore) {
+          expect(body.nextCursor).toBeNull();
+          break;
+        }
+        cursor = body.nextCursor ?? undefined;
+      }
+
+      expect(duplicates).toEqual([]);
+      expect(seen.size).toBe(100);
+    });
+  });
+});

--- a/tests/integration/route-codespaces.test.ts
+++ b/tests/integration/route-codespaces.test.ts
@@ -495,7 +495,10 @@ describe('Codespaces Routes (IT-1150)', () => {
     expect(body.data[0].content).toBeUndefined();
   });
 
-  it('IT-1170: GET /:id/skills returns empty array when no templates', async () => {
+  it('IT-1170: GET /:id/skills propagates upstream failure (F07-03)', async () => {
+    // F07-03: the skills handler must NOT mask a template-service failure
+    // as an empty list. Propagate as `{ok:false, error}` so clients can
+    // surface a degraded state instead of an indistinguishable empty one.
     mockTemplateService.getMergedConfig.mockResolvedValue({
       ok: false,
       error: { code: 'NOT_FOUND', message: 'No templates', status: 404 },
@@ -503,10 +506,10 @@ describe('Codespaces Routes (IT-1150)', () => {
 
     const res = await app.request('http://localhost/cs-1/skills');
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(404);
     const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.data).toEqual([]);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
   });
 
   it('IT-1171: GET /:id/skills returns empty when skills array is empty', async () => {

--- a/tests/integration/route-sessions.test.ts
+++ b/tests/integration/route-sessions.test.ts
@@ -64,7 +64,14 @@ describe('Sessions Routes (IT-1250)', () => {
     expect(body.data).toHaveLength(2);
     expect(body.pagination.limit).toBe(50);
     expect(body.pagination.offset).toBe(0);
-    expect(mockService.list).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    // F07-01: global sessions list fixes sort direction so cursor-based
+    // pagination is stable. Without a cursor it falls back to offset+limit.
+    expect(mockService.list).toHaveBeenCalledWith({
+      limit: 50,
+      offset: 0,
+      orderBy: 'updatedAt',
+      orderDirection: 'desc',
+    });
   });
 
   it('IT-1251: GET / respects limit and offset params', async () => {
@@ -72,7 +79,13 @@ describe('Sessions Routes (IT-1250)', () => {
 
     await app.request('http://localhost/?limit=10&offset=20');
 
-    expect(mockService.list).toHaveBeenCalledWith({ limit: 10, offset: 20 });
+    // F07-01: same fixed sort as above.
+    expect(mockService.list).toHaveBeenCalledWith({
+      limit: 10,
+      offset: 20,
+      orderBy: 'updatedAt',
+      orderDirection: 'desc',
+    });
   });
 
   it('IT-1252: GET / returns error on service failure', async () => {

--- a/tests/integration/route-sessions.test.ts
+++ b/tests/integration/route-sessions.test.ts
@@ -64,10 +64,12 @@ describe('Sessions Routes (IT-1250)', () => {
     expect(body.data).toHaveLength(2);
     expect(body.pagination.limit).toBe(50);
     expect(body.pagination.offset).toBe(0);
-    // F07-01: global sessions list fixes sort direction so cursor-based
-    // pagination is stable. Without a cursor it falls back to offset+limit.
+    // F07-01: global sessions list always runs in cursor mode — the route
+    // fetches `limit + 1` so `paginate()` can derive `hasMore`/`nextCursor`
+    // without a count query. Default sort is `updatedAt` desc (with `id` as
+    // the tiebreaker).
     expect(mockService.list).toHaveBeenCalledWith({
-      limit: 50,
+      limit: 51,
       offset: 0,
       orderBy: 'updatedAt',
       orderDirection: 'desc',
@@ -79,9 +81,10 @@ describe('Sessions Routes (IT-1250)', () => {
 
     await app.request('http://localhost/?limit=10&offset=20');
 
-    // F07-01: same fixed sort as above.
+    // F07-01: same cursor-mode semantics — route overshoots by 1 to detect
+    // `hasMore`.
     expect(mockService.list).toHaveBeenCalledWith({
-      limit: 10,
+      limit: 11,
       offset: 20,
       orderBy: 'updatedAt',
       orderDirection: 'desc',

--- a/tests/integration/route-tasks.test.ts
+++ b/tests/integration/route-tasks.test.ts
@@ -65,11 +65,15 @@ describe('Tasks Routes (IT-1350)', () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.items).toHaveLength(2);
-    expect(body.data.totalCount).toBe(2);
+    // F07-01: cursor envelope returns {items, nextCursor, hasMore} without
+    // a synthesized totalCount that was just the page size.
+    expect(body.data.hasMore).toBe(false);
+    expect(body.data.nextCursor).toBeNull();
     expect(mockService.list).toHaveBeenCalledWith('cs-1', {
       column: undefined,
-      limit: 50,
-      offset: 0,
+      limit: 51,
+      orderBy: 'position',
+      orderDirection: 'asc',
     });
   });
 
@@ -78,10 +82,12 @@ describe('Tasks Routes (IT-1350)', () => {
 
     await app.request('http://localhost/?codespaceId=cs-1&column=in_progress');
 
+    // F07-01: cursor-paginated route fetches limit+1 and fixes the sort.
     expect(mockService.list).toHaveBeenCalledWith('cs-1', {
       column: 'in_progress',
-      limit: 50,
-      offset: 0,
+      limit: 51,
+      orderBy: 'position',
+      orderDirection: 'asc',
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses the four P1 findings in `specs/arch_review_april/07-api-surface.md`.

### F07-01 — Pagination: cursor spec vs offset reality
- Added `paginate<T>()` + `decodeRequestCursor()` helpers in `src/lib/api/pagination.ts`.
- Extended `TaskService.list()` and `SessionCrudService.list()` to accept an optional `cursor: { sortValue, id }` option that translates to a compound `(sortValue, id)` tuple comparison.
- Migrated the three highest-traffic list routes to the canonical cursor envelope:
  - `GET /api/tasks` (sort: `position` asc)
  - `GET /api/sessions` global list (sort: `updatedAt` desc; the filtered `codespaceId` path keeps its offset+`total` envelope because the UI reads `total` for filter-count badges)
  - `GET /api/events/log` (sort: `receivedAt` desc — was already cursor-shaped but used a bespoke `receivedAt|id` format; now uses the canonical base64 cursor)
- Rewrote `specs/application/api/pagination.md` to describe **cursor (canonical)** and **offset (legacy)** styles and annotate which endpoints live in each camp.
- Remaining offset endpoints can migrate opportunistically.

### F07-03 — `{ok:true, data:[]}` masking failures
- `codespaces.ts` skills handler now propagates `templateService.getMergedConfig` failures as `{ok:false, error}` instead of masking as empty.
- The five `events.ts` empty-list returns (all legitimate "user has no teams / no sources" states, not masked failures) now carry `source: 'empty'` so a future `source: 'degraded'` variant can signal an upstream outage without breaking clients.

### F07-04 — Rate limit: per-IP, in-process, multiplies across instances
- Refactored `src/lib/api/rate-limiter.ts` around a pluggable `keyFrom(ctx)` function preferring `userId` → `tokenId` → trusted-proxy-aware IP.
- Exposed a `RateLimitBackend` interface so the in-memory store can be swapped for Redis in one line without touching middleware call sites.
- The in-memory backend logs a one-time startup warning so multi-instance deployments know counters don't cross instances.
- **Scope reduction (noted in the finding):** did NOT introduce a Redis runtime dependency — the drop-in shape is captured in the JSDoc example on `rateLimiter()`. Follow-up is a ~30 LOC Redis `RateLimitBackend` gated on `REDIS_URL`.

### F07-05 — Request-ID never reaches services or event payloads
- Theme 10 F10-03 already plumbed `correlationId` through the durable-streams envelope via `getRequestId()` (AsyncLocalStorage). Verified end-to-end with a new regression test.
- `createLogger` already pulls `getRequestId()` on every call, so no per-service wiring is required as long as services run under the AsyncLocalStorage frame the router establishes.

## Test delta

+27 tests (9300 → 9327). New test files:

- `src/lib/api/__tests__/paginate-helper.test.ts` — 9 unit tests including a 100-row round-trip that asserts no duplicates / no skips.
- `tests/integration/cursor-pagination.test.ts` — 3 DB-backed tests iterating through 100 tasks and 100 sessions with real service code + SQLite.
- `src/lib/api/__tests__/request-id-propagation.test.ts` — 8 tests covering F07-05 end-to-end (header ↔ logger ↔ event metadata).
- `src/server/routes/__tests__/codespaces-skills.test.ts` — 3 tests for F07-03 (ensures infrastructure failure propagates, not masks).
- `src/lib/api/__tests__/rate-limiter.test.ts` — 5 new tests for F07-04 covering user-vs-IP separation, token-only skipping, custom `keyFrom`.

Existing tests updated to match the new shapes:
- `tests/integration/route-tasks.test.ts`, `tests/integration/route-sessions.test.ts`, `tests/integration/route-codespaces.test.ts`
- `src/server/routes/__tests__/tasks.test.ts`, `src/server/routes/__tests__/sessions.test.ts`
- `tests/api/tasks.test.ts`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx vitest run` — 9327 passed, 4 skipped (all pre-existing skips)
- [x] `bun run build` — app build clean (agent-runner's `bedrock-agentcore/runtime` type error is pre-existing and unrelated)
- [x] `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
