### PR TITLE
fix(arch-review): theme 08 — frontend (P1s)

### DIFF
--- a/specs/arch_review_april/08-frontend.md
+++ b/specs/arch_review_april/08-frontend.md
@@ -29,15 +29,23 @@ Stack: TanStack Start 1.167 + Router with `autoCodeSplitting`, TanStack DB, Reac
 
 ### F08-01: Every prior readiness critical is still open
 - **Priority**: P1
+- **Status**: Resolved (April 2026 remediation) — except console.* cleanup, see follow-up.
 - **Observation**: `specs/release_plan/08-frontend-readiness.md` C1-C5 all reproduce at HEAD. `fallback={null}` in six sites (`routes/index.tsx:511`, `codespaces/index.tsx:477`, `codespaces/$codespaceId/index.tsx:467`, `workflow-designer/index.tsx:599`, `live-task-view/index.tsx:249`, `global-shortcuts.tsx:387`). 229 `console.*` calls across 62 `src/app` files. Only three component error boundaries. `ui/connection-status-banner.tsx` exists but is never mounted.
 - **Risk**: Kanban render crash still wipes the route tree; blank panels on lazy-load; API outages produce inconsistent per-view errors.
 - **Recommendation**: One PR: wrap Kanban / WorkflowDesigner / SessionHistory in boundaries, replace `fallback={null}` with skeletons, mount `ConnectionStatusBanner` at `__root.tsx`, strip `console.debug/log` via Vite define. Close the readiness doc.
+- **Resolution**:
+  - Error boundaries: `KanbanBoard` now wrapped in `codespaces/$codespaceId/index.tsx`; `WorkflowDesigner` wrapped in `routes/designer/index.tsx` and `routes/catalog/$workflowId.tsx`; `SessionHistory` wrapped in `routes/sessions/index.tsx`. All use the shared `ErrorBoundary` from `src/app/components/ui/error-boundary.tsx` (added by F09-02, theme 09).
+  - Suspense skeletons: all six `fallback={null}` sites replaced with the shared `DialogLoadingFallback` (SR-only live region) or `PanelLoadingFallback` (skeleton scaffold) from `src/app/components/ui/suspense-fallbacks.tsx`.
+  - Connection banner: `ConnectionStatusBanner` mounted at `__root.tsx`, driven by a new `useGlobalConnectionStatus()` hook that combines `navigator.onLine`, the `online`/`offline` events, and a 60s `/api/health` poll with a 5s timeout and a two-failure debounce before escalating from `reconnecting` → `disconnected`.
+- **Follow-up**: The 229 `console.*` calls are intentionally out of scope for this PR — the change set would sprawl. Track as a dedicated follow-up: add a Biome rule forbidding `console.debug`/`console.log` in `src/app/**` and a Vite `define` to strip any survivors in production. Documented under `specs/release_plan/08-frontend-readiness.md` C2.
 
 ### F08-02: Frontend test directory is empty
 - **Priority**: P1
+- **Status**: Resolved (pre-existing, April 2026 — theme 09 F09-02).
 - **Observation**: `find src/app -name "*.test.*"` returns zero results. No component, hook, or route-loader tests. The `apiServerFetch<T>` double-wrap bug has a server-side test but 40+ frontend consumers have none. `use-session` rAF batching, seen-event dedupe, SSE reconnect state, Kanban DnD reorder, plan-approval transitions are all UI-untested.
 - **Risk**: Regressions land silently. Refactors to `use-session.ts` or `DurableStreamsClient` can break streaming without a CI signal.
 - **Recommendation**: Stand up Vitest + `@testing-library/react` + `jsdom`. Seed three tests: (a) `use-session` dedupe across reconnect, (b) flat-array shape of `apiClient.sessions.listEvents()`, (c) `TopologyErrorBoundary` recovers. Add `src/app` to the 3-way Vitest shard split.
+- **Resolution**: Addressed by theme 09 F09-02 — the shared `ErrorBoundary` plus the three seed tests (`src/app/__tests__/{api-client-shape,error-boundary,session-dedupe}.test.tsx`) landed in #172. Theme 08 adds two more seed suites on top: `connection-status-banner.test.tsx` (3 tests) and `suspense-fallbacks.test.tsx` (3 tests).
 
 ### F08-03: `warning` Tailwind classes are silent no-ops
 - **Priority**: P2

--- a/src/app/__tests__/connection-status-banner.test.tsx
+++ b/src/app/__tests__/connection-status-banner.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * F08-01 seed tests for `ConnectionStatusBanner`.
+ *
+ * The banner is mounted in `__root.tsx` via `useGlobalConnectionStatus`.
+ * These tests lock in the three status renderings so regressions on the
+ * global connectivity signal surface in CI.
+ */
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ConnectionStatusBanner } from '@/app/components/ui/connection-status-banner';
+
+describe('ConnectionStatusBanner', () => {
+  it('renders nothing when connected', () => {
+    const { container } = render(<ConnectionStatusBanner status="connected" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the reconnecting state with a role=alert', () => {
+    render(<ConnectionStatusBanner status="reconnecting" />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(/reconnecting/i);
+  });
+
+  it('renders the disconnected state with a role=alert', () => {
+    render(<ConnectionStatusBanner status="disconnected" />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(/connection lost/i);
+  });
+});

--- a/src/app/__tests__/suspense-fallbacks.test.tsx
+++ b/src/app/__tests__/suspense-fallbacks.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * F08-01 seed tests for the shared Suspense fallbacks.
+ *
+ * Verifies that the shared fallback replacements for the old `fallback={null}`
+ * sites render an accessible `role="status"` / `aria-busy="true"` region so
+ * screen readers announce that content is loading, and that the visible panel
+ * variant renders a skeleton scaffold (not an empty shell).
+ */
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  DialogLoadingFallback,
+  PanelLoadingFallback,
+} from '@/app/components/ui/suspense-fallbacks';
+
+describe('DialogLoadingFallback', () => {
+  it('renders an accessible status region that is visually hidden', () => {
+    render(<DialogLoadingFallback />);
+    const region = screen.getByRole('status');
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    // Visually hidden, but present in the accessibility tree.
+    expect(region).toHaveClass('sr-only');
+  });
+
+  it('supports a custom label for the SR announcement', () => {
+    render(<DialogLoadingFallback label="Loading new task dialog…" />);
+    expect(screen.getByRole('status')).toHaveTextContent('Loading new task dialog…');
+  });
+});
+
+describe('PanelLoadingFallback', () => {
+  it('renders a skeleton scaffold inside a role=status region', () => {
+    render(<PanelLoadingFallback />);
+    const region = screen.getByRole('status');
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    // The skeleton scaffold should produce at least one skeleton element.
+    expect(screen.getAllByTestId('skeleton-card').length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/components/features/global-shortcuts.tsx
+++ b/src/app/components/features/global-shortcuts.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from '@tanstack/react-router';
 import React, { Suspense, useCallback, useMemo } from 'react';
+import { DialogLoadingFallback } from '@/app/components/ui/suspense-fallbacks';
 import { type Shortcut, useKeyboardShortcuts } from '@/app/hooks/use-keyboard-shortcuts';
 import { useCodespaceContext } from '@/app/providers/codespace-context';
 import { useShortcutsContext } from '@/app/providers/shortcuts-provider';
@@ -384,7 +385,7 @@ export function GlobalShortcutsWithPicker(): React.JSX.Element {
         isLoading={isLoading}
         error={error}
       />
-      <Suspense fallback={null}>
+      <Suspense fallback={<DialogLoadingFallback label="Loading new codespace dialog…" />}>
         <NewProjectDialog
           open={isNewCodespaceDialogOpen}
           onOpenChange={(open) => (open ? openNewCodespaceDialog() : closeNewCodespaceDialog())}

--- a/src/app/components/features/live-task-view/index.tsx
+++ b/src/app/components/features/live-task-view/index.tsx
@@ -10,6 +10,7 @@ import {
   X,
 } from '@phosphor-icons/react';
 import React, { Suspense, useMemo, useState } from 'react';
+import { PanelLoadingFallback } from '@/app/components/ui/suspense-fallbacks';
 import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { AgentStatus, TaskColumn } from '@/db/schema/shared/enums.js';
 import { apiClient } from '@/lib/api/client';
@@ -320,7 +321,7 @@ export function LiveTaskView({
       </div>
 
       {/* Right: Audit Trail Panel */}
-      <Suspense fallback={null}>
+      <Suspense fallback={<PanelLoadingFallback />}>
         <AuditTrailPanel task={selectedTask} />
       </Suspense>
     </div>

--- a/src/app/components/features/workflow-designer/index.tsx
+++ b/src/app/components/features/workflow-designer/index.tsx
@@ -1,6 +1,7 @@
 import { CaretLeft, Warning } from '@phosphor-icons/react';
 import { type Edge, type Node, useEdgesState, useNodesState, type Viewport } from '@xyflow/react';
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { DialogLoadingFallback } from '@/app/components/ui/suspense-fallbacks';
 import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import '@xyflow/react/dist/style.css';
@@ -596,7 +597,7 @@ export function WorkflowDesigner({
       />
 
       {/* AI Generate Dialog */}
-      <Suspense fallback={null}>
+      <Suspense fallback={<DialogLoadingFallback label="Loading AI generate dialog…" />}>
         <AIGenerateDialog
           open={aiDialogOpen}
           onOpenChange={setAiDialogOpen}

--- a/src/app/components/ui/suspense-fallbacks.tsx
+++ b/src/app/components/ui/suspense-fallbacks.tsx
@@ -1,0 +1,73 @@
+/**
+ * Shared Suspense fallback components for lazy-loaded dialogs and panels.
+ *
+ * Replaces the six `fallback={null}` sites flagged in
+ * `specs/arch_review_april/08-frontend.md` F08-01: rendering `null` while a
+ * lazy chunk is downloading produces a "blank flash" for users on cold caches
+ * or slow links. These skeletons give a visible placeholder and also mark the
+ * element with `role="status"` / `aria-busy` so assistive tech announces the
+ * loading state.
+ *
+ * Two presets cover the common cases; callers can still pass a custom
+ * fallback when a more specialised layout is needed.
+ */
+import { Skeleton, SkeletonText } from '@/app/components/ui/skeleton';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Placeholder rendered inside a Suspense boundary whose child is a lazy-loaded
+ * dialog (NewProjectDialog, NewTaskDialog, AIGenerateDialog, …). Dialogs only
+ * mount after the user opens them, so `null` used to flash to an empty stage
+ * while the chunk downloaded. This renders an invisible, aria-live region so
+ * screen readers announce that content is loading without drawing a visible
+ * shell that might conflict with the real dialog's own opening animation.
+ */
+export function DialogLoadingFallback({
+  className,
+  label = 'Loading…',
+}: {
+  className?: string;
+  label?: string;
+}): React.JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      data-testid="dialog-loading-fallback"
+      className={cn('sr-only', className)}
+    >
+      {label}
+    </div>
+  );
+}
+DialogLoadingFallback.displayName = 'DialogLoadingFallback';
+
+/**
+ * Placeholder rendered inside a Suspense boundary whose child is a lazy-loaded
+ * visible panel (AuditTrailPanel, side panels, etc.). Renders a lightweight
+ * skeleton with a title and a few text lines so the layout doesn't jump when
+ * the real panel mounts.
+ */
+export function PanelLoadingFallback({
+  className,
+  lines = 5,
+}: {
+  className?: string;
+  lines?: number;
+}): React.JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      data-testid="panel-loading-fallback"
+      className={cn('flex h-full w-full flex-col gap-3 p-4', className)}
+    >
+      <Skeleton variant="text" height={18} width="40%" />
+      <SkeletonText lines={lines} lineHeight={12} lastLineWidth={60} />
+      <span className="sr-only">Loading panel…</span>
+    </div>
+  );
+}
+PanelLoadingFallback.displayName = 'PanelLoadingFallback';

--- a/src/app/hooks/use-global-connection-status.ts
+++ b/src/app/hooks/use-global-connection-status.ts
@@ -69,8 +69,24 @@ export function useGlobalConnectionStatus(): ConnectionStatus {
         setStatus('connected');
         return;
       }
+      // Non-2xx from /api/health — server is reachable but reporting degraded.
+      // Log so operators/devs can see API-down scenarios in the browser console
+      // rather than only inferring them from the banner.
+      console.warn(
+        '[useGlobalConnectionStatus] /api/health returned non-ok status',
+        res.status,
+        res.statusText
+      );
       consecutiveFailuresRef.current += 1;
-    } catch {
+    } catch (err) {
+      // fetch() rejected: network error, CORS, abort (timeout), DNS, etc.
+      // Surface the reason so a stuck probe or misconfigured origin is
+      // debuggable without attaching a network inspector.
+      const isAbort = err instanceof DOMException && err.name === 'AbortError';
+      console.warn(
+        '[useGlobalConnectionStatus] /api/health probe failed',
+        isAbort ? `(timed out after ${HEALTH_TIMEOUT_MS}ms)` : err
+      );
       consecutiveFailuresRef.current += 1;
     } finally {
       clearTimeout(timeout);

--- a/src/app/hooks/use-global-connection-status.ts
+++ b/src/app/hooks/use-global-connection-status.ts
@@ -1,0 +1,111 @@
+/**
+ * Global API connection health signal for the root shell's
+ * `ConnectionStatusBanner`.
+ *
+ * Combines three signals:
+ *   1. `navigator.onLine` — an immediate OS-level disconnect cue.
+ *   2. Window `online` / `offline` events — reactive updates without polling.
+ *   3. A low-frequency `/api/health` poll (60s) — catches the case where the
+ *      network is up but the API server is down or unreachable.
+ *
+ * F08-01 in `specs/arch_review_april/08-frontend.md` flagged the
+ * `ConnectionStatusBanner` component as unmounted. This hook provides the
+ * signal so the banner can be rendered once at the root and reflect global
+ * connectivity without each view having to plumb its own status.
+ */
+import { useCallback, useRef, useState } from 'react';
+import type { ConnectionStatus } from '@/app/hooks/use-connection-health';
+import { useEventListener } from '@/app/hooks/use-event-listener';
+import { useInterval } from '@/app/hooks/use-interval';
+import { useMountEffect } from '@/app/hooks/use-mount-effect';
+
+/**
+ * Poll interval in milliseconds for the `/api/health` probe. The banner
+ * already shows the OS-level offline signal instantly via the `offline`
+ * event, so the poll is a slow backstop; keeping it long (60s) avoids
+ * adding to the dev-only `setInterval` violations noted in CLAUDE.md.
+ */
+const HEALTH_POLL_MS = 60_000;
+
+/**
+ * Request timeout: if the server doesn't answer the health probe within
+ * `HEALTH_TIMEOUT_MS`, treat it as degraded. Short enough to avoid a stuck
+ * request blocking detection of a real outage.
+ */
+const HEALTH_TIMEOUT_MS = 5_000;
+
+/**
+ * On failure we show `reconnecting` first, then escalate to `disconnected`
+ * after this many consecutive misses. Prevents a single hiccup from flashing
+ * a scary banner.
+ */
+const FAILURES_BEFORE_DISCONNECTED = 2;
+
+export function useGlobalConnectionStatus(): ConnectionStatus {
+  const [status, setStatus] = useState<ConnectionStatus>(() =>
+    typeof navigator === 'undefined' || navigator.onLine ? 'connected' : 'disconnected'
+  );
+  const consecutiveFailuresRef = useRef(0);
+
+  const probeHealth = useCallback(async () => {
+    // If the browser already knows we're offline, don't bother.
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      consecutiveFailuresRef.current += 1;
+      setStatus('disconnected');
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
+    try {
+      const res = await fetch('/api/health', {
+        method: 'GET',
+        signal: controller.signal,
+        // Avoid caching — we want the live health of the origin.
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        consecutiveFailuresRef.current = 0;
+        setStatus('connected');
+        return;
+      }
+      consecutiveFailuresRef.current += 1;
+    } catch {
+      consecutiveFailuresRef.current += 1;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (consecutiveFailuresRef.current >= FAILURES_BEFORE_DISCONNECTED) {
+      setStatus('disconnected');
+    } else {
+      setStatus('reconnecting');
+    }
+  }, []);
+
+  // Online / offline events — reactive update without polling.
+  useEventListener(typeof window === 'undefined' ? null : window, 'online', () => {
+    consecutiveFailuresRef.current = 0;
+    setStatus('connected');
+  });
+  useEventListener(typeof window === 'undefined' ? null : window, 'offline', () => {
+    consecutiveFailuresRef.current += 1;
+    setStatus('disconnected');
+  });
+
+  // Kick off an initial probe on mount; don't await — we want mount to return.
+  useMountEffect(() => {
+    if (typeof window === 'undefined') return;
+    void probeHealth();
+  });
+
+  // Slow poll as a backstop for "network up, API down".
+  useInterval(
+    () => {
+      void probeHealth();
+    },
+    typeof window === 'undefined' ? null : HEALTH_POLL_MS
+  );
+
+  return status;
+}

--- a/src/app/routes/__root.tsx
+++ b/src/app/routes/__root.tsx
@@ -5,8 +5,10 @@ import {
   useRouter,
 } from '@tanstack/react-router';
 import { GlobalShortcutsWithPicker } from '@/app/components/features/global-shortcuts';
+import { ConnectionStatusBanner } from '@/app/components/ui/connection-status-banner';
 import { Toaster } from '@/app/components/ui/toaster';
 import { TooltipProvider } from '@/app/components/ui/tooltip';
+import { useGlobalConnectionStatus } from '@/app/hooks/use-global-connection-status';
 import { CodespaceContextProvider } from '@/app/providers/codespace-context';
 import { FolderContextProvider } from '@/app/providers/folder-context';
 import { ShortcutsProvider } from '@/app/providers/shortcuts-provider';
@@ -65,12 +67,16 @@ function NotFoundComponent() {
 }
 
 function RootComponent() {
+  // F08-01: Global connectivity banner — renders at the top of the shell when
+  // the API or network is unreachable so every route sees the same signal.
+  const connectionStatus = useGlobalConnectionStatus();
   return (
     <ShortcutsProvider>
       <FolderContextProvider>
         <CodespaceContextProvider>
           <TooltipProvider delayDuration={300}>
             <div className="min-h-screen bg-canvas text-fg">
+              <ConnectionStatusBanner status={connectionStatus} />
               <Outlet />
               <Toaster />
               <GlobalShortcutsWithPicker />

--- a/src/app/routes/catalog/$workflowId.tsx
+++ b/src/app/routes/catalog/$workflowId.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorkflowDesigner } from '@/app/components/features/workflow-designer';
 import { Button } from '@/app/components/ui/button';
+import { ErrorBoundary } from '@/app/components/ui/error-boundary';
 import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Workflow } from '@/db/schema';
 
@@ -225,7 +226,9 @@ function WorkflowDetailPage(): React.JSX.Element {
       }
     >
       <div className="h-full w-full" data-testid="workflow-detail-page">
-        <WorkflowDesigner initialWorkflow={workflow} readOnly={true} />
+        <ErrorBoundary label="Workflow Designer">
+          <WorkflowDesigner initialWorkflow={workflow} readOnly={true} />
+        </ErrorBoundary>
       </div>
     </LayoutShell>
   );

--- a/src/app/routes/codespaces/$codespaceId/index.tsx
+++ b/src/app/routes/codespaces/$codespaceId/index.tsx
@@ -15,6 +15,8 @@ import { LiveTaskView } from '@/app/components/features/live-task-view';
 import { SandboxIndicator } from '@/app/components/features/sandbox-indicator';
 import { TaskDetailDialog } from '@/app/components/features/task-detail-dialog/index';
 import { AIActionButton } from '@/app/components/ui/ai-action-button';
+import { ErrorBoundary } from '@/app/components/ui/error-boundary';
+import { DialogLoadingFallback } from '@/app/components/ui/suspense-fallbacks';
 import { useSandboxStatus } from '@/app/hooks/use-sandbox-status';
 import { useToast } from '@/app/hooks/use-toast';
 import type { Task } from '@/db/schema';
@@ -468,14 +470,16 @@ function CodespaceKanban(): React.JSX.Element {
       }
     >
       {viewMode === 'kanban' ? (
-        <KanbanBoard
-          tasks={tasks as Parameters<typeof KanbanBoard>[0]['tasks']}
-          onTaskMove={handleTaskMove as Parameters<typeof KanbanBoard>[0]['onTaskMove']}
-          onTaskClick={handleTaskClick as Parameters<typeof KanbanBoard>[0]['onTaskClick']}
-          onRunNow={handleRunNow}
-          onStopAgent={handleStopAgent}
-          onCancelTask={handleCancelTask}
-        />
+        <ErrorBoundary label="Kanban board">
+          <KanbanBoard
+            tasks={tasks as Parameters<typeof KanbanBoard>[0]['tasks']}
+            onTaskMove={handleTaskMove as Parameters<typeof KanbanBoard>[0]['onTaskMove']}
+            onTaskClick={handleTaskClick as Parameters<typeof KanbanBoard>[0]['onTaskClick']}
+            onRunNow={handleRunNow}
+            onStopAgent={handleStopAgent}
+            onCancelTask={handleCancelTask}
+          />
+        </ErrorBoundary>
       ) : (
         <LiveTaskView
           tasks={tasks}
@@ -503,7 +507,7 @@ function CodespaceKanban(): React.JSX.Element {
       )}
 
       {/* New Task Dialog - AI-powered task creation with streaming (lazy-loaded) */}
-      <Suspense fallback={null}>
+      <Suspense fallback={<DialogLoadingFallback label="Loading new task dialog…" />}>
         <NewTaskDialog
           codespaceId={codespaceId}
           open={showNewTask}

--- a/src/app/routes/codespaces/index.tsx
+++ b/src/app/routes/codespaces/index.tsx
@@ -16,6 +16,7 @@ const NewProjectDialog = React.lazy(() =>
 import { AddProjectCard, ProjectCard } from '@/app/components/features/project-card';
 import { AgentPaneLogo } from '@/app/components/ui/agentpane-logo';
 import { Button } from '@/app/components/ui/button';
+import { DialogLoadingFallback } from '@/app/components/ui/suspense-fallbacks';
 import {
   apiClient,
   type ProjectSummaryItem,
@@ -474,7 +475,7 @@ function CodespacesPage(): React.JSX.Element {
         )}
       </div>
 
-      <Suspense fallback={null}>
+      <Suspense fallback={<DialogLoadingFallback label="Loading new codespace dialog…" />}>
         <NewProjectDialog
           open={showNewCodespace}
           onOpenChange={setShowNewCodespace}

--- a/src/app/routes/designer/index.tsx
+++ b/src/app/routes/designer/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 import { EmptyState } from '@/app/components/features/empty-state';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { WorkflowDesigner } from '@/app/components/features/workflow-designer';
+import { ErrorBoundary } from '@/app/components/ui/error-boundary';
 import { useWatchEffect } from '@/app/hooks/use-watch-effect';
 import type { Workflow } from '@/db/schema';
 
@@ -97,7 +98,9 @@ function DesignerPage(): React.JSX.Element {
   return (
     <LayoutShell breadcrumbs={[{ label: breadcrumbLabel }]}>
       <div className="h-full w-full" data-testid="designer-page">
-        <WorkflowDesigner initialWorkflow={workflow ?? undefined} />
+        <ErrorBoundary label="Workflow Designer">
+          <WorkflowDesigner initialWorkflow={workflow ?? undefined} />
+        </ErrorBoundary>
       </div>
     </LayoutShell>
   );

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -16,6 +16,7 @@ import type { ProjectStatus, TaskCounts } from '@/app/components/features/projec
 import { AddProjectCard, ProjectCard } from '@/app/components/features/project-card';
 import { AgentPaneLogo } from '@/app/components/ui/agentpane-logo';
 import { Button } from '@/app/components/ui/button';
+import { DialogLoadingFallback } from '@/app/components/ui/suspense-fallbacks';
 import {
   apiClient,
   type CodespaceListItem,
@@ -508,7 +509,7 @@ function Dashboard(): React.JSX.Element {
         )}
       </div>
 
-      <Suspense fallback={null}>
+      <Suspense fallback={<DialogLoadingFallback label="Loading new codespace dialog…" />}>
         <NewProjectDialog
           open={showNewProject}
           onOpenChange={setShowNewProject}

--- a/src/app/routes/sessions/index.tsx
+++ b/src/app/routes/sessions/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
 import { LayoutShell } from '@/app/components/features/layout-shell';
 import { SessionHistory } from '@/app/components/features/session-history';
+import { ErrorBoundary } from '@/app/components/ui/error-boundary';
 import { useMountEffect } from '@/app/hooks/use-mount-effect';
 import { apiClient } from '@/lib/api/client';
 
@@ -112,20 +113,22 @@ function SessionsPage(): React.JSX.Element {
   return (
     <LayoutShell breadcrumbs={[{ label: 'Sessions' }]}>
       <div className="flex h-full w-full flex-col">
-        <SessionHistory
-          sessions={filteredSessions}
-          projects={codespaces}
-          selectedProjectId={selectedCodespaceId}
-          onProjectChange={setSelectedCodespaceId}
-          isLoading={isLoading}
-          onOpen={(sessionId) => navigate({ to: '/sessions/$sessionId', params: { sessionId } })}
-          onViewTask={(taskId, codespaceId) =>
-            navigate({
-              to: '/codespaces/$codespaceId/tasks/$taskId',
-              params: { codespaceId, taskId },
-            })
-          }
-        />
+        <ErrorBoundary label="Session history">
+          <SessionHistory
+            sessions={filteredSessions}
+            projects={codespaces}
+            selectedProjectId={selectedCodespaceId}
+            onProjectChange={setSelectedCodespaceId}
+            isLoading={isLoading}
+            onOpen={(sessionId) => navigate({ to: '/sessions/$sessionId', params: { sessionId } })}
+            onViewTask={(taskId, codespaceId) =>
+              navigate({
+                to: '/codespaces/$codespaceId/tasks/$taskId',
+                params: { codespaceId, taskId },
+              })
+            }
+          />
+        </ErrorBoundary>
       </div>
     </LayoutShell>
   );


### PR DESCRIPTION
## Summary

Addresses both P1 findings in `specs/arch_review_april/08-frontend.md`.

### F08-01 — Readiness criticals (resolved, except console.* follow-up)

- **Error boundaries** — `KanbanBoard` (in `codespaces/$codespaceId/index.tsx`), `WorkflowDesigner` (in `routes/designer/index.tsx` and `routes/catalog/$workflowId.tsx`), and `SessionHistory` (in `routes/sessions/index.tsx`) are now wrapped in the shared `ErrorBoundary` added by theme 09 F09-02 (#172). A render crash in any of these feature views no longer unmounts the whole shell.
- **Suspense skeletons** — all six `fallback={null}` sites replaced with two new shared fallbacks in `src/app/components/ui/suspense-fallbacks.tsx`:
  - `DialogLoadingFallback` — visually hidden `role="status"` + `aria-busy="true"` region for lazy-loaded dialogs (`NewProjectDialog`, `NewTaskDialog`, `AIGenerateDialog`). Avoids the opening-animation conflict a full skeleton would cause.
  - `PanelLoadingFallback` — skeleton scaffold with a title and text lines for visible lazy panels (`AuditTrailPanel`). Prevents layout jump when the real panel mounts.
- **Connection banner** — `ConnectionStatusBanner` is now mounted at `__root.tsx`, driven by a new `useGlobalConnectionStatus()` hook (`src/app/hooks/use-global-connection-status.ts`) that composes:
  - `navigator.onLine` for the initial signal
  - window `online` / `offline` events (wired via `useEventListener` from the sanctioned effect-factory hooks) for reactive updates
  - a 60 s `/api/health` poll (via `useInterval`) with a 5 s `AbortController` timeout and a two-failure debounce before escalating from `reconnecting` → `disconnected`

### F08-02 — Frontend zero-tests (pre-existing, theme 09)

Already addressed in #172 (theme 09 F09-02) with the shared `ErrorBoundary`, jsdom test project, and three seed tests. Theme 08 adds two further seed suites on top:

- `src/app/__tests__/connection-status-banner.test.tsx` (3 tests) — locks in the `connected` / `reconnecting` / `disconnected` rendering contract.
- `src/app/__tests__/suspense-fallbacks.test.tsx` (3 tests) — verifies the new shared fallbacks render an accessible `role="status"` region and, for the panel variant, a skeleton scaffold.

### Out of scope / follow-up

The 229 `console.*` calls are deliberately not migrated in this PR (would sprawl the diff across 62 files). Tracked as a follow-up in the spec: add a Biome rule forbidding `console.debug`/`console.log` in `src/app/**` and a Vite `define` strip for any survivors in production.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun vitest run --project jsdom` — 484/484 pass (5 new tests)
- [x] `bun vitest run` — full suite, 9345/9349 pass (4 skipped, pre-existing)
- [x] `bun run build` — Vite build succeeds (agent-runner `bedrock-agentcore/runtime` resolution error pre-exists on `p0-p1-april` and is unrelated)
- [ ] Manual QA of kanban / designer / sessions — cause a render throw, verify shell stays and Retry resets
- [ ] Manual QA of connection banner — toggle DevTools offline, verify banner appears; `/api/health` 500 should show `reconnecting` then `disconnected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
