### PR TITLE
fix(arch29-W2-C): OAuth refresh token plumbing (F03-09)

### DIFF
--- a/src/db/migrations-pg/0014_api_keys_refresh_token.sql
+++ b/src/db/migrations-pg/0014_api_keys_refresh_token.sql
@@ -1,0 +1,7 @@
+-- F03-09 (arch29-W2-C): plumb OAuth refresh token through the Claude Agent SDK.
+-- Mirrors SQLite migration 0019_api_keys_refresh_token.sql.
+--
+-- Encrypted column (AES-GCM, base64) — nullable because legacy rows and
+-- non-OAuth keys do not carry a refresh token.
+
+ALTER TABLE "api_keys" ADD COLUMN IF NOT EXISTS "encrypted_refresh_token" text;

--- a/src/db/migrations-pg/meta/_journal.json
+++ b/src/db/migrations-pg/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777680000000,
       "tag": "0013_sandbox_unique_partial",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1777766400000,
+      "tag": "0014_api_keys_refresh_token",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/0020_api_keys_refresh_token.sql
+++ b/src/db/migrations/0020_api_keys_refresh_token.sql
@@ -1,0 +1,12 @@
+-- F03-09 (arch29-W2-C): plumb OAuth refresh token through the Claude Agent SDK.
+--
+-- The agent-runner already accepts CLAUDE_OAUTH_REFRESH_TOKEN and threads it
+-- into the credentials file. The host side hardcoded `null` because no column
+-- existed to store it. Add an encrypted column (mirrors `encrypted_key`) so
+-- the host can populate it at OAuth grant time and forward it to the runner.
+--
+-- Nullable: legacy api_keys rows have no refresh token, and non-OAuth keys
+-- (e.g., regular `sk-ant-api*`) never carry one. The runner falls back to
+-- `null` (the SDK rejects empty string) when the column is absent.
+
+ALTER TABLE api_keys ADD COLUMN encrypted_refresh_token TEXT;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777680000000,
       "tag": "0019_sandbox_unique_partial",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1777766400000,
+      "tag": "0020_api_keys_refresh_token",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/postgres/api-keys.ts
+++ b/src/db/schema/postgres/api-keys.ts
@@ -13,6 +13,10 @@ export const apiKeys = pgTable('api_keys', {
   // F06-09: rotation-tracking columns. Null = not tracked (legacy rows).
   expiresAt: timestamp('expires_at', { mode: 'string' }),
   rotatedAt: timestamp('rotated_at', { mode: 'string' }),
+  // F03-09 (arch29-W2-C): encrypted OAuth refresh token (AES-GCM, base64) used
+  // by the Claude Agent SDK to silently rotate the access token mid-run. Null
+  // when the host has not been issued a refresh token (legacy rows or non-OAuth keys).
+  encryptedRefreshToken: text('encrypted_refresh_token'),
   createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { mode: 'string' })
     .defaultNow()

--- a/src/db/schema/sqlite/api-keys.ts
+++ b/src/db/schema/sqlite/api-keys.ts
@@ -22,6 +22,10 @@ export const apiKeys = sqliteTable('api_keys', {
   // F06-09: rotation-tracking columns. Null = not tracked (legacy rows).
   expiresAt: text('expires_at'),
   rotatedAt: text('rotated_at'),
+  // F03-09 (arch29-W2-C): encrypted OAuth refresh token (AES-GCM, base64) used by
+  // the Claude Agent SDK to silently rotate the access token mid-run. Null when
+  // the host has not been issued a refresh token (legacy rows, or non-OAuth keys).
+  encryptedRefreshToken: text('encrypted_refresh_token'),
   // Timestamps
   createdAt: text('created_at').default(sql`(datetime('now'))`).notNull(),
   updatedAt: text('updated_at')

--- a/src/server/routes/__tests__/api-keys.test.ts
+++ b/src/server/routes/__tests__/api-keys.test.ts
@@ -86,7 +86,11 @@ describe('API Keys Routes', () => {
       const json = await res.json();
       expect(json.ok).toBe(true);
       expect(json.data.keyInfo.configured).toBe(true);
-      expect(apiKeyService.saveKey).toHaveBeenCalledWith('anthropic', 'sk-ant-api03-test-key');
+      expect(apiKeyService.saveKey).toHaveBeenCalledWith(
+        'anthropic',
+        'sk-ant-api03-test-key',
+        undefined
+      );
     });
 
     it('returns 400 for invalid JSON body', async () => {

--- a/src/server/routes/api-keys.ts
+++ b/src/server/routes/api-keys.ts
@@ -19,9 +19,15 @@ function isKnownService(service: string): service is KnownService {
   return (KNOWN_API_KEY_SERVICES as readonly string[]).includes(service);
 }
 
-// Validation schemas
+// Validation schemas.
+// F03-09 (arch29-W2-C): the optional `refreshToken` is the OAuth refresh
+// token issued alongside an `sk-ant-oat*` access token. It is encrypted with
+// the same AES-GCM key as the access token and stored in
+// `api_keys.encrypted_refresh_token` so the agent-runner can rotate the
+// access token mid-run.
 const saveKeySchema = z.object({
   key: z.string().min(1, 'API key is required'),
+  refreshToken: z.string().min(1).optional(),
 });
 
 interface ApiKeysDeps {
@@ -104,7 +110,7 @@ export function createApiKeysRoutes({ apiKeyService }: ApiKeysDeps) {
       );
     }
 
-    const result = await apiKeyService.saveKey(service, parsed.data.key);
+    const result = await apiKeyService.saveKey(service, parsed.data.key, parsed.data.refreshToken);
 
     if (!result.ok) {
       log.error('Save key error', {

--- a/src/services/__tests__/container-agent-worktree.test.ts
+++ b/src/services/__tests__/container-agent-worktree.test.ts
@@ -84,6 +84,8 @@ function createStreamsMock() {
 function createApiKeyMock() {
   return {
     getDecryptedKey: vi.fn().mockResolvedValue('sk-ant-oat01-test-token'),
+    // F03-09 (arch29-W2-C): default to null (no refresh token stored).
+    getDecryptedRefreshToken: vi.fn().mockResolvedValue(null),
   };
 }
 

--- a/src/services/api-key.service.ts
+++ b/src/services/api-key.service.ts
@@ -29,9 +29,19 @@ export class ApiKeyService {
   constructor(private db: Database) {}
 
   /**
-   * Save an API key for a specific service (encrypted)
+   * Save an API key for a specific service (encrypted).
+   *
+   * F03-09 (arch29-W2-C): when `refreshToken` is supplied (OAuth grant flow),
+   * it is encrypted with the same AES-GCM key as the access token and stored
+   * in `encrypted_refresh_token`. Subsequent agent-runner invocations read it
+   * via {@link getDecryptedRefreshToken} and pipe it through to the SDK so the
+   * access token can be silently rotated mid-run.
    */
-  async saveKey(service: string, key: string): Promise<Result<ApiKeyInfo, ApiKeyError>> {
+  async saveKey(
+    service: string,
+    key: string,
+    refreshToken?: string | null
+  ): Promise<Result<ApiKeyInfo, ApiKeyError>> {
     // Basic validation
     if (!key || key.trim().length === 0) {
       return err({
@@ -56,6 +66,12 @@ export class ApiKeyService {
       const encrypted = await encryptToken(key);
       const masked = maskToken(key);
 
+      // Encrypt refresh token only when one was supplied. An empty string is
+      // treated the same as null so callers cannot accidentally persist an
+      // unusable empty-string token (the SDK rejects empty strings).
+      const encryptedRefreshToken =
+        refreshToken && refreshToken.trim().length > 0 ? await encryptToken(refreshToken) : null;
+
       const [saved] = await this.db
         .insert(apiKeys)
         .values({
@@ -64,6 +80,7 @@ export class ApiKeyService {
           maskedKey: masked,
           isValid: true,
           lastValidatedAt: new Date().toISOString(),
+          encryptedRefreshToken,
         })
         .returning();
 
@@ -137,6 +154,38 @@ export class ApiKeyService {
     } catch (error) {
       log.warn('Failed to decrypt API key', { error });
       throw ServiceErrors.DECRYPT_FAILED(service);
+    }
+  }
+
+  /**
+   * F03-09 (arch29-W2-C): get the decrypted OAuth refresh token for a service.
+   *
+   * Returns `null` when:
+   *   - no api_keys row exists for the service
+   *   - the row has no `encrypted_refresh_token` (legacy rows, non-OAuth keys,
+   *     or rows saved before this column existed).
+   *
+   * Decryption errors are logged and surfaced as `null` rather than throwing
+   * because a missing/corrupt refresh token is recoverable: the agent-runner
+   * simply runs without one (degrading silent rotation, not breaking startup).
+   * The access-token equivalent throws because absence there is fatal.
+   */
+  async getDecryptedRefreshToken(service: string): Promise<string | null> {
+    const row = await this.db.query.apiKeys.findFirst({
+      where: eq(apiKeys.service, service),
+    });
+
+    if (!row?.encryptedRefreshToken) {
+      return null;
+    }
+
+    try {
+      return decryptToken(row.encryptedRefreshToken);
+    } catch (error) {
+      log.warn('Failed to decrypt OAuth refresh token (continuing without)', {
+        data: { service, error: error instanceof Error ? error.message : String(error) },
+      });
+      return null;
     }
   }
 

--- a/src/services/container-agent/agentcore-bridge.service.ts
+++ b/src/services/container-agent/agentcore-bridge.service.ts
@@ -236,6 +236,11 @@ export class AgentCoreBridgeService {
     // theme-03 F11: resolve real OAuth expiry alongside the token so AgentCore
     // does not write a fabricated 24h lifetime into the credentials file.
     const oauthExpiresAtMs = await resolveOAuthExpiresAtMs(db);
+    // F03-09 (arch29-W2-C): forward the refresh token so the AgentCore handler
+    // can write it into the credentials file. AgentCore reads
+    // `oauthRefreshToken` from the payload; absence falls through to the
+    // env-var fallback (`CLAUDE_OAUTH_REFRESH_TOKEN`) and finally to null.
+    const oauthRefreshToken = await apiKeyService.getDecryptedRefreshToken('anthropic');
 
     // Build invocation payload
     const payload: Record<string, unknown> = {
@@ -247,6 +252,7 @@ export class AgentCoreBridgeService {
       phase,
       oauthToken,
       ...(oauthExpiresAtMs ? { oauthExpiresAt: oauthExpiresAtMs } : {}),
+      ...(oauthRefreshToken ? { oauthRefreshToken } : {}),
       cwd: '/workspace',
       ...(sdkSessionId ? { sdkSessionId } : {}),
     };

--- a/src/services/container-agent/container-exec.service.ts
+++ b/src/services/container-agent/container-exec.service.ts
@@ -526,6 +526,12 @@ export class ContainerExecService {
     const oauthToken = await resolveOAuthToken(apiKeyService);
     // theme-03 F11: look up real token expiry alongside the token itself.
     const oauthExpiresAtMs = oauthToken ? await resolveOAuthExpiresAtMs(db) : null;
+    // F03-09 (arch29-W2-C): pull the OAuth refresh token from the registry so
+    // the SDK can rotate the access token mid-run. Returns null when the key
+    // was saved without a refresh token (legacy rows, non-OAuth keys).
+    const oauthRefreshToken = oauthToken
+      ? await apiKeyService.getDecryptedRefreshToken('anthropic')
+      : null;
 
     if (!oauthToken) {
       log.info('No OAuth token available');
@@ -738,9 +744,11 @@ export class ContainerExecService {
       stopFilePath,
       oauthToken,
       oauthExpiresAtMs,
-      // refreshToken storage is not yet wired through the registry;
-      // agent-runner treats absence as "no refresh token".
-      oauthRefreshToken: null,
+      // F03-09 (arch29-W2-C): refresh token now flows from `api_keys.
+      // encrypted_refresh_token` through `ApiKeyService.getDecryptedRefreshToken`.
+      // Null when no refresh token is stored for this service (legacy rows or
+      // non-OAuth keys); the agent-runner falls back to its "no refresh" path.
+      oauthRefreshToken,
     });
 
     // Merge project-level env vars (sandbox.env setting) into container env.

--- a/tests/helpers/database.ts
+++ b/tests/helpers/database.ts
@@ -195,10 +195,12 @@ export async function setupTestDatabase(): Promise<TestDatabase> {
   }
 
   // F06-09: token rotation columns (migration 0017).
+  // F03-09 (arch29-W2-C): encrypted refresh token column (migration 0019).
   for (const stmt of [
     'ALTER TABLE api_tokens ADD COLUMN rotated_at TEXT',
     'ALTER TABLE api_keys ADD COLUMN expires_at TEXT',
     'ALTER TABLE api_keys ADD COLUMN rotated_at TEXT',
+    'ALTER TABLE api_keys ADD COLUMN encrypted_refresh_token TEXT',
     'ALTER TABLE github_tokens ADD COLUMN expires_at TEXT',
     'ALTER TABLE github_tokens ADD COLUMN rotated_at TEXT',
   ]) {

--- a/tests/integration/agent-oauth-refresh.test.ts
+++ b/tests/integration/agent-oauth-refresh.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration test: F03-09 (arch29-W2-C) — OAuth refresh token plumbing.
+ *
+ * Before: `container-exec.service.ts:722` hardcoded `oauthRefreshToken: null`
+ * with the inline comment "refreshToken storage is not yet wired through the
+ * registry". The agent-runner accepted `CLAUDE_OAUTH_REFRESH_TOKEN` but no
+ * host could populate it because no DB column existed.
+ *
+ * After: `api_keys.encrypted_refresh_token` (added in migration 0019/0013)
+ * holds the encrypted refresh token. `ApiKeyService.getDecryptedRefreshToken`
+ * surfaces the decrypted value, and `container-exec.service.ts` threads it
+ * through to the agent-runner via `CLAUDE_OAUTH_REFRESH_TOKEN`.
+ *
+ * Test bar (red→green):
+ *   - Before fix: `CLAUDE_OAUTH_REFRESH_TOKEN` is absent from the spawned
+ *     agent-runner env even when the api_keys row carries one.
+ *   - After fix: the env var matches the decrypted refresh token.
+ */
+
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiKeys } from '../../src/db/schema';
+import { ApiKeyService } from '../../src/services/api-key.service';
+import { ContainerExecService } from '../../src/services/container-agent/container-exec.service';
+import { SandboxStateManager } from '../../src/services/container-agent/sandbox-state';
+import { createTestProject } from '../factories/project.factory';
+import { createTestTask } from '../factories/task.factory';
+import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
+import {
+  createMockDurableStreamsService,
+  createMockSandbox,
+  createMockSandboxProvider,
+} from '../mocks/mock-services';
+
+// Mock settings service to avoid file I/O.
+vi.mock('../../src/services/settings.service.js', () => ({
+  getGlobalDefaultModel: vi.fn().mockResolvedValue('claude-sonnet-4-6'),
+  getAgentMaxRuntimeMs: vi.fn().mockResolvedValue(4 * 60 * 60 * 1000),
+}));
+
+vi.mock('../../src/lib/constants/models.js', () => ({
+  DEFAULT_AGENT_MODEL: 'claude-sonnet-4-6',
+  getFullModelId: vi.fn().mockImplementation((model: string) => model),
+}));
+
+vi.mock('../../src/lib/sandbox/skill-injector.js', () => ({
+  injectSkills: vi.fn().mockResolvedValue({ injected: 0, skipped: 0, errors: [] }),
+}));
+
+vi.mock('../../src/services/template.service.js', () => {
+  return {
+    TemplateService: class MockTemplateService {
+      getMergedConfig = vi.fn().mockResolvedValue({ ok: true, value: { skills: [] } });
+    },
+  };
+});
+
+vi.mock('../../src/lib/agents/container-bridge.js', () => ({
+  createContainerBridge: vi.fn().mockImplementation((opts) => ({
+    processStream: vi.fn().mockResolvedValue(undefined),
+    processStderr: vi.fn(),
+    _opts: opts,
+  })),
+}));
+
+function createMockReadable(): Readable {
+  const readable = new Readable({
+    read() {
+      /* intentionally empty */
+    },
+  });
+  readable.push(null);
+  return readable;
+}
+
+function createMockExecStreamResult() {
+  return {
+    stdout: createMockReadable(),
+    stderr: createMockReadable(),
+    wait: vi.fn().mockResolvedValue({ exitCode: 0 }),
+    kill: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('Agent OAuth refresh token plumbing (F03-09 / arch29-W2-C)', () => {
+  let db: ReturnType<typeof getTestDb>;
+  let state: SandboxStateManager;
+  let service: ContainerExecService;
+  let realApiKeyService: ApiKeyService;
+  let mockProvider: ReturnType<typeof createMockSandboxProvider>;
+  let mockStreams: ReturnType<typeof createMockDurableStreamsService>;
+  let mockSandbox: ReturnType<typeof createMockSandbox>;
+  let execStreamSpy: ReturnType<typeof vi.fn>;
+  let mockWorktreeInit: {
+    resolveWorktree: ReturnType<typeof vi.fn>;
+    initializeRemoteWorkspace: ReturnType<typeof vi.fn>;
+    cleanupWorktree: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    await setupTestDatabase();
+    db = getTestDb();
+
+    // Use a real ApiKeyService so we exercise the encrypted-column roundtrip.
+    realApiKeyService = new ApiKeyService(db as any);
+
+    vi.clearAllMocks();
+
+    execStreamSpy = vi.fn().mockResolvedValue(createMockExecStreamResult());
+    mockSandbox = createMockSandbox({
+      id: 'sandbox-oauth-rt-1',
+      codespaceId: 'proj-oauth-rt',
+      containerId: 'container-rt-abc',
+      status: 'running',
+      execStream: execStreamSpy,
+    });
+
+    mockProvider = createMockSandboxProvider({
+      get: vi.fn().mockResolvedValue(mockSandbox),
+      getById: vi.fn().mockResolvedValue(mockSandbox),
+      create: vi.fn().mockResolvedValue(mockSandbox),
+    });
+
+    mockStreams = createMockDurableStreamsService();
+
+    mockWorktreeInit = {
+      resolveWorktree: vi.fn().mockResolvedValue({
+        worktreeId: 'wt-rt-1',
+        worktreePath: '/workspace/.worktrees/task-branch',
+      }),
+      initializeRemoteWorkspace: vi.fn().mockResolvedValue({
+        worktreePath: '/workspace/.worktrees/task-branch',
+      }),
+      cleanupWorktree: vi.fn().mockResolvedValue(undefined),
+    };
+
+    state = new SandboxStateManager();
+
+    const deps = {
+      db: db as any,
+      provider: mockProvider,
+      streams: mockStreams,
+      apiKeyService: realApiKeyService as any,
+      worktreeService: undefined,
+      githubTokenService: undefined,
+      skillTrackingService: null,
+    };
+
+    service = new ContainerExecService(
+      deps,
+      state,
+      mockWorktreeInit as any,
+      vi.fn().mockResolvedValue(undefined),
+      vi.fn().mockReturnValue(undefined)
+    );
+
+    // Make sure no env-var fallback leaks into the test.
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_OAUTH_TOKEN;
+    delete process.env.CLAUDE_OAUTH_REFRESH_TOKEN;
+  });
+
+  afterEach(async () => {
+    state.dispose();
+    await clearTestDatabase();
+  });
+
+  it('refresh token from api_keys flows into CLAUDE_OAUTH_REFRESH_TOKEN env var', async () => {
+    // Seed: api_keys row with both access and refresh token.
+    const REFRESH = 'rt_test_secret_value';
+    const saveResult = await realApiKeyService.saveKey(
+      'anthropic',
+      'sk-ant-oat01-test-access',
+      REFRESH
+    );
+    expect(saveResult.ok).toBe(true);
+
+    // Sanity: the registry must surface the same plaintext.
+    const fromRegistry = await realApiKeyService.getDecryptedRefreshToken('anthropic');
+    expect(fromRegistry).toBe(REFRESH);
+
+    const project = await createTestProject({ id: 'proj-oauth-rt' });
+    const task = await createTestTask(project.id, {
+      title: 'OAuth refresh test',
+      column: 'in_progress',
+    });
+
+    const result = await service.startAgent({
+      codespaceId: project.id,
+      taskId: task.id,
+      sessionId: 'session-rt-1',
+      prompt: 'Refresh token test',
+      phase: 'plan',
+    });
+
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+
+    // The env passed to the agent-runner exec must contain the refresh token.
+    expect(execStreamSpy).toHaveBeenCalled();
+    const execArgs = execStreamSpy.mock.calls[0][0] as { env: Record<string, string> };
+    expect(execArgs.env.CLAUDE_OAUTH_REFRESH_TOKEN).toBe(REFRESH);
+  });
+
+  it('absence of refresh token in api_keys leaves CLAUDE_OAUTH_REFRESH_TOKEN unset (no empty-string injection)', async () => {
+    // Save key without a refresh token (legacy or non-OAuth path).
+    const saveResult = await realApiKeyService.saveKey('anthropic', 'sk-ant-oat01-no-rt');
+    expect(saveResult.ok).toBe(true);
+
+    const project = await createTestProject({ id: 'proj-oauth-rt' });
+    const task = await createTestTask(project.id, {
+      title: 'OAuth no-refresh test',
+      column: 'in_progress',
+    });
+
+    const result = await service.startAgent({
+      codespaceId: project.id,
+      taskId: task.id,
+      sessionId: 'session-rt-2',
+      prompt: 'No refresh token',
+      phase: 'plan',
+    });
+
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+
+    const execArgs = execStreamSpy.mock.calls[0][0] as { env: Record<string, string> };
+    // The env var must NOT be present (or, if present, must not be empty
+    // string — the SDK rejects empty strings).
+    expect(execArgs.env.CLAUDE_OAUTH_REFRESH_TOKEN).toBeUndefined();
+  });
+
+  it('legacy api_keys row (no encrypted_refresh_token column value) returns null and skips the env var', async () => {
+    // Simulate a legacy row by writing directly to the DB without the new
+    // column. (The column is nullable so the INSERT succeeds without it.)
+    await db.delete(apiKeys);
+    await db.insert(apiKeys).values({
+      service: 'anthropic',
+      // Encrypted form of an OAuth access token. The actual content does not
+      // matter for this test — we only care that the refresh token path
+      // returns null when encrypted_refresh_token is null.
+      encryptedKey: 'unused-but-non-empty', // bypass unique constraint
+      maskedKey: 'sk-ant-***',
+      isValid: true,
+      // encryptedRefreshToken intentionally omitted (defaults to null).
+    } as any);
+
+    const refresh = await realApiKeyService.getDecryptedRefreshToken('anthropic');
+    expect(refresh).toBeNull();
+  });
+});

--- a/tests/integration/agentcore-bridge-service.test.ts
+++ b/tests/integration/agentcore-bridge-service.test.ts
@@ -108,6 +108,9 @@ function createMockContainerExec() {
 function createMockApiKeyService() {
   return {
     getApiKey: vi.fn().mockResolvedValue('test-api-key'),
+    getDecryptedKey: vi.fn().mockResolvedValue('sk-ant-oat01-test-token'),
+    // F03-09 (arch29-W2-C): default to null (no refresh token stored).
+    getDecryptedRefreshToken: vi.fn().mockResolvedValue(null),
   };
 }
 

--- a/tests/integration/api-keys-schema-drift.test.ts
+++ b/tests/integration/api-keys-schema-drift.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration test: detect schema drift between Drizzle's `api_keys` table
+ * and the actual SQLite runtime schema.
+ *
+ * F03-09 (arch29-W2-C): the agent-runner's OAuth refresh token plumbing was
+ * dead-end on the host because no `encrypted_refresh_token` column existed
+ * to store the value. This test asserts every Drizzle column in `api_keys`
+ * exists in the runtime schema, and specifically calls out
+ * `encrypted_refresh_token` so a future migration regression fails loudly.
+ *
+ * The dedicated schema-drift suite (`schema-drift-all-tables.test.ts`)
+ * iterates every table generically. This file keeps the assertions
+ * explicit for the OAuth-critical `api_keys` table because Drizzle column
+ * names can drift silently from DB column names (`encryptedRefreshToken`
+ * vs `encrypted_refresh_token`).
+ */
+
+import { getTableColumns, sql } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { apiKeys } from '../../src/db/schema';
+import { ApiKeyService } from '../../src/services/api-key.service';
+import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
+
+describe('api_keys schema drift detection (F03-09 / arch29-W2-C)', () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(async () => {
+    await setupTestDatabase();
+    db = getTestDb();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+  });
+
+  it('DB api_keys table has every column defined in Drizzle schema', () => {
+    const drizzleColumns = getTableColumns(apiKeys);
+    const expectedColumns = Object.values(drizzleColumns).map((col) => col.name);
+
+    const tableInfo = db.all<{ name: string }>(sql`PRAGMA table_info(api_keys)`);
+    const actualColumns = new Set(tableInfo.map((col) => col.name));
+
+    for (const expected of expectedColumns) {
+      expect(
+        actualColumns.has(expected),
+        `DB api_keys table missing column '${expected}' that Drizzle schema defines`
+      ).toBe(true);
+    }
+  });
+
+  it('api_keys table has the encrypted_refresh_token column (F03-09)', () => {
+    // Explicit assertion so the failure message points at F03-09 directly.
+    const tableInfo = db.all<{ name: string; type: string; notnull: number }>(
+      sql`PRAGMA table_info(api_keys)`
+    );
+    const refreshCol = tableInfo.find((c) => c.name === 'encrypted_refresh_token');
+    expect(
+      refreshCol,
+      'api_keys.encrypted_refresh_token must exist for OAuth refresh token plumbing (F03-09)'
+    ).toBeDefined();
+    // Must be nullable: legacy rows + non-OAuth keys do not carry a refresh token.
+    expect(refreshCol?.notnull, 'encrypted_refresh_token must be nullable').toBe(0);
+    // Must be TEXT (encrypted base64).
+    expect(refreshCol?.type.toLowerCase()).toBe('text');
+  });
+
+  it('saveKey + getDecryptedRefreshToken roundtrip persists an encrypted refresh token', async () => {
+    const service = new ApiKeyService(db as any);
+
+    // Save with refresh token.
+    const saveResult = await service.saveKey(
+      'anthropic',
+      'sk-ant-oat01-roundtrip-token',
+      'rt-secret-roundtrip'
+    );
+    expect(saveResult.ok, JSON.stringify(saveResult)).toBe(true);
+
+    // Roundtrip: the DB must return the same plaintext refresh token.
+    const decrypted = await service.getDecryptedRefreshToken('anthropic');
+    expect(decrypted).toBe('rt-secret-roundtrip');
+
+    // The stored value must NOT equal the plaintext (i.e., it really was
+    // encrypted). Look at the raw row.
+    const rows = await db.select().from(apiKeys);
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.encryptedRefreshToken, 'encryptedRefreshToken column populated').toBeTruthy();
+    expect(row.encryptedRefreshToken).not.toBe('rt-secret-roundtrip');
+  });
+
+  it('saveKey without refresh token leaves encrypted_refresh_token null', async () => {
+    const service = new ApiKeyService(db as any);
+
+    const saveResult = await service.saveKey('anthropic', 'sk-ant-oat01-no-refresh');
+    expect(saveResult.ok).toBe(true);
+
+    const decrypted = await service.getDecryptedRefreshToken('anthropic');
+    expect(decrypted).toBeNull();
+
+    const rows = await db.select().from(apiKeys);
+    expect(rows[0].encryptedRefreshToken).toBeNull();
+  });
+
+  it('saveKey treats empty-string refresh token as null (SDK rejects empty string)', async () => {
+    const service = new ApiKeyService(db as any);
+
+    const saveResult = await service.saveKey('anthropic', 'sk-ant-oat01-empty-rt', '');
+    expect(saveResult.ok).toBe(true);
+
+    const decrypted = await service.getDecryptedRefreshToken('anthropic');
+    expect(decrypted).toBeNull();
+  });
+
+  it('getDecryptedRefreshToken returns null when service has no row', async () => {
+    const service = new ApiKeyService(db as any);
+
+    const result = await service.getDecryptedRefreshToken('nonexistent');
+    expect(result).toBeNull();
+  });
+});

--- a/tests/mocks/mock-services.ts
+++ b/tests/mocks/mock-services.ts
@@ -301,7 +301,13 @@ export function createMockDurableStreamsService(
  */
 export interface ApiKeyService {
   getDecryptedKey: (service: string) => Promise<string | null>;
-  saveKey?: (service: string, key: string) => Promise<Result<unknown, unknown>>;
+  /** F03-09 (arch29-W2-C): OAuth refresh token retrieval. */
+  getDecryptedRefreshToken: (service: string) => Promise<string | null>;
+  saveKey?: (
+    service: string,
+    key: string,
+    refreshToken?: string | null
+  ) => Promise<Result<unknown, unknown>>;
   getKeyInfo?: (service: string) => Promise<Result<unknown, unknown>>;
   deleteKey?: (service: string) => Promise<Result<void, unknown>>;
   markInvalid?: (service: string) => Promise<void>;
@@ -318,6 +324,8 @@ export interface ApiKeyService {
 export function createMockApiKeyService(overrides?: Partial<ApiKeyService>): ApiKeyService {
   return {
     getDecryptedKey: vi.fn().mockResolvedValue(null),
+    // F03-09 (arch29-W2-C): default to null (no refresh token stored).
+    getDecryptedRefreshToken: vi.fn().mockResolvedValue(null),
     saveKey: vi.fn().mockResolvedValue(
       ok({
         id: 'key-1',

--- a/tests/services/container-agent.service.test.ts
+++ b/tests/services/container-agent.service.test.ts
@@ -161,9 +161,14 @@ function createMockProvider(sandbox?: ReturnType<typeof createMockSandbox>) {
   };
 }
 
-function createMockApiKeyService(token: string | null = 'sk-ant-oat01-test-token') {
+function createMockApiKeyService(
+  token: string | null = 'sk-ant-oat01-test-token',
+  refreshToken: string | null = null
+) {
   return {
     getDecryptedKey: vi.fn().mockResolvedValue(token),
+    // F03-09 (arch29-W2-C): default to null (no refresh token stored).
+    getDecryptedRefreshToken: vi.fn().mockResolvedValue(refreshToken),
     saveKey: vi.fn(),
     deleteKey: vi.fn(),
   } as any;
@@ -521,6 +526,10 @@ describe('ContainerAgentService', () => {
     it('falls back to ANTHROPIC_AUTH_TOKEN env var when database key throws', async () => {
       const throwingService = {
         getDecryptedKey: vi.fn().mockRejectedValue(new Error('DB error')),
+        // F03-09 (arch29-W2-C): refresh-token resolution is gated on the
+        // access-token returning truthy, so this is never called when
+        // getDecryptedKey throws — but provide it for type-safety.
+        getDecryptedRefreshToken: vi.fn().mockResolvedValue(null),
         saveKey: vi.fn(),
         deleteKey: vi.fn(),
       } as any;


### PR DESCRIPTION
## Summary

Closes the host-side gap on OAuth refresh-token plumbing. The agent-runner already accepts `CLAUDE_OAUTH_REFRESH_TOKEN` and threads it into `~/.claude/.credentials.json` (theme-03 F11), but the host hardcoded `null` at `container-exec.service.ts:722` because no `apiKeys` column existed to store the value. The Claude SDK had no refresh token, so when the access token expired mid-run the user got an opaque 401 — exactly the symptom F11 was meant to fix.

This PR:

- Adds nullable `encryptedRefreshToken` (text) column to `apiKeys` in both SQLite and Postgres Drizzle schemas, with matching migrations `0019` / `0013` (and the `_journal.json` entries).
- Encrypts the refresh token with the same AES-GCM key as the access token via `ApiKeyService.saveKey(service, key, refreshToken?)`. Empty string is normalized to null because the SDK rejects empty strings.
- Adds `ApiKeyService.getDecryptedRefreshToken(service)` — returns `null` for missing rows, missing column values, and decrypt failures (graceful degrade: the runner simply runs without rotation rather than crash).
- Threads the value through `container-exec.service.ts` and `agentcore-bridge.service.ts`, so both Docker and AgentCore paths populate the runner.
- Extends `POST /api/keys/:service` to accept an optional `refreshToken` body field for OAuth grants.
- Extends the test-helper migration chain and `createMockApiKeyService` to include the new column / method, and updates 4 inline mock builders that didn't go through the central helper.

## Test bar (red → green)

**Before fix** — `tests/integration/agent-oauth-refresh.test.ts > refresh token from api_keys flows into CLAUDE_OAUTH_REFRESH_TOKEN env var`:
```
AssertionError: expected undefined to be 'rt_test_secret_value'
```
(verified locally by stashing `container-exec.service.ts` — `oauthRefreshToken` was hardcoded null, so the env var never appeared on the runner exec).

**After fix** — same test passes. The env var equals the decrypted refresh token round-tripped through `api_keys.encrypted_refresh_token`.

Additional coverage:

- `tests/integration/api-keys-schema-drift.test.ts` — drift assertion on `api_keys` (covers the new column explicitly, plus a roundtrip and an empty-string normalization case).
- Updated `tests/integration/agentcore-bridge-service.test.ts` and 4 other inline mocks so `getDecryptedRefreshToken` is callable.

## Status vs April 29 review

- **F03-09** — refresh-token plumbing is no longer dead-end. Host registry can store and surface the value; both Docker and AgentCore paths forward it to the runner.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx @biomejs/biome check --max-diagnostics=500 --diagnostic-level=error src/ tests/` — clean
- [x] `npx vitest run --project integration` — 2254 passed, 9 skipped
- [x] `npx vitest run` (full suite) — 9443 passed, 9 skipped
- [x] Manual: stash the `container-exec.service.ts` change, re-run `tests/integration/agent-oauth-refresh.test.ts` → fails as expected.

Signed-off-by: Simon Lynch <srlynch@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
