### PR TITLE
fix(arch29-W2-E): sandbox UNIQUE lifecycle fix (F04-08)

### DIFF
--- a/src/db/migrations-pg/0013_sandbox_unique_partial.sql
+++ b/src/db/migrations-pg/0013_sandbox_unique_partial.sql
@@ -1,0 +1,23 @@
+-- F04-08 (arch29-W2-E): Sandbox UNIQUE lifecycle fix.
+--
+-- The original schema declared `codespace_id UNIQUE` on `sandbox_instances`,
+-- which made the natural stop -> create lifecycle impossible: once a sandbox
+-- was stopped, the next `SandboxService.create()` for the same codespace
+-- failed with a unique-constraint violation on the still-present row, even
+-- though the intent was "at most one *active* sandbox per codespace".
+--
+-- Fix: drop the global UNIQUE on `codespace_id` and replace it with a
+-- partial unique index that fires only while the sandbox is in an active
+-- status. Stopped/error rows can coexist freely so the stop -> create
+-- lifecycle works.
+
+-- Drop the old UNIQUE constraint. PG names it via the column's `.unique()`
+-- declaration: `<table>_<column>_unique`. The DROP is idempotent because
+-- IF EXISTS swallows the absence in case a prior migration already removed it.
+ALTER TABLE "sandbox_instances" DROP CONSTRAINT IF EXISTS "sandbox_instances_codespace_id_unique";
+
+-- Install the partial unique index. Active = rows whose status indicates the
+-- sandbox is alive or transitioning toward alive.
+CREATE UNIQUE INDEX IF NOT EXISTS "sandbox_instances_codespace_active_unique"
+  ON "sandbox_instances" ("codespace_id")
+  WHERE status IN ('creating', 'running', 'idle', 'stopping');

--- a/src/db/migrations-pg/meta/_journal.json
+++ b/src/db/migrations-pg/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1776729600000,
       "tag": "0012_add_event_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0013_sandbox_unique_partial",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/0019_sandbox_unique_partial.sql
+++ b/src/db/migrations/0019_sandbox_unique_partial.sql
@@ -1,0 +1,27 @@
+-- F04-08 (arch29-W2-E): Sandbox UNIQUE lifecycle fix.
+--
+-- The original schema declared `codespace_id UNIQUE` on `sandbox_instances`,
+-- which made the natural stop -> create lifecycle impossible: once a sandbox
+-- was stopped, the next `SandboxService.create()` for the same codespace
+-- failed with SQLITE_CONSTRAINT_UNIQUE on the still-present row, even though
+-- the intent was "at most one *active* sandbox per codespace".
+--
+-- Fix: drop the column-level UNIQUE on `codespace_id` and replace it with a
+-- partial unique index that fires only while the sandbox is in an active
+-- status. Stopped/error rows can coexist freely so the stop -> create
+-- lifecycle works.
+--
+-- The actual SQLite migration runs through the bootstrap MIGRATIONS array
+-- (v33: sandbox-unique-partial-index). This file is the drizzle-kit
+-- equivalent for documentation parity. SQLite cannot drop a column-level
+-- UNIQUE in place; the bootstrap migration rebuilds the table.
+--> statement-breakpoint
+DROP INDEX IF EXISTS `sandbox_instances_project_id_unique`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `sandbox_instances_codespace_id_unique`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `sandbox_instances_codespace_active_unique`
+  ON `sandbox_instances` (`codespace_id`)
+  WHERE status IN ('creating', 'running', 'idle', 'stopping');
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `sandbox_instances_status_idx` ON `sandbox_instances` (`status`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1745424000000,
       "tag": "0018_add_event_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1777680000000,
+      "tag": "0019_sandbox_unique_partial",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/postgres/sandboxes.ts
+++ b/src/db/schema/postgres/sandboxes.ts
@@ -1,36 +1,58 @@
 import { createId } from '@paralleldrive/cuid2';
-import { boolean, integer, jsonb, pgTable, text, timestamp, unique } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
 import type { SandboxStatus, VolumeMountRecord } from '../shared/types';
 import { codespaces } from './codespaces';
 import { tasks } from './tasks';
 
 export type { SandboxStatus, VolumeMountRecord };
 
-export const sandboxInstances = pgTable('sandbox_instances', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
-  codespaceId: text('codespace_id')
-    .notNull()
-    .unique()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
-  containerId: text('container_id').notNull(),
-  status: text('status').$type<SandboxStatus>().default('stopped').notNull(),
-  image: text('image').notNull(),
-  memoryMb: integer('memory_mb').notNull(),
-  cpuCores: integer('cpu_cores').notNull(),
-  idleTimeoutMinutes: integer('idle_timeout_minutes').notNull(),
-  volumeMounts: jsonb('volume_mounts').$type<VolumeMountRecord[]>().default([]),
-  env: jsonb('env').$type<Record<string, string>>(),
-  errorMessage: text('error_message'),
-  createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
-  lastActivityAt: timestamp('last_activity_at', { mode: 'string' }).defaultNow().notNull(),
-  stoppedAt: timestamp('stopped_at', { mode: 'string' }),
-  updatedAt: timestamp('updated_at', { mode: 'string' })
-    .defaultNow()
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-});
+/**
+ * F04-08 (arch29-W2-E): see SQLite schema for rationale. The global UNIQUE
+ * constraint on `codespace_id` is replaced by a partial unique index that
+ * fires only while the sandbox is active.
+ */
+export const sandboxInstances = pgTable(
+  'sandbox_instances',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
+    containerId: text('container_id').notNull(),
+    status: text('status').$type<SandboxStatus>().default('stopped').notNull(),
+    image: text('image').notNull(),
+    memoryMb: integer('memory_mb').notNull(),
+    cpuCores: integer('cpu_cores').notNull(),
+    idleTimeoutMinutes: integer('idle_timeout_minutes').notNull(),
+    volumeMounts: jsonb('volume_mounts').$type<VolumeMountRecord[]>().default([]),
+    env: jsonb('env').$type<Record<string, string>>(),
+    errorMessage: text('error_message'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    lastActivityAt: timestamp('last_activity_at', { mode: 'string' }).defaultNow().notNull(),
+    stoppedAt: timestamp('stopped_at', { mode: 'string' }),
+    updatedAt: timestamp('updated_at', { mode: 'string' })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+  },
+  (table) => [
+    uniqueIndex('sandbox_instances_codespace_active_unique')
+      .on(table.codespaceId)
+      .where(sql`status IN ('creating', 'running', 'idle', 'stopping')`),
+  ]
+);
 
 export const sandboxTmuxSessions = pgTable(
   'sandbox_tmux_sessions',

--- a/src/db/schema/sqlite/sandboxes.ts
+++ b/src/db/schema/sqlite/sandboxes.ts
@@ -1,6 +1,6 @@
 import { createId } from '@paralleldrive/cuid2';
 import { sql } from 'drizzle-orm';
-import { integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+import { integer, sqliteTable, text, unique, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import type { SandboxStatus, VolumeMountRecord } from '../shared/types';
 import { codespaces } from './codespaces';
 import { tasks } from './tasks';
@@ -9,46 +9,67 @@ export type { SandboxStatus, VolumeMountRecord };
 
 /**
  * Sandbox instances table
+ *
+ * F04-08 (arch29-W2-E): The original schema used `codespaceId.unique()`,
+ * which made the natural stop -> create lifecycle impossible: once a sandbox
+ * was stopped, the next `create()` for the same codespace failed with
+ * `SQLITE_CONSTRAINT_UNIQUE` on the still-present row, even though the
+ * intent was "at most one *active* sandbox per codespace".
+ *
+ * The fix: drop the global UNIQUE on `codespace_id` and replace it with a
+ * partial unique index that fires only while the sandbox is active. This
+ * lets multiple stopped/error rows coexist while still blocking concurrent
+ * active sandboxes for the same codespace.
  */
-export const sandboxInstances = sqliteTable('sandbox_instances', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => createId()),
+export const sandboxInstances = sqliteTable(
+  'sandbox_instances',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId()),
 
-  codespaceId: text('codespace_id')
-    .notNull()
-    .unique()
-    .references(() => codespaces.id, { onDelete: 'cascade' }),
+    codespaceId: text('codespace_id')
+      .notNull()
+      .references(() => codespaces.id, { onDelete: 'cascade' }),
 
-  containerId: text('container_id').notNull(),
+    containerId: text('container_id').notNull(),
 
-  status: text('status').$type<SandboxStatus>().default('stopped').notNull(),
+    status: text('status').$type<SandboxStatus>().default('stopped').notNull(),
 
-  image: text('image').notNull(),
+    image: text('image').notNull(),
 
-  memoryMb: integer('memory_mb').notNull(),
+    memoryMb: integer('memory_mb').notNull(),
 
-  cpuCores: integer('cpu_cores').notNull(),
+    cpuCores: integer('cpu_cores').notNull(),
 
-  idleTimeoutMinutes: integer('idle_timeout_minutes').notNull(),
+    idleTimeoutMinutes: integer('idle_timeout_minutes').notNull(),
 
-  volumeMounts: text('volume_mounts', { mode: 'json' }).$type<VolumeMountRecord[]>().default([]),
+    volumeMounts: text('volume_mounts', { mode: 'json' }).$type<VolumeMountRecord[]>().default([]),
 
-  env: text('env', { mode: 'json' }).$type<Record<string, string>>(),
+    env: text('env', { mode: 'json' }).$type<Record<string, string>>(),
 
-  errorMessage: text('error_message'),
+    errorMessage: text('error_message'),
 
-  createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
+    createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
 
-  lastActivityAt: text('last_activity_at').default(sql`(datetime('now'))`).notNull(),
+    lastActivityAt: text('last_activity_at').default(sql`(datetime('now'))`).notNull(),
 
-  stoppedAt: text('stopped_at'),
+    stoppedAt: text('stopped_at'),
 
-  updatedAt: text('updated_at')
-    .default(sql`(datetime('now'))`)
-    .notNull()
-    .$onUpdate(() => new Date().toISOString()),
-});
+    updatedAt: text('updated_at')
+      .default(sql`(datetime('now'))`)
+      .notNull()
+      .$onUpdate(() => new Date().toISOString()),
+  },
+  (table) => [
+    // F04-08: only one active sandbox per codespace; stopped/error rows can
+    // coexist so the create-after-stop lifecycle works. "Active" is any
+    // status where the sandbox is alive or transitioning toward alive.
+    uniqueIndex('sandbox_instances_codespace_active_unique')
+      .on(table.codespaceId)
+      .where(sql`status IN ('creating', 'running', 'idle', 'stopping')`),
+  ]
+);
 
 /**
  * Sandbox tmux sessions table

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -384,4 +384,99 @@ CREATE INDEX IF NOT EXISTS event_outbox_next_attempt_at_idx ON event_outbox(next
 CREATE INDEX IF NOT EXISTS event_outbox_status_next_attempt_idx ON event_outbox(status, next_attempt_at);
 `,
   },
+
+  // 33. Sandbox UNIQUE lifecycle fix (F04-08, arch29-W2-E):
+  // Rebuild sandbox_instances so the global UNIQUE on codespace_id is replaced
+  // by a partial unique index that fires only while the sandbox is in an
+  // *active* state. This unblocks the natural stop -> create lifecycle:
+  // before this fix, calling SandboxService.create() for a codespace whose
+  // previous sandbox row had moved to 'stopped' threw SQLITE_CONSTRAINT_UNIQUE.
+  //
+  // SQLite cannot drop a column-level UNIQUE constraint in place (the
+  // automatic sqlite_autoindex_* cannot be dropped), so we rebuild the
+  // table. The migration is idempotent on fresh installs (the table is
+  // created in step 1 with the new shape, then the rebuild is a no-op
+  // copy of zero rows).
+  {
+    version: 33,
+    name: 'sandbox-unique-partial-index',
+    sql: `
+-- Step 1: ensure the target table exists. On fresh installs, this is the
+-- only statement that meaningfully runs (the rest become no-ops because
+-- the rebuild pivot copies zero rows).
+CREATE TABLE IF NOT EXISTS sandbox_instances (
+  id TEXT PRIMARY KEY NOT NULL,
+  codespace_id TEXT NOT NULL REFERENCES codespaces(id) ON DELETE CASCADE,
+  container_id TEXT NOT NULL,
+  status TEXT DEFAULT 'stopped' NOT NULL,
+  image TEXT NOT NULL,
+  memory_mb INTEGER NOT NULL,
+  cpu_cores INTEGER NOT NULL,
+  idle_timeout_minutes INTEGER NOT NULL,
+  volume_mounts TEXT DEFAULT '[]',
+  env TEXT,
+  error_message TEXT,
+  created_at TEXT DEFAULT (datetime('now')) NOT NULL,
+  last_activity_at TEXT DEFAULT (datetime('now')) NOT NULL,
+  stopped_at TEXT,
+  updated_at TEXT DEFAULT (datetime('now')) NOT NULL
+);
+
+-- Step 2: rebuild without the column-level UNIQUE on codespace_id.
+-- Existing databases that already have the OLD shape (column-level UNIQUE)
+-- get the new shape too. Drop any leftover staging table from a prior
+-- partial run to keep this idempotent.
+DROP TABLE IF EXISTS sandbox_instances_new_v33;
+
+CREATE TABLE sandbox_instances_new_v33 (
+  id TEXT PRIMARY KEY NOT NULL,
+  codespace_id TEXT NOT NULL REFERENCES codespaces(id) ON DELETE CASCADE,
+  container_id TEXT NOT NULL,
+  status TEXT DEFAULT 'stopped' NOT NULL,
+  image TEXT NOT NULL,
+  memory_mb INTEGER NOT NULL,
+  cpu_cores INTEGER NOT NULL,
+  idle_timeout_minutes INTEGER NOT NULL,
+  volume_mounts TEXT DEFAULT '[]',
+  env TEXT,
+  error_message TEXT,
+  created_at TEXT DEFAULT (datetime('now')) NOT NULL,
+  last_activity_at TEXT DEFAULT (datetime('now')) NOT NULL,
+  stopped_at TEXT,
+  updated_at TEXT DEFAULT (datetime('now')) NOT NULL
+);
+
+-- Step 3: copy rows. Per CLAUDE.md "Migration safety": pre-filter rows
+-- whose codespace_id no longer points to a real codespace so the FK in
+-- the new table doesn't fail. INSERT OR IGNORE is belt-and-suspenders for
+-- duplicate-PK skips on retries.
+INSERT OR IGNORE INTO sandbox_instances_new_v33 (
+  id, codespace_id, container_id, status, image, memory_mb, cpu_cores,
+  idle_timeout_minutes, volume_mounts, env, error_message,
+  created_at, last_activity_at, stopped_at, updated_at
+)
+SELECT
+  id, codespace_id, container_id, status, image, memory_mb, cpu_cores,
+  idle_timeout_minutes, volume_mounts, env, error_message,
+  created_at, last_activity_at, stopped_at, updated_at
+FROM sandbox_instances
+WHERE codespace_id IS NOT NULL
+  AND codespace_id IN (SELECT id FROM codespaces);
+
+-- Step 4: pivot the table.
+DROP TABLE sandbox_instances;
+ALTER TABLE sandbox_instances_new_v33 RENAME TO sandbox_instances;
+
+-- Step 5: install the partial unique index. Only one active sandbox per
+-- codespace at a time; stopped/error rows can coexist freely so the
+-- create-after-stop lifecycle works.
+CREATE UNIQUE INDEX IF NOT EXISTS sandbox_instances_codespace_active_unique
+  ON sandbox_instances(codespace_id)
+  WHERE status IN ('creating', 'running', 'idle', 'stopping');
+
+-- Step 6: supporting index for status-filtered queries (reconciliation
+-- phase reads by status).
+CREATE INDEX IF NOT EXISTS sandbox_instances_status_idx ON sandbox_instances(status);
+`,
+  },
 ];

--- a/tests/integration/sandbox-unique-lifecycle.test.ts
+++ b/tests/integration/sandbox-unique-lifecycle.test.ts
@@ -1,0 +1,315 @@
+/**
+ * F04-08 (arch29-W2-E): Sandbox UNIQUE constraint lifecycle fix.
+ *
+ * Before this fix, `sandbox_instances.codespace_id` carried a global UNIQUE
+ * constraint. Once a sandbox was stopped, the row stuck around in the table
+ * with `status='stopped'`. The next `SandboxService.create()` for the same
+ * codespace failed with `SQLITE_CONSTRAINT_UNIQUE` even though the existing
+ * row was no longer active. This test pins down the new behaviour:
+ *
+ *  - GREEN: stop a sandbox, then create a new one for the same codespace.
+ *           Both rows must coexist (one stopped, one running).
+ *  - GREEN: only one *active* sandbox per codespace can exist at any time.
+ *           The partial unique index still rejects two simultaneously
+ *           running rows for the same codespace.
+ *  - RED before fix: the first scenario fails with SQLITE_CONSTRAINT_UNIQUE
+ *           on the second create (regression for F04-08).
+ *
+ * The test exercises the schema directly (raw inserts) so it isolates the
+ * constraint from any service-layer logic that might mask it.
+ */
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { sandboxInstances } from '../../src/db/schema';
+import { createTestProject } from '../factories/project.factory';
+import { clearTestDatabase, execRawSql, getTestDb, setupTestDatabase } from '../helpers/database';
+
+/**
+ * Recreate the schema shape this PR ships, mirroring the bootstrap migration
+ * v33 ("sandbox-unique-partial-index"). The base test migration chain does
+ * not include `sandbox_instances` (it's in MISSING_IN_TEST_DB), so we set
+ * it up here in the post-fix shape.
+ */
+function ensureSandboxInstancesTableWithPartialIndex(): void {
+  // Drop any prior table so each test starts from a known state. The DROP
+  // also wipes any in-memory cached SQL plans referencing the legacy
+  // UNIQUE constraint, which matters because tests in other files create
+  // the legacy shape.
+  try {
+    execRawSql('DROP TABLE IF EXISTS sandbox_instances');
+  } catch {
+    // ignore — table may already be absent
+  }
+  execRawSql(`
+    CREATE TABLE sandbox_instances (
+      id TEXT PRIMARY KEY NOT NULL,
+      codespace_id TEXT NOT NULL,
+      container_id TEXT NOT NULL,
+      status TEXT DEFAULT 'stopped' NOT NULL,
+      image TEXT NOT NULL,
+      memory_mb INTEGER NOT NULL,
+      cpu_cores INTEGER NOT NULL,
+      idle_timeout_minutes INTEGER NOT NULL,
+      volume_mounts TEXT DEFAULT '[]',
+      env TEXT,
+      error_message TEXT,
+      created_at TEXT DEFAULT (datetime('now')) NOT NULL,
+      last_activity_at TEXT DEFAULT (datetime('now')) NOT NULL,
+      stopped_at TEXT,
+      updated_at TEXT DEFAULT (datetime('now')) NOT NULL
+    );
+  `);
+  execRawSql(`
+    CREATE UNIQUE INDEX IF NOT EXISTS sandbox_instances_codespace_active_unique
+      ON sandbox_instances(codespace_id)
+      WHERE status IN ('creating', 'running', 'idle', 'stopping');
+  `);
+}
+
+/**
+ * Recreate the *legacy* shape (column-level UNIQUE on codespace_id). Used
+ * to assert the regression itself: the bug exists when this shape is in
+ * play, and disappears after the partial-index migration.
+ */
+function ensureSandboxInstancesTableWithGlobalUnique(): void {
+  try {
+    execRawSql('DROP TABLE IF EXISTS sandbox_instances');
+  } catch {
+    // ignore — table may already be absent
+  }
+  execRawSql(`
+    CREATE TABLE sandbox_instances (
+      id TEXT PRIMARY KEY NOT NULL,
+      codespace_id TEXT NOT NULL UNIQUE,
+      container_id TEXT NOT NULL,
+      status TEXT DEFAULT 'stopped' NOT NULL,
+      image TEXT NOT NULL,
+      memory_mb INTEGER NOT NULL,
+      cpu_cores INTEGER NOT NULL,
+      idle_timeout_minutes INTEGER NOT NULL,
+      volume_mounts TEXT DEFAULT '[]',
+      env TEXT,
+      error_message TEXT,
+      created_at TEXT DEFAULT (datetime('now')) NOT NULL,
+      last_activity_at TEXT DEFAULT (datetime('now')) NOT NULL,
+      stopped_at TEXT,
+      updated_at TEXT DEFAULT (datetime('now')) NOT NULL
+    );
+  `);
+}
+
+describe('F04-08: sandbox_instances UNIQUE lifecycle fix (arch29-W2-E)', () => {
+  beforeEach(async () => {
+    await setupTestDatabase();
+  });
+
+  afterEach(async () => {
+    try {
+      execRawSql('DELETE FROM sandbox_instances');
+    } catch {
+      // table may have been dropped between tests; safe to ignore
+    }
+    await clearTestDatabase();
+  });
+
+  it('regression baseline (pre-fix): legacy global UNIQUE blocks stop -> create', async () => {
+    // Set up the OLD schema shape so we can prove the regression exists.
+    // This test is a control: it documents the bug we're fixing.
+    ensureSandboxInstancesTableWithGlobalUnique();
+    const project = await createTestProject();
+
+    // First sandbox row (active).
+    execRawSql(`
+      INSERT INTO sandbox_instances (
+        id, codespace_id, container_id, status, image, memory_mb, cpu_cores,
+        idle_timeout_minutes
+      ) VALUES (
+        'sb-old-1', '${project.id}', 'cont-1', 'running', 'test-image:1.0',
+        2048, 2, 30
+      );
+    `);
+
+    // Stop it.
+    execRawSql(`
+      UPDATE sandbox_instances
+      SET status = 'stopped', stopped_at = datetime('now')
+      WHERE id = 'sb-old-1';
+    `);
+
+    // Try to create a new sandbox for the same codespace. With the legacy
+    // global UNIQUE, this MUST throw.
+    let threwExpected = false;
+    try {
+      execRawSql(`
+        INSERT INTO sandbox_instances (
+          id, codespace_id, container_id, status, image, memory_mb, cpu_cores,
+          idle_timeout_minutes
+        ) VALUES (
+          'sb-old-2', '${project.id}', 'cont-2', 'running', 'test-image:1.0',
+          2048, 2, 30
+        );
+      `);
+    } catch (err) {
+      threwExpected = err instanceof Error && /UNIQUE constraint failed/i.test(err.message);
+    }
+    expect(threwExpected).toBe(true);
+  });
+
+  it('post-fix: stop then create succeeds for the same codespace (partial unique index)', async () => {
+    ensureSandboxInstancesTableWithPartialIndex();
+    const project = await createTestProject();
+    const db = getTestDb();
+
+    // First sandbox: created and running.
+    await db.insert(sandboxInstances).values({
+      id: 'sb-new-1',
+      codespaceId: project.id,
+      containerId: 'cont-1',
+      status: 'running',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+    });
+
+    // Stop it.
+    await db
+      .update(sandboxInstances)
+      .set({ status: 'stopped', stoppedAt: new Date().toISOString() })
+      .where(eq(sandboxInstances.id, 'sb-new-1'));
+
+    // Second sandbox for the SAME codespace. With the partial unique index,
+    // this must succeed because the first row is no longer active.
+    await db.insert(sandboxInstances).values({
+      id: 'sb-new-2',
+      codespaceId: project.id,
+      containerId: 'cont-2',
+      status: 'running',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+    });
+
+    // Both rows coexist; one stopped, one running.
+    const rows = await db
+      .select()
+      .from(sandboxInstances)
+      .where(eq(sandboxInstances.codespaceId, project.id));
+    expect(rows).toHaveLength(2);
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    expect(byId.get('sb-new-1')?.status).toBe('stopped');
+    expect(byId.get('sb-new-2')?.status).toBe('running');
+  });
+
+  it('post-fix: two simultaneously active sandboxes for same codespace still rejected', async () => {
+    ensureSandboxInstancesTableWithPartialIndex();
+    const project = await createTestProject();
+    const db = getTestDb();
+
+    // First active sandbox.
+    await db.insert(sandboxInstances).values({
+      id: 'sb-active-1',
+      codespaceId: project.id,
+      containerId: 'cont-1',
+      status: 'running',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+    });
+
+    // Second sandbox in *running* status for the same codespace MUST be
+    // rejected by the partial unique index (the index fires for both
+    // 'running' rows).
+    let threwExpected = false;
+    try {
+      await db.insert(sandboxInstances).values({
+        id: 'sb-active-2',
+        codespaceId: project.id,
+        containerId: 'cont-2',
+        status: 'running',
+        image: 'test-image:1.0',
+        memoryMb: 2048,
+        cpuCores: 2,
+        idleTimeoutMinutes: 30,
+      });
+    } catch (err) {
+      threwExpected = err instanceof Error && /UNIQUE constraint failed/i.test(err.message);
+    }
+    expect(threwExpected).toBe(true);
+
+    // Only one row visible.
+    const rows = await db
+      .select()
+      .from(sandboxInstances)
+      .where(eq(sandboxInstances.codespaceId, project.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe('sb-active-1');
+  });
+
+  it('post-fix: multiple stopped/error sandboxes for same codespace coexist freely', async () => {
+    ensureSandboxInstancesTableWithPartialIndex();
+    const project = await createTestProject();
+    const db = getTestDb();
+
+    // Insert three terminal-state sandbox rows for the same codespace. The
+    // partial unique index does NOT fire for any of these statuses, so all
+    // three should land.
+    await db.insert(sandboxInstances).values({
+      id: 'sb-terminal-1',
+      codespaceId: project.id,
+      containerId: 'cont-1',
+      status: 'stopped',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+      stoppedAt: new Date().toISOString(),
+    });
+    await db.insert(sandboxInstances).values({
+      id: 'sb-terminal-2',
+      codespaceId: project.id,
+      containerId: 'cont-2',
+      status: 'error',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+      errorMessage: 'simulated failure',
+    });
+    await db.insert(sandboxInstances).values({
+      id: 'sb-terminal-3',
+      codespaceId: project.id,
+      containerId: 'cont-3',
+      status: 'stopped',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+      stoppedAt: new Date().toISOString(),
+    });
+
+    // And one fresh active sandbox — should also succeed because none of
+    // the terminal rows are active.
+    await db.insert(sandboxInstances).values({
+      id: 'sb-active-fresh',
+      codespaceId: project.id,
+      containerId: 'cont-active',
+      status: 'running',
+      image: 'test-image:1.0',
+      memoryMb: 2048,
+      cpuCores: 2,
+      idleTimeoutMinutes: 30,
+    });
+
+    const rows = await db
+      .select()
+      .from(sandboxInstances)
+      .where(eq(sandboxInstances.codespaceId, project.id));
+    expect(rows).toHaveLength(4);
+    const activeRows = rows.filter((r) => r.status === 'running');
+    expect(activeRows).toHaveLength(1);
+    expect(activeRows[0]?.id).toBe('sb-active-fresh');
+  });
+});


### PR DESCRIPTION
## Summary

The `sandbox_instances.codespace_id UNIQUE` constraint blocks the natural stop -> create lifecycle: once a sandbox is stopped, the next `SandboxService.create()` for the same codespace fails with `SQLITE_CONSTRAINT_UNIQUE`, leaving an orphan container with no DB row.

This PR replaces the global UNIQUE with a partial unique index on `codespace_id` that fires only while the sandbox is in an active status (`creating`, `running`, `idle`, `stopping`). Stopped/error rows now coexist freely so the create-after-stop lifecycle works; the partial index still rejects two simultaneously running sandboxes for the same codespace.

## Findings closed

- **F04-08 (P1)** — UNIQUE constraint blocks recreate after stop.

## Files

**Schema:**
- `src/db/schema/sqlite/sandboxes.ts` — drop column-level `.unique()`, add `uniqueIndex('sandbox_instances_codespace_active_unique').on(...).where(...)`
- `src/db/schema/postgres/sandboxes.ts` — same change for PG

**Migrations:**
- `src/db/migrations-pg/0013_sandbox_unique_partial.sql` — drops the `sandbox_instances_codespace_id_unique` constraint and creates the partial unique index
- `src/db/migrations/0019_sandbox_unique_partial.sql` — drizzle-kit SQLite migration (documentation parity; actual prod path is bootstrap v33)
- `src/lib/bootstrap/migrations/index.ts` — bootstrap migration v33 rebuilds the `sandbox_instances` table because SQLite cannot drop a column-level UNIQUE in place. Per CLAUDE.md "Migration safety", orphaned `codespace_id` refs are pre-filtered before the rebuild.

**Tests:**
- `tests/integration/sandbox-unique-lifecycle.test.ts` (NEW)

## Test plan (red -> green)

- [x] **before:** `regression baseline (pre-fix): legacy global UNIQUE blocks stop -> create` (proves the bug)
- [x] **after:** `post-fix: stop then create succeeds for the same codespace` (PASS with the fix)
- [x] `post-fix: two simultaneously active sandboxes for same codespace still rejected` — partial unique index still enforces one-active
- [x] `post-fix: multiple stopped/error sandboxes for same codespace coexist freely`
- [x] All 51 existing sandbox tests still pass (`sandbox-service.test.ts`, `sandbox-service-crud.test.ts`, `sandbox-reconciliation.test.ts`)
- [x] Schema-drift suite still passes (56/56)
- [x] Migration ordering test still passes (5/5)
- [x] `npx tsc --noEmit` clean
- [x] Biome check clean

## Status vs April 29 review

- **F04-08** — closed. Schema declares partial unique; SQLite + PG migrations install it; integration test pins the expected behaviour in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
