### PR TITLE
fix(arch-review): follow-up to #176 — tool whitelist default and PG schema drift

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -308,7 +308,7 @@ All file paths in commits and PRs should be relative to the worktree root. The w
 
 ### Publishing `@agentpane/cli-monitor` to npm
 
-The CLI monitor package lives at `packages/cli-monitor`. To publish:
+The CLI monitor package lives at `packages/cli-monitor` (current version: `0.2.1`). To publish:
 
 ```bash
 cd packages/cli-monitor
@@ -316,10 +316,10 @@ npm version patch --no-git-tag-version   # bump version
 npm publish --//registry.npmjs.org/:_authToken=<token>
 ```
 
-- The `prepublishOnly` script runs tests and builds automatically.
-- **npm access token** is stored in `/specs/CLI_monitor/.env` (`npm_access_token`). Use this token for the `--//registry.npmjs.org/:_authToken=` flag.
+- The `prepublishOnly` script runs tests and builds (`bun run test && bun run build:js`) automatically.
+- **npm access token** — ask the user for it; do not commit or hardcode. The previous `/specs/CLI_monitor/.env` path no longer exists.
 - The package is published with `"access": "public"` under the `@agentpane` scope.
-- Build output: `dist/index.js` (single Bun-bundled file, ~75 KB).
+- Build output: `dist/index.js` (single Bun-bundled Node target). The `build` script also compiles platform binaries via `bun build --compile`.
 
 ## Agent Execution Architecture
 
@@ -484,9 +484,13 @@ OAuth tokens passed via `ANTHROPIC_API_KEY` env var are blocked by the API, whic
 |------|---------|
 | `agent-runner/src/index.ts` | Entry point for Claude Agent SDK inside container |
 | `agent-runner/src/event-emitter.ts` | Emits structured events for real-time UI updates |
+| `agent-runner/src/agentcore-handler.ts` | AWS Bedrock AgentCore integration |
 | `docker/Dockerfile.agent-sandbox` | Docker image with Claude CLI and agent runner |
 | `docker/entrypoint.sh` | Fixes permissions for bind-mounted volumes |
-| `src/services/container-agent.service.ts` | Orchestrates container creation and agent execution |
+| `src/services/container-agent.service.ts` | Top-level re-export / orchestration entry |
+| `src/services/container-agent/container-agent.service.ts` | Main orchestration (creation + execution) |
+| `src/services/container-agent/plan-approval.service.ts` | Plan ready / approve / reject transitions |
+| `src/services/container-agent/agent-review.service.ts` | Post-execution review and merge |
 
 ### Agent Runner Configuration
 
@@ -542,42 +546,54 @@ When performing any research, concurrent subagents can be used for performance a
 
 ## Use this tech stack
 
-| Layer              | Technology       | Package                                                                                             | Version          |
-| ------------------ | ---------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
-| Runtime            | Bun              | https://bun.sh                                                                                      | 1.3.10           |
-| Build              | Vite             | vite (https://github.com/vitejs/vite)                                                               | 8.0.1            |
-| Framework          | TanStack Start   | @tanstack/react-start (https://github.com/TanStack/router)                                          | 1.166.1          |
-| API Router         | Hono             | hono (https://github.com/honojs/hono)                                                               | 4.12.7           |
-| Database           | SQLite           | better-sqlite3 (https://github.com/WiseLibs/better-sqlite3)                                         | 12.8.0           |
-| ORM                | Drizzle          | drizzle-orm + drizzle-kit (https://github.com/drizzle-team/drizzle-orm)                             | 0.45.1 / 0.31.10 |
-| Client State       | TanStack DB      | @tanstack/db + @tanstack/react-db (https://github.com/TanStack/db)                                  | 0.5.33 / 0.1.77  |
-| Agent Events       | Durable Streams  | @durable-streams/* (https://github.com/durable-streams/durable-streams)                              | 0.2.x            |
-| AI / Agents        | Claude Agent SDK | @anthropic-ai/claude-agent-sdk (https://github.com/anthropics/claude-agent-sdk-typescript)          | 0.2.76           |
-| AI / API           | Anthropic SDK    | @anthropic-ai/sdk (https://github.com/anthropics/anthropic-sdk-typescript)                          | 0.78.0           |
-| Memory             | Honcho           | @honcho-ai/sdk (https://github.com/plastic-labs/honcho)                                             | 2.0.1            |
-| UI                 | Radix + Tailwind | @radix-ui/* + tailwindcss (https://github.com/radix-ui/primitives)                                  | 1.2.4 / 4.1.18   |
-| Workflow Designer  | React Flow       | @xyflow/react (https://github.com/xyflow/xyflow)                                                    | 12.10.1          |
-| Graph Layout       | ELK              | elkjs (https://github.com/kieler/elkjs)                                                             | 0.11.0           |
-| Drag & Drop        | dnd-kit          | @dnd-kit/core + @dnd-kit/sortable (https://github.com/clauderic/dnd-kit)                            | 6.3.1 / 10.0.0   |
-| Icons              | Phosphor         | @phosphor-icons/react (https://github.com/phosphor-icons/react)                                     | 2.1.10           |
-| Testing            | Vitest           | vitest (https://github.com/vitest-dev/vitest)                                                       | 4.0.16           |
-| UI Testing         | Agent Browser    | agent-browser (https://github.com/anthropics/agent-browser)                                         | 0.7.6            |
-| E2E Testing        | Playwright       | playwright + @playwright/test (https://github.com/microsoft/playwright)                             | 1.58.1           |
-| Linting/Formatting | Biome            | @biomejs/biome (https://github.com/biomejs/biome)                                                   | 2.4.4            |
-| CI/CD              | GitHub Actions   | https://github.com/features/actions                                                                 | -                |
+Versions below reflect `package.json` as of 2026-04-21. Run `jq '.dependencies,.devDependencies' package.json` to verify before relying on specific pins.
+
+| Layer              | Technology          | Package                                                                                             | Version           |
+| ------------------ | ------------------- | --------------------------------------------------------------------------------------------------- | ----------------- |
+| Runtime            | Bun + Node          | https://bun.sh (Node >=24)                                                                          | Bun 1.3.12 / Node 24+ |
+| Build              | Vite                | vite (https://github.com/vitejs/vite)                                                               | ^8.0.8            |
+| Framework          | TanStack Start      | @tanstack/react-start + @tanstack/react-router (https://github.com/TanStack/router)                 | ^1.167.41 / ^1.168.22 |
+| API Router         | Hono                | hono (https://github.com/honojs/hono)                                                               | ^4.12.14          |
+| Database           | SQLite + PostgreSQL | better-sqlite3 + postgres (https://github.com/WiseLibs/better-sqlite3)                              | ^12.9.0 / ^3.4.9  |
+| ORM                | Drizzle             | drizzle-orm + drizzle-kit (https://github.com/drizzle-team/drizzle-orm)                             | ^0.45.2 / ^0.31.10 |
+| Client State       | TanStack DB         | @tanstack/db + @tanstack/react-db (https://github.com/TanStack/db)                                  | 0.6.5 / ^0.1.83   |
+| Agent Events       | Durable Streams     | @durable-streams/client + server + state (https://github.com/durable-streams/durable-streams)       | 0.2.3 / 0.3.1 / 0.2.5 |
+| AI / Agents        | Claude Agent SDK    | @anthropic-ai/claude-agent-sdk (https://github.com/anthropics/claude-agent-sdk-typescript)          | ^0.2.113          |
+| AI / API           | Anthropic SDK       | @anthropic-ai/sdk (https://github.com/anthropics/anthropic-sdk-typescript)                          | ^0.90.0           |
+| UI                 | Radix + Tailwind    | @radix-ui/* + tailwindcss (https://github.com/radix-ui/primitives)                                  | 1.x / ^4.2.2      |
+| Workflow Designer  | React Flow          | @xyflow/react (https://github.com/xyflow/xyflow)                                                    | 12.10.2           |
+| Graph Layout       | ELK                 | elkjs (https://github.com/kieler/elkjs)                                                             | ^0.11.1           |
+| Drag & Drop        | dnd-kit             | @dnd-kit/core + @dnd-kit/sortable (https://github.com/clauderic/dnd-kit)                            | ^6.3.1 / ^10.0.0  |
+| Icons              | Phosphor            | @phosphor-icons/react (https://github.com/phosphor-icons/react)                                     | ^2.1.10           |
+| React              | React 19            | react + react-dom                                                                                   | ^19.2.5           |
+| Testing            | Vitest              | vitest (https://github.com/vitest-dev/vitest)                                                       | 4.1.4             |
+| UI Testing         | Agent Browser       | agent-browser (https://github.com/anthropics/agent-browser)                                         | 0.26.0            |
+| E2E Testing        | Playwright          | playwright + @playwright/test (https://github.com/microsoft/playwright)                             | ^1.59.1           |
+| Mutation Testing   | Stryker             | @stryker-mutator/core + vitest-runner (https://github.com/stryker-mutator/stryker-js)               | ^9.6.1            |
+| Linting/Formatting | Biome               | @biomejs/biome (https://github.com/biomejs/biome)                                                   | ^2.4.12           |
+| TypeScript         | tsc                 | typescript                                                                                          | ^6.0.3            |
+| CI/CD              | GitHub Actions      | https://github.com/features/actions                                                                 | -                 |
+
+> **Note**: Honcho (`@honcho-ai/sdk`) was previously listed but is **not installed**. Memory is currently implemented in-app without Honcho.
 
 ### Utility Libraries
 
-| Package                  | Version | Purpose                                |
-| ------------------------ | ------- | -------------------------------------- |
-| class-variance-authority | 0.7.1   | Component variant styling (cva)        |
-| @paralleldrive/cuid2     | 3.3.0   | Secure collision-resistant IDs         |
-| zod                      | 4.3.6   | Schema validation                      |
-| @radix-ui/react-slot     | 1.2.4   | asChild prop support                   |
-| @tailwindcss/vite        | 4.2.2   | Tailwind v4 Vite plugin                |
-| octokit                  | 5.0.5   | GitHub API client (REST + GraphQL)     |
-| react-markdown           | 10.1.0  | Markdown rendering                     |
-| dockerode                | 4.0.10  | Docker API client                      |
-| @kubernetes/client-node  | 1.4.0   | Kubernetes API client                  |
-| vite                     | 8.0.1   | Build tool                             |
-| react                    | 19.2.4  | UI framework                           |
+| Package                  | Version  | Purpose                                |
+| ------------------------ | -------- | -------------------------------------- |
+| class-variance-authority | ^0.7.1   | Component variant styling (cva)        |
+| @paralleldrive/cuid2     | ^3.3.0   | Secure collision-resistant IDs         |
+| zod                      | 4.3.6    | Schema validation                      |
+| @radix-ui/react-slot     | ^1.2.4   | asChild prop support                   |
+| @tailwindcss/vite        | ^4.2.2   | Tailwind v4 Vite plugin                |
+| octokit                  | ^5.0.5   | GitHub API client (REST + GraphQL)     |
+| react-markdown           | ^10.1.0  | Markdown rendering                     |
+| dockerode                | ^4.0.10  | Docker API client                      |
+| @kubernetes/client-node  | ^1.4.0   | Kubernetes API client                  |
+| @aws-sdk/client-sts      | ^3.1032.0 | AWS STS client (Terraform composer)   |
+| @cdktf/hcl2json          | ^0.21.0  | HCL ↔ JSON parsing (Terraform)         |
+| dompurify                | ^3.4.0   | HTML sanitization                      |
+| shiki                    | ^4.0.2   | Syntax highlighting                    |
+| yaml                     | ^2.8.3   | YAML parsing                           |
+| cron-parser              | ^5.5.0   | Cron expression parsing                |
+| fast-check               | ^4.7.0   | Property-based testing (dev)           |
+| knip                     | ^6.4.1   | Dead-code detection (dev)              |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -360,19 +360,6 @@ When a task is moved to `in_progress` (via drag-drop on the Kanban board):
    - Executes the approved plan
    - On completion: task moves to `waiting_approval`
 
-### Team Mode
-
-Team mode enables parallel agent execution for complex tasks. When the planning agent calls `ExitPlanMode` with `launchSwarm: true`, the execution phase spawns multiple sub-agents that work concurrently on different parts of the plan. Each sub-agent gets its own worktree for isolated work.
-
-```typescript
-interface ExitPlanModeOptions {
-  allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-  launchSwarm?: boolean;      // Enable team mode
-  teammateCount?: number;     // Number of parallel agents
-  pushToRemote?: boolean;     // Remote session support
-}
-```
-
 ### Key Files
 
 | File | Purpose |

--- a/src/app/components/features/project-settings.tsx
+++ b/src/app/components/features/project-settings.tsx
@@ -169,7 +169,8 @@ export function ProjectSettings({
     project.config ?? {
       worktreeRoot: '.worktrees',
       defaultBranch: 'main',
-      allowedTools: [],
+      // F06-06: `[]` now denies all tools. `['*']` preserves the open-access default.
+      allowedTools: ['*'],
       maxTurns: 50,
     }
   );

--- a/src/db/schema/postgres/event-outbox.ts
+++ b/src/db/schema/postgres/event-outbox.ts
@@ -22,7 +22,8 @@ export const eventOutbox = pgTable(
     type: text('type').notNull(),
     // Migration 0012 creates this column as JSONB. Drizzle was previously declared as
     // `text` which caused a schema drift (caught by tests/integration/*-schema-drift.test.ts).
-    payload: jsonb('payload').notNull(),
+    // The `$type` annotation gives consumers a typed handle instead of `unknown`.
+    payload: jsonb('payload').$type<Record<string, unknown>>().notNull(),
     status: text('status', { enum: ['pending', 'published', 'dead'] })
       .notNull()
       .default('pending'),

--- a/src/db/schema/postgres/event-outbox.ts
+++ b/src/db/schema/postgres/event-outbox.ts
@@ -10,7 +10,7 @@
 
 import { createId } from '@paralleldrive/cuid2';
 import { sql } from 'drizzle-orm';
-import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 export const eventOutbox = pgTable(
   'event_outbox',
@@ -20,7 +20,9 @@ export const eventOutbox = pgTable(
       .$defaultFn(() => createId()),
     streamId: text('stream_id').notNull(),
     type: text('type').notNull(),
-    payload: text('payload').notNull(),
+    // Migration 0012 creates this column as JSONB. Drizzle was previously declared as
+    // `text` which caused a schema drift (caught by tests/integration/*-schema-drift.test.ts).
+    payload: jsonb('payload').notNull(),
     status: text('status', { enum: ['pending', 'published', 'dead'] })
       .notNull()
       .default('pending'),

--- a/src/lib/github/config-sync.ts
+++ b/src/lib/github/config-sync.ts
@@ -1,6 +1,7 @@
 import type { Octokit } from 'octokit';
 import { z } from 'zod';
 import type { CodespaceConfig } from '../../db/schema';
+import { ALLOW_ALL_TOOLS } from '../constants/tools.js';
 import { GitHubErrors } from '../errors/github-errors.js';
 import type { Result } from '../utils/result.js';
 import { err, ok } from '../utils/result.js';
@@ -81,7 +82,8 @@ export async function syncConfigFromGitHub(
       initScript: validationResult.data.initScript,
       envFile: validationResult.data.envFile ?? '.env',
       defaultBranch: validationResult.data.defaultBranch ?? 'main',
-      allowedTools: validationResult.data.allowedTools ?? [],
+      // F06-06: `[]` fails closed. Preserve pre-F06-06 default when user omits the field.
+      allowedTools: validationResult.data.allowedTools ?? ALLOW_ALL_TOOLS,
       maxTurns: validationResult.data.maxTurns ?? 50,
       model: validationResult.data.model,
       systemPrompt: validationResult.data.systemPrompt,

--- a/src/services/agent/agent-crud.service.ts
+++ b/src/services/agent/agent-crud.service.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq } from 'drizzle-orm';
 import type { Agent, AgentConfig, NewAgent } from '../../db/schema';
 import { agents, codespaces } from '../../db/schema';
+import { ALLOW_ALL_TOOLS } from '../../lib/constants/tools.js';
 import type { AgentError } from '../../lib/errors/agent-errors.js';
 import { AgentErrors } from '../../lib/errors/agent-errors.js';
 import type { ValidationError } from '../../lib/errors/validation-errors.js';
@@ -35,8 +36,11 @@ export class AgentCrudService {
       return err(ValidationErrors.INVALID_ID('codespaceId'));
     }
 
+    // F06-06: `[]` means "deny all tools" (fail-closed). When no explicit
+    // config is set at either level, fall back to `ALLOW_ALL_TOOLS` (`['*']`)
+    // to preserve the pre-F06-06 default of "no config = open access".
     const config: AgentConfig = {
-      allowedTools: input.config?.allowedTools ?? codespace.config?.allowedTools ?? [],
+      allowedTools: input.config?.allowedTools ?? codespace.config?.allowedTools ?? ALLOW_ALL_TOOLS,
       maxTurns: input.config?.maxTurns ?? codespace.config?.maxTurns ?? 50,
       model: input.config?.model ?? codespace.config?.model,
       systemPrompt: input.config?.systemPrompt ?? codespace.config?.systemPrompt,
@@ -134,7 +138,8 @@ export class AgentCrudService {
     }
 
     const mergedConfig: AgentConfig = {
-      allowedTools: input.allowedTools ?? existing.value.config?.allowedTools ?? [],
+      // F06-06: see create() — fall back to ALLOW_ALL_TOOLS when no config set.
+      allowedTools: input.allowedTools ?? existing.value.config?.allowedTools ?? ALLOW_ALL_TOOLS,
       maxTurns: input.maxTurns ?? existing.value.config?.maxTurns ?? 50,
       model: input.model ?? existing.value.config?.model,
       systemPrompt: input.systemPrompt ?? existing.value.config?.systemPrompt,

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -4,6 +4,7 @@ import type { TaskColumn } from '../../db/schema';
 import { agentRuns, agents, codespaces, sessions, tasks, worktrees } from '../../db/schema';
 import { handleAgentError } from '../../lib/agents/recovery.js';
 import { runAgentExecution, runAgentPlanning } from '../../lib/agents/stream-handler.js';
+import { ALLOW_ALL_TOOLS } from '../../lib/constants/tools.js';
 
 import type { AgentError } from '../../lib/errors/agent-errors.js';
 import { AgentErrors } from '../../lib/errors/agent-errors.js';
@@ -592,7 +593,8 @@ export class AgentExecutionService {
       session.value.id,
       taskPrompt,
       {
-        allowedTools: agent.config?.allowedTools ?? [],
+        // F06-06: `[]` fails closed. Fall back to ALLOW_ALL_TOOLS when no config set.
+        allowedTools: agent.config?.allowedTools ?? ALLOW_ALL_TOOLS,
         maxTurns: agent.config?.maxTurns ?? 50,
         model: resolvedModel,
         cwd: worktree.value.path,
@@ -1210,7 +1212,8 @@ export class AgentExecutionService {
         agentId,
         sessionId,
         prompt,
-        allowedTools: agent.config?.allowedTools ?? [],
+        // F06-06: `[]` fails closed. Fall back to ALLOW_ALL_TOOLS when no config set.
+        allowedTools: agent.config?.allowedTools ?? ALLOW_ALL_TOOLS,
         maxTurns: agent.config?.maxTurns ?? 50,
         model: resolvedModel,
         cwd,

--- a/src/services/container-agent/container-exec.service.ts
+++ b/src/services/container-agent/container-exec.service.ts
@@ -16,6 +16,7 @@ import type { CompleteEventMetrics, ContainerBridge } from '../../lib/agents/con
 import { createContainerBridge } from '../../lib/agents/container-bridge.js';
 import { DEFAULT_AGENT_MODEL, getFullModelId } from '../../lib/constants/models.js';
 import { CONTAINER_WORKSPACE_PATH } from '../../lib/constants/sandbox.js';
+import { ALLOW_ALL_TOOLS } from '../../lib/constants/tools.js';
 import { getRequestId } from '../../lib/context/request-context.js';
 import type { SandboxError } from '../../lib/errors/sandbox-errors.js';
 import { SandboxErrors } from '../../lib/errors/sandbox-errors.js';
@@ -450,7 +451,8 @@ export class ContainerExecService {
     const agentConfig: AgentConfig = {
       model: resolvedModel ?? getFullModelId(DEFAULT_AGENT_MODEL),
       maxTurns: maxTurns ?? codespace.config?.maxTurns ?? 50,
-      allowedTools: codespace.config?.allowedTools ?? [],
+      // F06-06: `[]` fails closed. Fall back to ALLOW_ALL_TOOLS when no config set.
+      allowedTools: codespace.config?.allowedTools ?? ALLOW_ALL_TOOLS,
     };
     log.info('Resolved agent config', {
       data: { model: agentConfig.model, maxTurns: agentConfig.maxTurns },

--- a/tests/lib/github/github.test.ts
+++ b/tests/lib/github/github.test.ts
@@ -214,7 +214,10 @@ describe('GitHub Config Sync', () => {
         expect(result.value.config.worktreeRoot).toBe('.worktrees');
         expect(result.value.config.defaultBranch).toBe('main');
         expect(result.value.config.maxTurns).toBe(50);
-        expect(result.value.config.allowedTools).toEqual([]);
+        // F06-06: when allowedTools is missing from the GitHub config, we
+        // default to ALLOW_ALL_TOOLS (`['*']`) to preserve pre-F06-06
+        // "no config = open access". An explicit `[]` still fails closed.
+        expect(result.value.config.allowedTools).toEqual(['*']);
         expect(result.value.config.envFile).toBe('.env');
       }
     });


### PR DESCRIPTION
## Summary

Follow-up to #176 addressing two critical and one low-severity issue surfaced by a post-merge code review.

**Critical — tool whitelist `[]` silently denies all tools (F06-06 caller regression).**
#176 flipped the whitelist semantic (an empty `allowedTools` array now fails closed). But 7 call-sites still passed `?? []` as the "no config set" fallback, so every agent/codespace created without an explicit `allowedTools` entry would silently deny every tool on its next run. Switched those fallbacks to the `ALLOW_ALL_TOOLS` (`['*']`) sentinel so the pre-F06-06 default of "no config = open access" is preserved, while an explicit `[]` continues to fail closed as F06-06 intends.

Files changed:
- `src/services/agent/agent-crud.service.ts` (create, update)
- `src/services/agent/agent-execution.service.ts` (2 call-sites into `runAgentExecution` / `executeAgentAsync`)
- `src/services/container-agent/container-exec.service.ts`
- `src/lib/github/config-sync.ts` (GitHub config import default)
- `src/app/components/features/project-settings.tsx` (UI default for new codespace config)

**High — Postgres `event_outbox.payload` schema drift.**
`src/db/migrations-pg/0012_add_event_outbox.sql` creates `payload` as `JSONB NOT NULL`, but the Drizzle PG schema declared it as `text('payload').notNull()`. `tests/integration/*-schema-drift.test.ts` checks column types at runtime and would flag this on the Postgres path. Changed Drizzle to `jsonb('payload').notNull()` to match the applied migration.

**Low — CLAUDE.md Team Mode cleanup.**
Per F3 directive in `specs/arch_review_april/remediation-plan.md`, #176 deleted `launchSwarm` / `teammateCount` / `pushToRemote` end-to-end but left the corresponding "Team Mode" section in `.claude/CLAUDE.md`. Removed the stale block.

## Test plan

- [x] `npx tsc --noEmit` — passes (the only remaining error is a pre-existing dompurify resolution, unrelated to these changes and present on main before `bun install`)
- [x] `npx @biomejs/biome check` — clean on the modified files
- [x] Pre-commit hooks (Biome, TypeScript, Schema Drift Check, Semgrep, detect-secrets) — all pass
- [ ] Verify agent execution against an agent with no explicit `allowedTools` still has open tool access (manual smoke)
- [ ] Verify PG schema-drift integration test passes in CI

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
