### PR TITLE
fix(arch29-W1-D): shell-injection hardening (F06-NEW-01 P0, F06-NEW-03 P0, F06-NEW-06 P1)

### DIFF
--- a/src/server/bootstrap/service-container.ts
+++ b/src/server/bootstrap/service-container.ts
@@ -60,18 +60,35 @@ const log = createLogger('ServiceContainer');
 /**
  * Create the Bun-based CommandRunner for shell operations.
  *
- * F06-02 surfaces two entry points:
- *   - `exec(command, cwd)` — legacy `sh -c` path for callers that need
- *     pipes or shell features (git-service reads from pipes, init scripts
- *     are user-authored shell). Callers on this path MUST pre-validate any
- *     user-supplied values they interpolate; see `validateShellCommand`.
- *   - `execArgs(argv, cwd)` — safe positional-argv path. `Bun.spawn(argv)`
- *     passes arguments literally so shell metacharacters cannot be
- *     interpreted. New callers with untrusted input should prefer this.
+ * F06-02 / F06-NEW-01: `execArgs(argv, cwd)` is the canonical, safe path.
+ * `Bun.spawn(argv)` passes arguments literally so shell metacharacters
+ * cannot be interpreted. ALL new callers with any external/user input MUST
+ * use `execArgs`.
+ *
+ * `exec(command, cwd)` is the deprecated legacy `sh -c` path retained only
+ * for callers that genuinely require shell features (init-script execution,
+ * pipes). Each invocation emits a `log.warn` so a future PR can audit and
+ * remove remaining call sites. New callers MUST NOT use this path.
  */
 function createBunCommandRunner(): CommandRunner {
   return {
+    /**
+     * @deprecated F06-NEW-01 — `sh -c` shell evaluation is unsafe for any
+     * input that was not authored entirely by the deployment operator.
+     * Use {@link CommandRunner.execArgs} instead. Remaining callers (init
+     * scripts) emit a runtime warning so we can finish migrating in a
+     * follow-up PR before removing this path.
+     */
     exec: async (command: string, cwd: string) => {
+      // F06-NEW-01: emit a warning every time the legacy shell path is used
+      // so we can audit and remove remaining call sites in a follow-up PR.
+      // The preview is truncated so a noisy command does not balloon the log.
+      log.warn('CommandRunner.exec (sh -c) is deprecated; migrate caller to execArgs', {
+        data: {
+          commandPreview: command.slice(0, 200),
+          cwd,
+        },
+      });
       const proc = Bun.spawn(['sh', '-c', command], {
         cwd,
         stdout: 'pipe',
@@ -89,9 +106,9 @@ function createBunCommandRunner(): CommandRunner {
       return { stdout, stderr };
     },
     execArgs: async (argv: string[], cwd: string) => {
-      // Positional-argv form (F06-02). No shell is invoked: `Bun.spawn(argv)`
-      // passes arguments literally, so metacharacters in user-controlled
-      // values cannot be interpreted by sh.
+      // Positional-argv form (F06-02 / F06-NEW-01). No shell is invoked:
+      // `Bun.spawn(argv)` passes arguments literally, so metacharacters in
+      // user-controlled values cannot be interpreted by sh.
       if (argv.length === 0) {
         throw new Error('argv must contain at least one element');
       }

--- a/src/services/__tests__/worktree.service.test.ts
+++ b/src/services/__tests__/worktree.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { WorktreeErrors } from '../../lib/errors/worktree-errors.js';
+import type { CommandResult } from '../worktree.service.js';
 import { WorktreeService } from '../worktree.service.js';
 
 vi.mock('node:fs', async () => {
@@ -36,6 +37,26 @@ const createDbMock = () => ({
   delete: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
 });
 
+/**
+ * F06-NEW-01: WorktreeService now requires `execArgs` on the CommandRunner
+ * for every git/cp invocation. `exec` is reserved for the user-authored
+ * `initScript` path. Tests construct a runner whose `exec` and `execArgs`
+ * share the same mock impl so a single `mockResolvedValueOnce(...)` chain
+ * still works regardless of which API path the production code chooses.
+ */
+type SharedMock = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<CommandResult>>>;
+
+const createRunner = (impl?: SharedMock | ((...args: unknown[]) => Promise<CommandResult>)) => {
+  const fn = (impl ?? vi.fn(async () => ({ stdout: '', stderr: '' }))) as SharedMock;
+  return {
+    fn,
+    runner: {
+      exec: fn,
+      execArgs: fn,
+    },
+  };
+};
+
 // Standard test input for worktree creation
 const createInput = {
   codespaceId: 'p1',
@@ -49,7 +70,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.codespaces.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput);
 
     expect(result.ok).toBe(false);
@@ -66,8 +88,8 @@ describe('WorktreeService', () => {
       config: { worktreeRoot: '.worktrees' },
     });
 
-    const exec = vi.fn(async () => ({ stdout: 'branch', stderr: '' }));
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner(vi.fn(async () => ({ stdout: 'branch', stderr: '' })));
+    const service = new WorktreeService(db as never, runner);
 
     const result = await service.create(createInput);
 
@@ -75,6 +97,11 @@ describe('WorktreeService', () => {
     if (!result.ok) {
       expect(result.error.code).toBe('WORKTREE_BRANCH_EXISTS');
     }
+    // F06-NEW-01: branch-list invocation goes through positional argv
+    expect(fn).toHaveBeenCalledWith(
+      ['git', 'branch', '--list', expect.stringContaining('fix-login-bug')],
+      '/tmp/project'
+    );
   });
 
   it('creates worktree record on success', async () => {
@@ -85,7 +112,6 @@ describe('WorktreeService', () => {
       config: { worktreeRoot: '.worktrees', initScript: undefined },
     });
 
-    // Mock insert returning the initial worktree record
     const insertReturning = vi.fn().mockResolvedValue([
       {
         id: 'w1',
@@ -97,7 +123,6 @@ describe('WorktreeService', () => {
     ]);
     db.insert.mockReturnValue({ values: vi.fn(() => ({ returning: insertReturning })) });
 
-    // Mock update returning the activated worktree record
     const updateReturning = vi.fn().mockResolvedValue([
       {
         id: 'w1',
@@ -113,8 +138,8 @@ describe('WorktreeService', () => {
       })),
     });
 
-    const exec = vi.fn(async () => ({ stdout: '', stderr: '' }));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
 
     const result = await service.create(createInput, {
       skipEnvCopy: true,
@@ -132,7 +157,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.remove('missing');
 
     expect(result.ok).toBe(false);
@@ -145,7 +171,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findMany.mockResolvedValue([]);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.list('p1');
 
     expect(result.ok).toBe(true);
@@ -173,7 +200,8 @@ describe('WorktreeService', () => {
       },
     ]);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.list('p1');
 
     expect(result.ok).toBe(true);
@@ -199,7 +227,8 @@ describe('WorktreeService', () => {
       updatedAt: new Date('2024-01-01'),
     });
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getStatus('w1');
 
     expect(result.ok).toBe(true);
@@ -214,7 +243,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getStatus('missing');
 
     expect(result.ok).toBe(false);
@@ -231,7 +261,8 @@ describe('WorktreeService', () => {
       codespaceId: 'p1',
     });
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getByBranch('p1', 'agent/123/t1');
 
     expect(result.ok).toBe(true);
@@ -244,7 +275,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getByBranch('p1', 'nonexistent');
 
     expect(result.ok).toBe(true);
@@ -257,7 +289,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.copyEnv('missing');
 
     expect(result.ok).toBe(false);
@@ -277,12 +310,16 @@ describe('WorktreeService', () => {
       },
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.copyEnv('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith(expect.stringContaining('cp'), '/tmp/project');
+    // F06-NEW-01: positional argv with `--` separator.
+    expect(fn).toHaveBeenCalledWith(
+      ['cp', '--', expect.stringContaining('.env.local'), expect.stringContaining('.env.local')],
+      '/tmp/project'
+    );
   });
 
   it('copyEnv returns error when cp fails', async () => {
@@ -296,8 +333,8 @@ describe('WorktreeService', () => {
       },
     });
 
-    const exec = vi.fn().mockRejectedValue(new Error('cp failed'));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(vi.fn(async () => Promise.reject(new Error('cp failed'))));
+    const service = new WorktreeService(db as never, runner);
     const result = await service.copyEnv('w1');
 
     expect(result.ok).toBe(false);
@@ -310,7 +347,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.installDeps('missing');
 
     expect(result.ok).toBe(false);
@@ -326,12 +364,12 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.installDeps('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith('bun install', '/tmp/worktree');
+    expect(fn).toHaveBeenCalledWith(['bun', 'install'], '/tmp/worktree');
   });
 
   it('installDeps returns error when bun install fails', async () => {
@@ -341,8 +379,10 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi.fn().mockRejectedValue(new Error('bun install failed'));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(
+      vi.fn(async () => Promise.reject(new Error('bun install failed')))
+    );
+    const service = new WorktreeService(db as never, runner);
     const result = await service.installDeps('w1');
 
     expect(result.ok).toBe(false);
@@ -355,7 +395,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.runInitScript('missing');
 
     expect(result.ok).toBe(false);
@@ -372,7 +413,8 @@ describe('WorktreeService', () => {
       codespace: { config: {} },
     });
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.runInitScript('w1');
 
     expect(result.ok).toBe(true);
@@ -386,12 +428,13 @@ describe('WorktreeService', () => {
       codespace: { config: { initScript: 'npm run setup' } },
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.runInitScript('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith('npm run setup', '/tmp/worktree');
+    // initScript intentionally goes through `exec` (user-authored shell).
+    expect(fn).toHaveBeenCalledWith('npm run setup', '/tmp/worktree');
   });
 
   it('runInitScript sanitizes control characters', async () => {
@@ -402,12 +445,12 @@ describe('WorktreeService', () => {
       codespace: { config: { initScript: 'npm\0 run\x08 setup' } },
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.runInitScript('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith('npm run setup', '/tmp/worktree');
+    expect(fn).toHaveBeenCalledWith('npm run setup', '/tmp/worktree');
   });
 
   it('runInitScript returns ok when script is only whitespace after sanitization', async () => {
@@ -418,12 +461,12 @@ describe('WorktreeService', () => {
       codespace: { config: { initScript: '   ' } },
     });
 
-    const exec = vi.fn();
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.runInitScript('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).not.toHaveBeenCalled();
+    expect(fn).not.toHaveBeenCalled();
   });
 
   it('runInitScript returns error when script fails', async () => {
@@ -434,8 +477,8 @@ describe('WorktreeService', () => {
       codespace: { config: { initScript: 'npm run setup' } },
     });
 
-    const exec = vi.fn().mockRejectedValue(new Error('script failed'));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(vi.fn(async () => Promise.reject(new Error('script failed'))));
+    const service = new WorktreeService(db as never, runner);
     const result = await service.runInitScript('w1');
 
     expect(result.ok).toBe(false);
@@ -448,7 +491,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.commit('missing', 'message');
 
     expect(result.ok).toBe(false);
@@ -465,12 +509,12 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
       .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git status
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.commit('w1', 'message');
 
     expect(result.ok).toBe(true);
@@ -494,21 +538,23 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
       .mockResolvedValueOnce({ stdout: 'M file.ts', stderr: '' }) // git status
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git commit
       .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }); // git rev-parse
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.commit('w1', 'Fix bug');
 
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value).toBe('abc123');
     }
-    expect(exec).toHaveBeenCalledWith(expect.stringContaining('git commit'), '/tmp/worktree');
+    // F06-NEW-01: commit message arrives as a literal argv entry, NOT
+    // interpolated into a shell string.
+    expect(fn).toHaveBeenCalledWith(['git', 'commit', '-m', 'Fix bug'], '/tmp/worktree');
   });
 
   it('commit returns error when git fails', async () => {
@@ -519,8 +565,8 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi.fn().mockRejectedValue(new Error('git failed'));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(vi.fn(async () => Promise.reject(new Error('git failed'))));
+    const service = new WorktreeService(db as never, runner);
     const result = await service.commit('w1', 'message');
 
     expect(result.ok).toBe(false);
@@ -545,16 +591,13 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.remove('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith(
-      expect.stringContaining('git worktree remove'),
-      '/tmp/project'
-    );
-    expect(exec).toHaveBeenCalledWith(expect.stringContaining('git branch -D'), '/tmp/project');
+    expect(fn).toHaveBeenCalledWith(['git', 'worktree', 'remove', '/tmp/worktree'], '/tmp/project');
+    expect(fn).toHaveBeenCalledWith(['git', 'branch', '-D', 'agent/123/t1'], '/tmp/project');
   });
 
   it('remove with force flag', async () => {
@@ -573,12 +616,16 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { fn, runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.remove('w1', true);
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith(expect.stringContaining('--force'), '/tmp/project');
+    // F06-NEW-01: --force is its own argv element, never string-interpolated.
+    expect(fn).toHaveBeenCalledWith(
+      ['git', 'worktree', 'remove', '/tmp/worktree', '--force'],
+      '/tmp/project'
+    );
   });
 
   it('remove returns error when git fails', async () => {
@@ -597,8 +644,8 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi.fn().mockRejectedValue(new Error('git failed'));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(vi.fn(async () => Promise.reject(new Error('git failed'))));
+    const service = new WorktreeService(db as never, runner);
     const result = await service.remove('w1');
 
     expect(result.ok).toBe(false);
@@ -633,8 +680,8 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.prune('p1');
 
     expect(result.ok).toBe(true);
@@ -658,7 +705,8 @@ describe('WorktreeService', () => {
     ]);
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.prune('p1');
 
     expect(result.ok).toBe(true);
@@ -673,7 +721,8 @@ describe('WorktreeService', () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.merge('missing');
 
     expect(result.ok).toBe(false);
@@ -697,20 +746,23 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git status (no changes)
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git checkout
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git pull
       .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git merge
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.merge('w1');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith(expect.stringContaining('git checkout'), '/tmp/project');
-    expect(exec).toHaveBeenCalledWith(expect.stringContaining('git merge'), '/tmp/project');
+    expect(fn).toHaveBeenCalledWith(['git', 'checkout', 'main'], '/tmp/project');
+    expect(fn).toHaveBeenCalledWith(
+      ['git', 'merge', 'agent/123/t1', '--no-ff', '-m', expect.any(String)],
+      '/tmp/project'
+    );
   });
 
   it('merge returns conflict error on merge conflict', async () => {
@@ -728,16 +780,17 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git status
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git checkout
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git pull
       .mockResolvedValueOnce({ stdout: '', stderr: 'CONFLICT' }) // git merge
-      .mockResolvedValueOnce({ stdout: 'file1.ts\nfile2.ts', stderr: '' }); // git diff
-
-    const service = new WorktreeService(db as never, { exec });
+      .mockResolvedValueOnce({ stdout: 'file1.ts\nfile2.ts', stderr: '' }) // git diff
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git merge --abort
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.merge('w1');
 
     expect(result.ok).toBe(false);
@@ -761,29 +814,27 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git status
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git checkout
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git pull
       .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git merge
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.merge('w1', 'develop');
 
     expect(result.ok).toBe(true);
-    expect(exec).toHaveBeenCalledWith(
-      expect.stringContaining('git checkout "develop"'),
-      '/tmp/project'
-    );
+    expect(fn).toHaveBeenCalledWith(['git', 'checkout', 'develop'], '/tmp/project');
   });
 
   it('getDiff returns error when worktree not found', async () => {
     const db = createDbMock();
     db.query.worktrees.findFirst.mockResolvedValue(null);
 
-    const service = new WorktreeService(db as never, { exec: vi.fn() });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getDiff('missing');
 
     expect(result.ok).toBe(false);
@@ -801,12 +852,12 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '10\t5\tfile1.ts\n3\t1\tfile2.ts', stderr: '' }) // numstat
       .mockResolvedValueOnce({ stdout: '', stderr: '' }); // full diff
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getDiff('w1');
 
     expect(result.ok).toBe(true);
@@ -816,6 +867,8 @@ describe('WorktreeService', () => {
       expect(result.value.stats.additions).toBe(13);
       expect(result.value.stats.deletions).toBe(6);
     }
+    // F06-NEW-01: revspec is a single argv element, never interpolated.
+    expect(fn).toHaveBeenCalledWith(['git', 'diff', '--numstat', 'main...HEAD'], '/tmp/worktree');
   });
 
   it('getDiff returns empty when no changes', async () => {
@@ -827,12 +880,12 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // numstat
       .mockResolvedValueOnce({ stdout: '', stderr: '' }); // full diff
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getDiff('w1');
 
     expect(result.ok).toBe(true);
@@ -851,8 +904,8 @@ describe('WorktreeService', () => {
       path: '/tmp/worktree',
     });
 
-    const exec = vi.fn().mockRejectedValue(new Error('git failed'));
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(vi.fn(async () => Promise.reject(new Error('git failed'))));
+    const service = new WorktreeService(db as never, runner);
     const result = await service.getDiff('w1');
 
     expect(result.ok).toBe(false);
@@ -869,12 +922,12 @@ describe('WorktreeService', () => {
       config: { worktreeRoot: '.worktrees' },
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // branch check
       .mockRejectedValueOnce(new Error('git worktree add failed')); // worktree add
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput);
 
     expect(result.ok).toBe(false);
@@ -895,8 +948,8 @@ describe('WorktreeService', () => {
       values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) })),
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput);
 
     expect(result.ok).toBe(false);
@@ -924,7 +977,6 @@ describe('WorktreeService', () => {
     ]);
     db.insert.mockReturnValue({ values: vi.fn(() => ({ returning: insertReturning })) });
 
-    // For worktree lookup in copyEnv
     db.query.worktrees.findFirst.mockResolvedValue({
       id: 'w1',
       path: '/tmp/worktree',
@@ -936,13 +988,13 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // branch check
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
       .mockRejectedValueOnce(new Error('cp failed')); // copyEnv
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput);
 
     expect(result.ok).toBe(false);
@@ -970,7 +1022,6 @@ describe('WorktreeService', () => {
     ]);
     db.insert.mockReturnValue({ values: vi.fn(() => ({ returning: insertReturning })) });
 
-    // For worktree lookups
     db.query.worktrees.findFirst.mockImplementation(() => ({
       id: 'w1',
       path: '/tmp/worktree',
@@ -982,13 +1033,13 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // branch check
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
-      .mockRejectedValueOnce(new Error('bun install failed')); // installDeps (skipEnvCopy=true)
-
-    const service = new WorktreeService(db as never, { exec });
+      .mockRejectedValueOnce(new Error('bun install failed')); // installDeps
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput, { skipEnvCopy: true });
 
     expect(result.ok).toBe(false);
@@ -1016,7 +1067,6 @@ describe('WorktreeService', () => {
     ]);
     db.insert.mockReturnValue({ values: vi.fn(() => ({ returning: insertReturning })) });
 
-    // For worktree lookups
     db.query.worktrees.findFirst.mockImplementation(() => ({
       id: 'w1',
       path: '/tmp/worktree',
@@ -1028,13 +1078,13 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: updateWhere })),
     });
 
-    const exec = vi
-      .fn()
+    const fn = vi
+      .fn<(...args: unknown[]) => Promise<CommandResult>>()
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // branch check
       .mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
       .mockRejectedValueOnce(new Error('init script failed')); // initScript
-
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner(fn);
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput, { skipEnvCopy: true, skipDepsInstall: true });
 
     expect(result.ok).toBe(false);
@@ -1067,8 +1117,8 @@ describe('WorktreeService', () => {
       set: vi.fn(() => ({ where: vi.fn(() => ({ returning: updateReturning })) })),
     });
 
-    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
-    const service = new WorktreeService(db as never, { exec });
+    const { runner } = createRunner();
+    const service = new WorktreeService(db as never, runner);
     const result = await service.create(createInput, {
       skipEnvCopy: true,
       skipDepsInstall: true,
@@ -1079,5 +1129,195 @@ describe('WorktreeService', () => {
     if (!result.ok) {
       expect(result.error.code).toBe('WORKTREE_CREATION_FAILED');
     }
+  });
+
+  // ── F06-NEW-01 / F06-NEW-03: shell-injection regression tests ──
+
+  describe('F06-NEW-01: shell injection via positional argv', () => {
+    it('hostile branch name with `; rm -rf /;` is treated as a literal argv element', async () => {
+      const db = createDbMock();
+      db.query.codespaces.findFirst.mockResolvedValue({
+        id: 'p1',
+        path: '/tmp/project',
+        config: { worktreeRoot: '.worktrees' },
+      });
+
+      const malicious = "evil'; rm -rf /; echo '";
+      const insertReturning = vi.fn().mockResolvedValue([
+        {
+          id: 'w1',
+          codespaceId: 'p1',
+          branch: malicious,
+          path: '/tmp/worktree',
+          status: 'creating',
+        },
+      ]);
+      db.insert.mockReturnValue({ values: vi.fn(() => ({ returning: insertReturning })) });
+
+      const updateReturning = vi.fn().mockResolvedValue([
+        {
+          id: 'w1',
+          codespaceId: 'p1',
+          branch: malicious,
+          path: '/tmp/worktree',
+          status: 'active',
+        },
+      ]);
+      db.update.mockReturnValue({
+        set: vi.fn(() => ({ where: vi.fn(() => ({ returning: updateReturning })) })),
+      });
+
+      const { fn, runner } = createRunner();
+      const service = new WorktreeService(db as never, runner);
+      // Use the malicious string as a task title fragment so the slugified
+      // branch contains the dangerous chars (slug-style: rejected mostly).
+      // We instead exercise `commit()` where the message arrives raw.
+      const wt = await service.create(
+        { ...createInput, taskTitle: 'safe-title' },
+        { skipEnvCopy: true, skipDepsInstall: true, skipInitScript: true }
+      );
+      expect(wt.ok).toBe(true);
+
+      // For commit(): the message is LLM-controlled and may contain ANY
+      // shell metachar. Verify it arrives as a single argv string.
+      db.query.worktrees.findFirst.mockResolvedValue({
+        id: 'w1',
+        branch: 'safe-title-t1',
+        path: '/tmp/worktree',
+      });
+      fn.mockReset();
+      fn.mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
+        .mockResolvedValueOnce({ stdout: 'M file.ts', stderr: '' }) // git status
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git commit
+        .mockResolvedValueOnce({ stdout: 'sha\n', stderr: '' }); // git rev-parse
+
+      await service.commit('w1', malicious);
+
+      // The malicious string must appear as a SINGLE argv element, not
+      // split into separate shell tokens by `;` or quote-broken interpolation.
+      const commitCall = fn.mock.calls.find(
+        (c) => Array.isArray(c[0]) && (c[0] as string[]).includes('commit')
+      );
+      expect(commitCall).toBeDefined();
+      const argv = commitCall![0] as string[];
+      expect(argv).toEqual(['git', 'commit', '-m', malicious]);
+      // Critical: the malicious payload is NOT shell-interpolated into a
+      // multi-statement string. It's a single argv element.
+      expect(argv.some((a) => a === malicious)).toBe(true);
+      expect(argv.some((a) => a.includes('rm -rf') && a !== malicious)).toBe(false);
+    });
+
+    it('hostile path in copyEnv goes through `cp -- src target` argv', async () => {
+      const db = createDbMock();
+      db.query.worktrees.findFirst.mockResolvedValue({
+        id: 'w1',
+        path: '/tmp/worktree',
+        codespace: {
+          path: '/tmp/project',
+          // envFile from codespace config is admin-controlled but a hostile
+          // admin (or compromised setting) could specify an injection.
+          config: { envFile: '.env"; rm -rf /; #' },
+        },
+      });
+
+      const { fn, runner } = createRunner();
+      const service = new WorktreeService(db as never, runner);
+      await service.copyEnv('w1');
+
+      const argv = fn.mock.calls[0]![0] as string[];
+      expect(argv[0]).toBe('cp');
+      expect(argv[1]).toBe('--');
+      // Source and target paths each contain the malicious string verbatim
+      // — but they're SEPARATE argv elements, so `cp` sees them as filenames.
+      expect(argv[2]).toContain('.env"; rm -rf /; #');
+      expect(argv[3]).toContain('.env"; rm -rf /; #');
+    });
+
+    it('runner without execArgs (legacy stub) throws on git operations', async () => {
+      const db = createDbMock();
+      db.query.codespaces.findFirst.mockResolvedValue({
+        id: 'p1',
+        path: '/tmp/project',
+        config: { worktreeRoot: '.worktrees' },
+      });
+
+      const legacyRunner = { exec: vi.fn(async () => ({ stdout: '', stderr: '' })) };
+      const service = new WorktreeService(db as never, legacyRunner);
+
+      // F06-NEW-01: a runner without `execArgs` is rejected by the service
+      // when it reaches the first git/cp call. The branch-check is the
+      // first such call in `create()` — `requireExecArgs` throws which
+      // propagates straight up because the throw is OUTSIDE the try/catch
+      // (the type-checker enforces it via `requireExecArgs`).
+      await expect(service.create(createInput)).rejects.toThrow(
+        /CommandRunner\.execArgs is required/
+      );
+    });
+  });
+
+  describe('F06-NEW-06: validateShellCommand hardening', () => {
+    it('rejects U+2028 line separator', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('foo\u2028bar')).toThrow();
+    });
+
+    it('rejects U+2029 paragraph separator', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('foo\u2029bar')).toThrow();
+    });
+
+    it('rejects NULL byte', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('foo\u0000bar')).toThrow();
+    });
+
+    it('rejects standalone `&`', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('cmd & other')).toThrow();
+    });
+
+    it('rejects redirection `>` and `<`', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('cmd > file')).toThrow();
+      expect(() => validateShellCommand('cmd < file')).toThrow();
+    });
+
+    it('rejects `${var}` expansion', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('echo ${HOME}')).toThrow();
+    });
+
+    it('rejects backslash-newline continuation', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('cmd \\\nother')).toThrow();
+    });
+
+    it('rejects `\\t` tab', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('cmd\twith\ttab')).toThrow();
+    });
+
+    it('rejects `\\v` vertical tab', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('cmd\vwith\vvtab')).toThrow();
+    });
+
+    it('still rejects original metacharacters', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('a; b')).toThrow();
+      expect(() => validateShellCommand('a | b')).toThrow();
+      expect(() => validateShellCommand('a `b`')).toThrow();
+      expect(() => validateShellCommand('a $(b)')).toThrow();
+      expect(() => validateShellCommand('a && b')).toThrow();
+      expect(() => validateShellCommand('a || b')).toThrow();
+      expect(() => validateShellCommand('a\nb')).toThrow();
+      expect(() => validateShellCommand('a\rb')).toThrow();
+    });
+
+    it('accepts plain alphanumeric command', async () => {
+      const { validateShellCommand } = await import('../worktree.service.js');
+      expect(() => validateShellCommand('npm run setup')).not.toThrow();
+      expect(() => validateShellCommand('git status')).not.toThrow();
+    });
   });
 });

--- a/src/services/worktree.service.ts
+++ b/src/services/worktree.service.ts
@@ -67,17 +67,19 @@ export type PruneResult = {
 export type WorktreeServiceResult<T> = Promise<Result<T, WorktreeError>>;
 
 /**
- * Escapes a string for safe use in shell commands within double quotes.
- * Removes null bytes and escapes: backslash, double quote, backtick, dollar sign, and newlines.
+ * Asserts that a CommandRunner exposes the safe positional-argv `execArgs`
+ * primitive (F06-NEW-01). All production runners — `createBunCommandRunner`
+ * and `createSandboxCommandRunner` — supply it. The only places that hit
+ * this assertion are tests using a minimal `{ exec: vi.fn() }` mock; those
+ * tests must add an `execArgs` mock to keep the safe path covered.
  */
-const escapeShellString = (str: string): string => {
-  return str
-    .replace(/\0/g, '') // Remove null bytes to prevent injection
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/`/g, '\\`')
-    .replace(/\$/g, '\\$')
-    .replace(/\n/g, '\\n');
+const requireExecArgs = (runner: CommandRunner): NonNullable<CommandRunner['execArgs']> => {
+  if (!runner.execArgs) {
+    throw new Error(
+      'CommandRunner.execArgs is required (F06-NEW-01); update the test stub or runner factory'
+    );
+  }
+  return runner.execArgs;
 };
 
 const extractHunks = (diff: string, filePath: string): DiffHunk[] => {
@@ -145,10 +147,26 @@ export type CommandRunner = {
  * Throws if dangerous characters are detected.
  *
  * Exported so callers that must compose a shell string can opt in to the
- * same guard the sandbox runner applies (F06-02).
+ * same guard the sandbox runner applies (F06-02). Hardened in F06-NEW-06 to
+ * reject:
+ *   - U+0000 (NULL byte) — terminates the C-string in some shell parsers.
+ *   - U+2028 / U+2029 (Unicode line separators) — bash 5+ treats these as
+ *     ordinary, but `dash` (Alpine default in many sandboxes) and other
+ *     shells passed through `sh -c` may not, and a future container
+ *     migration could re-open the gap.
+ *   - `\t` / `\v` — token separators in some shells, can split when
+ *     combined with backslash quoting.
+ *   - Standalone `&` (background) plus the existing `&&`.
+ *   - `>` / `<` redirection, `${`/`$(` expansion, backslash-newline.
  */
 export function validateShellCommand(command: string): void {
-  const DANGEROUS_PATTERN = /[;|`]|\$\(|&&|\|\||[\n\r]/;
+  // F06-NEW-06: reject NULL byte (U+0000) and Unicode line separators
+  // (U+2028, U+2029) unconditionally. \u escapes used so the source file
+  // stays grep-able and editor-safe.
+  if (/[\u0000\u2028\u2029]/.test(command)) {
+    throw ServiceErrors.SHELL_INJECTION_DETECTED(command);
+  }
+  const DANGEROUS_PATTERN = /[;|&`<>]|\$\(|\$\{|&&|\|\||[\n\r\t\v]|\\\n/;
   if (DANGEROUS_PATTERN.test(command)) {
     throw ServiceErrors.SHELL_INJECTION_DETECTED(command);
   }
@@ -243,22 +261,20 @@ export class WorktreeService {
     const root = codespace.config?.worktreeRoot ?? '.worktrees';
     const worktreePath = path.join(codespace.path, root, branch);
 
-    const escapedBranchForCheck = escapeShellString(branch);
-    const branchCheck = await this.runner.exec(
-      `git branch --list "${escapedBranchForCheck}"`,
-      codespace.path
-    );
+    // F06-NEW-01: positional argv keeps user-influenced values out of the
+    // shell. `git branch --list` accepts pattern as a literal arg, so a
+    // hostile branch name like `'; rm -rf /;'` cannot escape into sh.
+    const execArgs = requireExecArgs(this.runner);
+    const branchCheck = await execArgs(['git', 'branch', '--list', branch], codespace.path);
     if (branchCheck.stdout.trim()) {
       return err(WorktreeErrors.BRANCH_EXISTS(branch));
     }
 
     try {
-      const escapedPath = escapeShellString(worktreePath);
-      const escapedBranch = escapeShellString(branch);
-      const escapedBaseBranch = escapeShellString(baseBranch);
-
-      await this.runner.exec(
-        `git worktree add "${escapedPath}" -b "${escapedBranch}" "${escapedBaseBranch}"`,
+      // F06-NEW-01: argv form. `git worktree add <path> -b <branch> <base>`
+      // is the documented signature; values pass literally via spawn.
+      await execArgs(
+        ['git', 'worktree', 'add', worktreePath, '-b', branch, baseBranch],
         codespace.path
       );
     } catch (error) {
@@ -361,15 +377,15 @@ export class WorktreeService {
     softInvariant(!!removing, 'Failed to set worktree status to removing', { worktreeId });
 
     try {
-      const forceFlag = force ? '--force' : '';
-      const escapedPath = escapeShellString(worktree.path);
-      const escapedBranch = escapeShellString(worktree.branch);
-
-      await this.runner.exec(
-        `git worktree remove "${escapedPath}" ${forceFlag}`,
-        worktree.codespace.path
-      );
-      await this.runner.exec(`git branch -D "${escapedBranch}"`, worktree.codespace.path);
+      // F06-NEW-01: argv form. `--force` is a flag; we add it conditionally
+      // as a separate argv element rather than interpolating into a string.
+      const execArgs = requireExecArgs(this.runner);
+      const removeArgs = ['git', 'worktree', 'remove', worktree.path];
+      if (force) {
+        removeArgs.push('--force');
+      }
+      await execArgs(removeArgs, worktree.codespace.path);
+      await execArgs(['git', 'branch', '-D', worktree.branch], worktree.codespace.path);
 
       const [removed] = await this.db
         .update(worktrees)
@@ -442,9 +458,10 @@ export class WorktreeService {
     const targetPath = path.join(worktree.path, envFile);
 
     try {
-      const escapedSource = escapeShellString(sourcePath);
-      const escapedTarget = escapeShellString(targetPath);
-      await this.runner.exec(`cp "${escapedSource}" "${escapedTarget}"`, worktree.codespace.path);
+      // F06-NEW-01: argv form with `--` so a path beginning with `-`
+      // cannot be interpreted as a flag by `cp`.
+      const execArgs = requireExecArgs(this.runner);
+      await execArgs(['cp', '--', sourcePath, targetPath], worktree.codespace.path);
       return ok(undefined);
     } catch (error) {
       return err(WorktreeErrors.ENV_COPY_FAILED(String(error), error));
@@ -461,7 +478,10 @@ export class WorktreeService {
     }
 
     try {
-      await this.runner.exec('bun install', worktree.path);
+      // F06-NEW-01: literal argv with no user input. `bun install` reads
+      // package.json from cwd; nothing is interpolated.
+      const execArgs = requireExecArgs(this.runner);
+      await execArgs(['bun', 'install'], worktree.path);
       return ok(undefined);
     } catch (error) {
       return err(WorktreeErrors.INIT_SCRIPT_FAILED('bun install', String(error), error));
@@ -513,17 +533,18 @@ export class WorktreeService {
     }
 
     try {
-      // Note: cwd parameter uses raw path (passed to process spawn, not shell interpolated)
-      // Only command arguments need shell escaping
-      await this.runner.exec('git add -A', worktree.path);
-      const status = await this.runner.exec('git status --porcelain', worktree.path);
+      // F06-NEW-01: positional argv. The commit message originates from
+      // agent-completion text (LLM-controlled), so it MUST NOT touch the
+      // shell. `git commit -m <msg>` accepts the message as a literal arg.
+      const execArgs = requireExecArgs(this.runner);
+      await execArgs(['git', 'add', '-A'], worktree.path);
+      const status = await execArgs(['git', 'status', '--porcelain'], worktree.path);
       if (!status.stdout.trim()) {
         return ok('');
       }
 
-      const escapedMessage = escapeShellString(message);
-      await this.runner.exec(`git commit -m "${escapedMessage}"`, worktree.path);
-      const sha = await this.runner.exec('git rev-parse HEAD', worktree.path);
+      await execArgs(['git', 'commit', '-m', message], worktree.path);
+      const sha = await execArgs(['git', 'rev-parse', 'HEAD'], worktree.path);
 
       const [committed] = await this.db
         .update(worktrees)
@@ -565,27 +586,27 @@ export class WorktreeService {
     }
 
     try {
-      // Note: cwd uses raw path; only command arguments need escaping
-      const escapedTarget = escapeShellString(target);
-      const escapedBranch = escapeShellString(worktree.branch);
+      // F06-NEW-01: argv form. Branch names are codespace-config or
+      // task-derived data; pass literally to git.
+      const execArgs = requireExecArgs(this.runner);
+      const mergeMessage = `Merge branch '${worktree.branch}'`;
 
-      await this.runner.exec(`git checkout "${escapedTarget}"`, worktree.codespace.path);
-      await this.runner.exec('git pull --rebase', worktree.codespace.path);
-      const mergeMessage = escapeShellString(`Merge branch '${worktree.branch}'`);
-      const merge = await this.runner.exec(
-        `git merge "${escapedBranch}" --no-ff -m "${mergeMessage}"`,
+      await execArgs(['git', 'checkout', target], worktree.codespace.path);
+      await execArgs(['git', 'pull', '--rebase'], worktree.codespace.path);
+      const merge = await execArgs(
+        ['git', 'merge', worktree.branch, '--no-ff', '-m', mergeMessage],
         worktree.codespace.path
       );
 
       if (merge.stderr.includes('CONFLICT')) {
-        const conflicts = await this.runner.exec(
-          'git diff --name-only --diff-filter=U',
+        const conflicts = await execArgs(
+          ['git', 'diff', '--name-only', '--diff-filter=U'],
           worktree.codespace.path
         );
 
         // Abort the failed merge to leave the repo in a clean state
         try {
-          await this.runner.exec('git merge --abort', worktree.codespace.path);
+          await execArgs(['git', 'merge', '--abort'], worktree.codespace.path);
         } catch {
           // Merge abort can fail if merge wasn't in progress — ignore
         }
@@ -644,18 +665,15 @@ export class WorktreeService {
     }
 
     try {
-      // Note: cwd uses raw path; only command arguments need escaping
-      const escapedBaseBranch = escapeShellString(worktree.baseBranch);
+      // F06-NEW-01: argv form. The triple-dot revspec is appended to the
+      // base-branch literal so git receives `<base>...HEAD` as a single
+      // argv element — no shell interpolation.
+      const execArgs = requireExecArgs(this.runner);
+      const revspec = `${worktree.baseBranch}...HEAD`;
 
       // Get diff statistics for file-level analysis
-      const numstat = await this.runner.exec(
-        `git diff --numstat "${escapedBaseBranch}"...HEAD`,
-        worktree.path
-      );
-      const fullDiff = await this.runner.exec(
-        `git diff "${escapedBaseBranch}"...HEAD`,
-        worktree.path
-      );
+      const numstat = await execArgs(['git', 'diff', '--numstat', revspec], worktree.path);
+      const fullDiff = await execArgs(['git', 'diff', revspec], worktree.path);
 
       const files: DiffFile[] = numstat.stdout
         .trim()

--- a/tests/functional/prove-session-worktree-bugs.test.ts
+++ b/tests/functional/prove-session-worktree-bugs.test.ts
@@ -705,25 +705,28 @@ describe('Prove/Disprove: Session and Worktree Service Bugs', () => {
       const { WorktreeService } = await import('../../src/services/worktree.service');
 
       let _callCount = 0;
-      const failingRunner = {
-        exec: vi.fn().mockImplementation(async (cmd: string) => {
-          _callCount++;
-          // Allow 'git add', 'git status', 'git commit', 'git rev-parse'
-          if (cmd.includes('git add') || cmd.includes('git status')) {
-            return { stdout: '', stderr: '' };
-          }
-          if (cmd.includes('git commit')) {
-            return { stdout: '', stderr: '' };
-          }
-          if (cmd.includes('git rev-parse')) {
-            return { stdout: 'abc123', stderr: '' };
-          }
-          // Fail on checkout (merge step)
-          if (cmd.includes('git checkout')) {
-            throw new Error('fatal: could not detach HEAD');
-          }
+      const responder = async (cmd: string) => {
+        _callCount++;
+        if (cmd.includes('git add') || cmd.includes('git status')) {
           return { stdout: '', stderr: '' };
-        }),
+        }
+        if (cmd.includes('git commit')) {
+          return { stdout: '', stderr: '' };
+        }
+        if (cmd.includes('git rev-parse')) {
+          return { stdout: 'abc123', stderr: '' };
+        }
+        if (cmd.includes('git checkout')) {
+          throw new Error('fatal: could not detach HEAD');
+        }
+        return { stdout: '', stderr: '' };
+      };
+      // F06-NEW-01: WorktreeService now uses execArgs for every git op.
+      // Provide both `exec` (legacy) and `execArgs` (joining argv with
+      // spaces so the includes() patterns above keep matching).
+      const failingRunner = {
+        exec: vi.fn().mockImplementation(async (cmd: string) => responder(cmd)),
+        execArgs: vi.fn().mockImplementation(async (argv: string[]) => responder(argv.join(' '))),
       };
 
       const worktreeService = new WorktreeService(db, failingRunner);
@@ -992,20 +995,20 @@ describe('Prove/Disprove: Session and Worktree Service Bugs', () => {
       const { WorktreeService } = await import('../../src/services/worktree.service');
 
       const gitCommands: string[] = [];
-      const mockRunner = {
-        exec: vi.fn().mockImplementation(async (cmd: string) => {
-          gitCommands.push(cmd);
-          // git branch --list: no existing branch
-          if (cmd.includes('git branch --list')) {
-            return { stdout: '', stderr: '' };
-          }
-          // git worktree add: succeed
-          if (cmd.includes('git worktree add')) {
-            return { stdout: 'Preparing worktree', stderr: '' };
-          }
-          // All other commands succeed
+      const responder = async (cmd: string) => {
+        gitCommands.push(cmd);
+        if (cmd.includes('git branch --list')) {
           return { stdout: '', stderr: '' };
-        }),
+        }
+        if (cmd.includes('git worktree add')) {
+          return { stdout: 'Preparing worktree', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      };
+      // F06-NEW-01: WorktreeService now uses execArgs for every git op.
+      const mockRunner = {
+        exec: vi.fn().mockImplementation(async (cmd: string) => responder(cmd)),
+        execArgs: vi.fn().mockImplementation(async (argv: string[]) => responder(argv.join(' '))),
       };
 
       const worktreeService = new WorktreeService(db, mockRunner);

--- a/tests/integration/worktree.test.ts
+++ b/tests/integration/worktree.test.ts
@@ -1,4 +1,4 @@
-import { exec as execCallback } from 'node:child_process';
+import { exec as execCallback, execFile as execFileCallback } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,6 +11,7 @@ import { createTestTask } from '../factories/task.factory';
 import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
 
 const exec = promisify(execCallback);
+const execFile = promisify(execFileCallback);
 
 // Check if git is available
 let gitAvailable = true;
@@ -28,9 +29,20 @@ describe('WorktreeService Integration', () => {
   let worktreeService: WorktreeService;
   let setupSuccessful = false;
 
+  // F06-NEW-01: integration runner provides both `exec` (legacy shell) and
+  // `execArgs` (positional, no shell). The service uses execArgs for every
+  // git/cp invocation; exec remains for the user-script init path.
   const commandRunner = {
     exec: async (command: string, cwd: string) => {
       const result = await exec(command, { cwd });
+      return { stdout: result.stdout, stderr: result.stderr };
+    },
+    execArgs: async (argv: string[], cwd: string) => {
+      if (argv.length === 0) {
+        throw new Error('argv must contain at least one element');
+      }
+      const [cmd, ...args] = argv;
+      const result = await execFile(cmd as string, args, { cwd });
       return { stdout: result.stdout, stderr: result.stderr };
     },
   };

--- a/tests/lib/agents/command-runner-fuzz.test.ts
+++ b/tests/lib/agents/command-runner-fuzz.test.ts
@@ -1,0 +1,202 @@
+/**
+ * F06-NEW-01 / F06-NEW-03 — property-based shell-injection fuzz test.
+ *
+ * Generates strings containing every shell metacharacter we know about and
+ * verifies they survive LITERALLY to the spawned process when passed as
+ * argv elements. The host runner (Bun.spawn) is the production path, but
+ * we test the architectural invariant: argv elements are never composed
+ * into a `sh -c` template.
+ *
+ * Without the fix:
+ *   - `escapeShellString` lets `;`, `|`, `&` through because the helper
+ *     only escapes `\\`, `"`, `` ` ``, `$`, and turns `\n` into the
+ *     literal `\\n`. Composed into `git commit -m "$msg"` and run via
+ *     `sh -c`, a hostile commit message of `evil"; rm -rf /; echo "ok`
+ *     would terminate the quoted argument and execute `rm -rf /`.
+ *
+ * With the fix (this test):
+ *   - All callers go through `runner.execArgs(argv, cwd)` which spawns
+ *     directly (no shell). Each argv entry is delivered to the child
+ *     process as one string, regardless of metacharacters.
+ *
+ * The test uses `createSandboxCommandRunner` because it works in pure-JS
+ * Vitest (no Bun runtime needed) — the architectural property (argv
+ * never reaches the shell template) holds for both `createBunCommandRunner`
+ * and `createSandboxCommandRunner`. The strongest invariant we can assert
+ * is BYTE-IDENTITY of the shell template across every input: the template
+ * is `cd '<cwd>' && exec "$@"`, and any hostile payload travels past `--`
+ * as a literal positional ($1...$N), never seen by `sh -c`.
+ */
+
+/** biome-ignore-all lint/nursery/noFloatingPromises: fc.assert is sync when the property fn is sync; the rule can't infer this from the overloaded return type. */
+
+import * as fc from 'fast-check';
+import { describe, expect, it, vi } from 'vitest';
+import { createSandboxCommandRunner } from '../../../src/services/worktree.service.js';
+
+/**
+ * Arbitrary that generates strings containing at least one shell
+ * metacharacter. Each char in the alphabet has been observed as an
+ * injection vector in real shell runners.
+ */
+const HOSTILE_CHARS = [
+  ';',
+  '|',
+  '&',
+  '`',
+  '$',
+  '(',
+  ')',
+  '"',
+  "'",
+  '\\',
+  '\n',
+  '\r',
+  '\t',
+  '\v',
+  '\u2028',
+  '\u2029',
+  '<',
+  '>',
+];
+
+const hostileString = fc
+  .stringMatching(/.+/)
+  .filter((s) => HOSTILE_CHARS.some((c) => s.includes(c)));
+
+/** Cwd for tests using `/tmp/cwd`. */
+const TEMPLATE_CWD = `cd '/tmp/cwd' && exec "$@"`;
+/** Cwd for tests using `/tmp` (shorter, used in focused tests). */
+const TEMPLATE_TMP = `cd '/tmp' && exec "$@"`;
+
+describe('F06-NEW-01: command-runner argv survives shell metacharacters', () => {
+  it('every hostile string passed as argv arrives as a single shell positional, never composed into sh -c', () => {
+    fc.assert(
+      fc.property(hostileString, (hostile) => {
+        const sandbox = {
+          exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+        };
+        const runner = createSandboxCommandRunner(sandbox);
+
+        // Pretend a hostile branch name reaches `git branch -D <branch>`.
+        // biome-ignore lint/style/noNonNullAssertion: createSandboxCommandRunner always supplies execArgs.
+        runner.execArgs!(['git', 'branch', '-D', hostile], '/tmp/cwd');
+
+        // sandbox.exec is called as `('sh', ['-c', "cd '/tmp/cwd' && exec \"$@\"",
+        // '--', 'git', 'branch', '-D', hostile])` — the hostile value is
+        // a separate positional argument, never embedded in the shell
+        // command string.
+        expect(sandbox.exec).toHaveBeenCalledTimes(1);
+        const [shellCmd, args] = sandbox.exec.mock.calls[0]!;
+        expect(shellCmd).toBe('sh');
+        // Byte-identity: the shell template is identical for every input,
+        // because the hostile payload rides past `--` as a positional.
+        expect(args[1]).toBe(TEMPLATE_CWD);
+        // The hostile string lives at the end of the argv positionals,
+        // delivered to git verbatim via "$@".
+        expect(args[args.length - 1]).toBe(hostile);
+      }),
+      { numRuns: 200 }
+    );
+  });
+
+  it('hostile arg containing `;` does NOT split into multiple shell statements', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('foo;bar', 'foo;rm -rf /', 'a;;b', ';bar;'), (hostile) => {
+        const sandbox = {
+          exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+        };
+        const runner = createSandboxCommandRunner(sandbox);
+        // biome-ignore lint/style/noNonNullAssertion: createSandboxCommandRunner always supplies execArgs.
+        runner.execArgs!(['echo', hostile], '/tmp');
+        const [, args] = sandbox.exec.mock.calls[0]!;
+        expect(args[args.length - 1]).toBe(hostile);
+        expect(args[1]).toBe(TEMPLATE_TMP);
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('hostile arg containing `|` does NOT pipe through shell', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('foo|bar', 'a|cat /etc/passwd', '||evil', '|'), (hostile) => {
+        const sandbox = {
+          exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+        };
+        const runner = createSandboxCommandRunner(sandbox);
+        // biome-ignore lint/style/noNonNullAssertion: createSandboxCommandRunner always supplies execArgs.
+        runner.execArgs!(['echo', hostile], '/tmp');
+        const [, args] = sandbox.exec.mock.calls[0]!;
+        expect(args[args.length - 1]).toBe(hostile);
+        expect(args[1]).toBe(TEMPLATE_TMP);
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('hostile arg containing `&` does NOT background a process', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('foo&bar', 'a&&evil', '&background', '&', 'a&b&c'), (hostile) => {
+        const sandbox = {
+          exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+        };
+        const runner = createSandboxCommandRunner(sandbox);
+        // biome-ignore lint/style/noNonNullAssertion: createSandboxCommandRunner always supplies execArgs.
+        runner.execArgs!(['echo', hostile], '/tmp');
+        const [, args] = sandbox.exec.mock.calls[0]!;
+        expect(args[args.length - 1]).toBe(hostile);
+        // Byte-identical template — even though it contains a literal
+        // `&&` between `cd` and `exec`, the hostile payload was NOT
+        // appended to it.
+        expect(args[1]).toBe(TEMPLATE_TMP);
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('hostile arg with command substitution `$()` is NOT evaluated', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('$(whoami)', 'foo$(rm -rf /)', '`id`', '${HOME}'), (hostile) => {
+        const sandbox = {
+          exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+        };
+        const runner = createSandboxCommandRunner(sandbox);
+        // biome-ignore lint/style/noNonNullAssertion: createSandboxCommandRunner always supplies execArgs.
+        runner.execArgs!(['echo', hostile], '/tmp');
+        const [, args] = sandbox.exec.mock.calls[0]!;
+        expect(args[args.length - 1]).toBe(hostile);
+        expect(args[1]).toBe(TEMPLATE_TMP);
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('hostile arg with newlines and Unicode line separators arrives literally', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          'foo\nbar',
+          'a\rb',
+          'tab\there',
+          'sep\u2028more',
+          'para\u2029more',
+          'multi\nline\rwith\u2028u2028'
+        ),
+        (hostile) => {
+          const sandbox = {
+            exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+          };
+          const runner = createSandboxCommandRunner(sandbox);
+          // biome-ignore lint/style/noNonNullAssertion: createSandboxCommandRunner always supplies execArgs.
+          runner.execArgs!(['printf', hostile], '/tmp');
+          const [, args] = sandbox.exec.mock.calls[0]!;
+          // Hostile chars are delivered as a single positional argument
+          // exactly as supplied. The shell template is byte-identical.
+          expect(args[args.length - 1]).toBe(hostile);
+          expect(args[1]).toBe(TEMPLATE_TMP);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});

--- a/tests/mocks/mock-git.ts
+++ b/tests/mocks/mock-git.ts
@@ -94,7 +94,27 @@ export function createMockCommandRunner(responses: CommandResponseMap = {}): Com
       return { stdout: '', stderr: '' };
     });
 
-  return { exec };
+  // F06-NEW-01: WorktreeService now uses positional `execArgs` for every
+  // git/cp invocation. Map the argv form back to the `command` pattern
+  // matcher by joining argv with spaces — this lets existing tests using
+  // patterns like 'branch --list' or 'worktree add' continue to match.
+  const execArgs = vi
+    .fn()
+    .mockImplementation(async (argv: string[], cwd: string): Promise<CommandResult> => {
+      const command = argv.join(' ');
+      for (const [pattern, response] of Object.entries(responses)) {
+        if (command.includes(pattern)) {
+          if (typeof response === 'function') {
+            const result = response(command, cwd);
+            return result instanceof Promise ? await result : result;
+          }
+          return response;
+        }
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+  return { exec, execArgs };
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Eliminates the shell-injection surface in `WorktreeService` and tightens `validateShellCommand`. Resolves 3 of the F06-NEW-* findings from the April 29 architecture review.

- **F06-NEW-01 (P0)** — `CommandRunner.exec` `sh -c` is deprecated with `@deprecated` JSDoc + runtime `log.warn`. All 7 string-composed shell calls in `worktree.service.ts` migrated to `runner.execArgs(argv, cwd)`. The only remaining `runner.exec` is the legitimate user-authored `initScript` path.
- **F06-NEW-03 (P0)** — `escapeShellString` helper deleted entirely. Positional argv eliminates the need for shell-quote escaping; the helper had multiple coverage gaps (`;`, `|`, `&`, `\r`, `(`, `)`, etc.) that would have re-opened with any new caller.
- **F06-NEW-06 (P1)** — `validateShellCommand` hardened to reject NULL byte (U+0000), Unicode line separators (U+2028, U+2029), `\t`, `\v`, standalone `&`, `>` / `<` redirection, `${` / `$(` expansion, and backslash-newline continuation.

## Files changed

- `src/server/bootstrap/service-container.ts:62` — `createBunCommandRunner.exec` marked `@deprecated`; emits `log.warn` on every call so a future PR can audit and remove remaining call sites.
- `src/services/worktree.service.ts` — drop `escapeShellString`; add `requireExecArgs()` helper that throws when a test stub omits `execArgs`. Tighten `validateShellCommand`. Convert these callers to positional argv:
  - `git branch --list` (branch existence check)
  - `git worktree add` (creation)
  - `git worktree remove [--force]` (removal)
  - `git branch -D`
  - `cp -- <src> <target>` (envFile copy)
  - `bun install`
  - `git add -A`, `git status --porcelain`, `git commit -m <msg>`, `git rev-parse HEAD` (commit; message is LLM-controlled)
  - `git checkout`, `git pull --rebase`, `git merge --no-ff -m`, `git merge --abort`, `git diff --name-only --diff-filter=U`
  - `git diff --numstat <revspec>`, `git diff <revspec>` (revspec `<base>...HEAD` is a single argv element)
- `src/services/__tests__/worktree.service.test.ts` — rewritten to provide `execArgs` mock; 13 new F06-NEW-01 + F06-NEW-06 cases.
- `tests/lib/agents/command-runner-fuzz.test.ts` — **new** fast-check property tests (200+50 runs each) verifying hostile strings with `;|&` `\` `\r()'\n\t  ` survive literally to argv. The shell template is asserted byte-identical across every input — proving the hostile payload never reaches `sh -c`.
- `tests/integration/worktree.test.ts` — runner now provides both `exec` (legacy) and `execArgs` (via `child_process.execFile`).
- `tests/functional/prove-session-worktree-bugs.test.ts` — two mock runners updated to expose `execArgs` so the existing `cmd.includes(...)` assertions still match.
- `tests/mocks/mock-git.ts` — `createMockCommandRunner` now exposes both `exec` and `execArgs` (the `execArgs` impl joins argv with spaces so existing pattern-match responses keep working).

## Test bar (red→green)

| Before fix (FAILS) | After fix (PASSES) |
|---|---|
| `escapeShellString` lets `;|&` through; `git commit -m "${escapedMessage}"` interpolates a malicious LLM message into `sh -c` and runs `rm -rf /` | All argv elements pass to `Bun.spawn(argv)` literally; `commit` test verifies argv `['git', 'commit', '-m', "evil'; rm -rf /; echo '"]` arrives as 4 elements — never split |
| `validateShellCommand('foo bar')` accepts (Unicode separator not rejected) | `validateShellCommand('foo bar')` throws `SHELL_INJECTION_DETECTED` |
| `validateShellCommand('foo\tbar')` accepts | `validateShellCommand('foo\tbar')` throws |
| Property test: hostile `&` payload forwarded to argv but the shell template is byte-identical | Property test passes — same template emitted regardless of input |

Specific test names:
- `tests/lib/agents/command-runner-fuzz.test.ts:F06-NEW-01: command-runner argv survives shell metacharacters` — 6 property tests, 200+50 runs each
- `src/services/__tests__/worktree.service.test.ts:F06-NEW-01: shell injection via positional argv` — 3 named cases (branch, copyEnv, legacy-runner-rejected)
- `src/services/__tests__/worktree.service.test.ts:F06-NEW-06: validateShellCommand hardening` — 10 cases (each rejected metacharacter + a positive)

## Status vs April 29 review

- F06-NEW-01 (P0): **RESOLVED** — all string-composed callers in `worktree.service` converted; legacy `exec` deprecated with runtime warning.
- F06-NEW-03 (P0): **RESOLVED** — `escapeShellString` deleted entirely; positional argv eliminates the need.
- F06-NEW-06 (P1): **RESOLVED** — `validateShellCommand` expanded to reject NULL, U+2028/U+2029, `\t`, `\v`, `&`, `<>`, `${`, `\\\n`.

## Hard constraints honored

- No new infrastructure, no new dependencies (`fast-check` is already in `package.json`).
- Drizzle untouched (no DB changes).
- All call sites converted; no half-finished implementation.
- Type-check + Biome pass cleanly.

## Test plan

- [x] Unit project (`npx vitest run --project unit`) — 4422/4422 passing
- [x] DB project (`npx vitest run --project db`) — 2169/2169 passing
- [x] Integration project (`npx vitest run --project integration`) — 2239/2239 passing
- [x] Functional project (`npx vitest run --project functional`) — 84/84 passing
- [x] JSDOM project (`npx vitest run --project jsdom`) — 484/484 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx @biomejs/biome check src/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
