### PR TITLE
fix(F05-05): add missing PG event_outbox schema module

### DIFF
--- a/src/db/schema/postgres/event-outbox.ts
+++ b/src/db/schema/postgres/event-outbox.ts
@@ -1,0 +1,43 @@
+/**
+ * event_outbox — F05-05 (Postgres).
+ *
+ * Transactional outbox for durable-streams publishes. A service that needs
+ * exactly-once delivery writes a row to this table inside the same Postgres
+ * transaction as the state change that produced the event. The
+ * `EventOutboxRelayService` polls every 50ms, publishes to Caddy, and marks
+ * rows `published` (hard-deleted after a retention window).
+ */
+
+import { createId } from '@paralleldrive/cuid2';
+import { sql } from 'drizzle-orm';
+import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const eventOutbox = pgTable(
+  'event_outbox',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    streamId: text('stream_id').notNull(),
+    type: text('type').notNull(),
+    payload: text('payload').notNull(),
+    status: text('status', { enum: ['pending', 'published', 'dead'] })
+      .notNull()
+      .default('pending'),
+    attempts: integer('attempts').notNull().default(0),
+    nextAttemptAt: timestamp('next_attempt_at', { withTimezone: true })
+      .notNull()
+      .default(sql`now()`),
+    lastError: text('last_error'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().default(sql`now()`),
+    publishedAt: timestamp('published_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('event_outbox_status_idx').on(table.status),
+    index('event_outbox_next_attempt_at_idx').on(table.nextAttemptAt),
+    index('event_outbox_status_next_attempt_idx').on(table.status, table.nextAttemptAt),
+  ]
+);
+
+export type EventOutboxRow = typeof eventOutbox.$inferSelect;
+export type NewEventOutboxRow = typeof eventOutbox.$inferInsert;

--- a/src/db/schema/postgres/index.ts
+++ b/src/db/schema/postgres/index.ts
@@ -10,6 +10,7 @@ export * from './codespace-tags';
 export * from './codespaces';
 export * from './dream-sessions';
 export * from './event-log';
+export * from './event-outbox';
 export * from './event-sources';
 export * from './event-subscriptions';
 export * from './folder-members';


### PR DESCRIPTION
Schema drift failed on PR #176 (p0-p1-april \u2192 main). Theme 05 F05-05 outbox landed SQLite + PG migration but not the Drizzle PG schema module. This PR ports it.

Drift check: PASS. Typecheck: clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
