### PR TITLE
fix(arch29-W2-H): API write validation + tasks/:id/move shape (F07-03, F07-06)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Supply-chain check (arch29-W1-C / F04-01, F04-02, F04-11)
         run: bash scripts/check-supply-chain.sh
 
+      - name: API write validation gate (arch29-W2-H / F07-03)
+        run: bash scripts/check-api-write-validation.sh
+
       - name: Type check
         run: bun run typecheck
 

--- a/scripts/check-api-write-validation.sh
+++ b/scripts/check-api-write-validation.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# arch29-W2-H / F07-03 — API write-path validation CI gate.
+#
+# Fails the build if any route handler under `src/server/routes/` calls
+# `c.req.json()` directly. The canonical pattern is `parseJsonBody(c, schema)`
+# from `src/server/validation.ts`, which combines JSON parsing with Zod
+# schema validation in a single step and returns a structured error envelope
+# on failure.
+#
+# Allow-listed sites: routes that legitimately accept a body that cannot be
+# represented by a Zod root schema (e.g. JSON literal `null` for "clear
+# override") may bypass this check by adding the comment
+#     // HONO-ALLOW-UNTYPED:
+# on the line immediately preceding the `c.req.json()` call. The body of
+# such a route MUST still be validated via `schema.safeParse(...)` after the
+# raw read.
+#
+# Usage:
+#   scripts/check-api-write-validation.sh
+#
+# Exit codes:
+#   0 — clean (or only allow-listed sites remain)
+#   1 — un-allow-listed bare `c.req.json()` call(s) found
+#   2 — too many allow-listed sites (> 2)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ROUTES_DIR="src/server/routes"
+
+# Find every line that contains `c.req.json()` in the routes directory.
+# Excludes test files (`__tests__/` and `*.test.ts`) — those reference the
+# pattern in comments / mock setups and are not subject to the rule.
+all_matches=$(grep -RnE "c\.req\.json\(\)" \
+  --include='*.ts' \
+  --exclude-dir='__tests__' \
+  --exclude='*.test.ts' \
+  --exclude='*.spec.ts' \
+  "$ROUTES_DIR" 2>/dev/null || true)
+
+if [ -z "$all_matches" ]; then
+  echo "API write validation gate: no bare c.req.json() callers in $ROUTES_DIR — clean."
+  exit 0
+fi
+
+violations=0
+allowed=0
+
+while IFS= read -r line; do
+  # Format: file:line:contents
+  file="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+
+  # Look at the preceding 10 lines for an allow-list comment.
+  start=$((lineno - 10))
+  if [ "$start" -lt 1 ]; then
+    start=1
+  fi
+  end=$((lineno - 1))
+  if [ "$end" -ge 1 ]; then
+    prev_content=$(awk "NR>=$start && NR<=$end" "$file" 2>/dev/null || true)
+  else
+    prev_content=""
+  fi
+
+  if echo "$prev_content" | grep -qE 'HONO-ALLOW-UNTYPED:'; then
+    allowed=$((allowed + 1))
+    echo "  allow-listed: $file:$lineno (HONO-ALLOW-UNTYPED above)"
+  else
+    violations=$((violations + 1))
+    echo "ERROR: bare c.req.json() at $file:$lineno"
+    echo "  Replace with: const parsed = await parseJsonBody(c, <schema>); if (!parsed.ok) return parsed.response;"
+  fi
+done <<< "$all_matches"
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "API write validation gate FAILED ($violations un-allow-listed violation(s))."
+  echo "See arch29-W2-H / specs/arch_review_april29/07-api-surface.md (F07-03)."
+  exit 1
+fi
+
+if [ "$allowed" -gt 2 ]; then
+  echo ""
+  echo "API write validation gate FAILED: too many allow-listed sites ($allowed > 2)."
+  echo "Migrate the rest to parseJsonBody. See arch29-W2-H plan."
+  exit 2
+fi
+
+echo "API write validation gate passed ($allowed allow-listed site(s) within budget)."

--- a/src/server/routes/__tests__/agents.test.ts
+++ b/src/server/routes/__tests__/agents.test.ts
@@ -250,7 +250,9 @@ describe('Agents API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_PARAMS');
+      // arch29-W2-H / F07-03: parseJsonBody now emits VALIDATION_ERROR
+      // for empty/invalid update bodies (was MISSING_PARAMS).
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 for invalid JSON body', async () => {
@@ -265,7 +267,46 @@ describe('Agents API Routes', () => {
 
       expect(res.status).toBe(400);
       const json = await res.json();
-      expect(json.error.code).toBe('INVALID_JSON');
+      // arch29-W2-H / F07-15: parseJsonBody emits VALIDATION_ERROR for
+      // JSON parse failures (was INVALID_JSON).
+      expect(json.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('arch29-W2-H / F07-03: rejects oversized systemPrompt (Zod-bypass regression)', async () => {
+      // Before W2-H, PATCH /api/agents/:id called `c.req.json()` directly
+      // and forwarded the body to `agentService.update` with no field
+      // validation. A client could send `{ systemPrompt: 'x'.repeat(1e6) }`
+      // and the giant string would land in the DB. This test asserts the
+      // schema now bounds the field at 20000 chars.
+      const { app, agentService } = createTestApp();
+
+      const oversized = 'x'.repeat(20_001);
+      const res = await request(app, 'PATCH', '/api/agents/agent-1', {
+        systemPrompt: oversized,
+      });
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe('VALIDATION_ERROR');
+      // Service must NOT have been called with the oversized payload.
+      expect(agentService.update).not.toHaveBeenCalled();
+    });
+
+    it('arch29-W2-H / F07-03: rejects unknown enum values for status fields', async () => {
+      // Before W2-H, the status field on workflows.ts:97 was bare-cast to
+      // the enum union — clients could write `status: "garbage"`. The
+      // updateAgentSchema does not have a status field, but the same
+      // pattern applied to allowedTools max length.
+      const { app, agentService } = createTestApp();
+
+      const res = await request(app, 'PATCH', '/api/agents/agent-1', {
+        allowedTools: Array.from({ length: 201 }, (_, i) => `tool-${i}`),
+      });
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe('VALIDATION_ERROR');
+      expect(agentService.update).not.toHaveBeenCalled();
     });
   });
 
@@ -361,7 +402,10 @@ describe('Agents API Routes', () => {
 
       expect(res.status).toBe(400);
       const json = await res.json();
-      expect(json.error.code).toBe('INVALID_ID');
+      // arch29-W2-H / F07-03: zod schema rejects taskIds that don't match
+      // idSchema regex with VALIDATION_ERROR (was a manual INVALID_ID
+      // check after raw JSON parse).
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
   });
 

--- a/src/server/routes/__tests__/api-keys.test.ts
+++ b/src/server/routes/__tests__/api-keys.test.ts
@@ -106,7 +106,9 @@ describe('API Keys Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      // arch29-W2-H / F07-15: parseJsonBody emits VALIDATION_ERROR for
+      // both JSON parse failures and zod validation failures.
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when key is missing', async () => {

--- a/src/server/routes/__tests__/cli-monitor.test.ts
+++ b/src/server/routes/__tests__/cli-monitor.test.ts
@@ -146,7 +146,7 @@ describe('CLI Monitor API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 200 with valid minimal payload', async () => {
@@ -224,7 +224,7 @@ describe('CLI Monitor API Routes', () => {
 
       expect(res.status).toBe(400);
       const json = await res.json();
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
   });
 
@@ -367,7 +367,7 @@ describe('CLI Monitor API Routes', () => {
 
       expect(res.status).toBe(400);
       const json = await res.json();
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
   });
 
@@ -431,7 +431,7 @@ describe('CLI Monitor API Routes', () => {
 
       expect(res.status).toBe(400);
       const json = await res.json();
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
   });
 

--- a/src/server/routes/__tests__/marketplaces.test.ts
+++ b/src/server/routes/__tests__/marketplaces.test.ts
@@ -135,7 +135,8 @@ describe('Marketplaces API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_NAME');
+      // arch29-W2-H / F07-15: error code standardised to VALIDATION_ERROR.
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when github info is missing', async () => {
@@ -148,7 +149,8 @@ describe('Marketplaces API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_REPO');
+      // arch29-W2-H / F07-15: error code standardised to VALIDATION_ERROR.
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 for invalid JSON body', async () => {
@@ -164,7 +166,7 @@ describe('Marketplaces API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('accepts githubUrl instead of owner/repo', async () => {

--- a/src/server/routes/__tests__/memory.test.ts
+++ b/src/server/routes/__tests__/memory.test.ts
@@ -410,7 +410,7 @@ describe('Memory API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('creates insight and returns 201', async () => {
@@ -702,7 +702,7 @@ describe('Memory API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns search results', async () => {
@@ -1436,7 +1436,7 @@ describe('Memory API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns error when service returns err', async () => {
@@ -1944,7 +1944,7 @@ describe('Memory API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 500 when service throws', async () => {

--- a/src/server/routes/__tests__/sandbox.test.ts
+++ b/src/server/routes/__tests__/sandbox.test.ts
@@ -228,7 +228,7 @@ describe('Sandbox Config API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when name is missing (create requires name)', async () => {
@@ -551,7 +551,7 @@ describe('Sandbox Config API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 for invalid type value in update', async () => {

--- a/src/server/routes/__tests__/tasks.test.ts
+++ b/src/server/routes/__tests__/tasks.test.ts
@@ -349,22 +349,34 @@ describe('Tasks API Routes', () => {
       expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
-    it('returns agent error info when agent start fails', async () => {
+    it('returns ok:false with AGENT_START_FAILED when agent start fails', async () => {
+      // arch29-W2-H / F07-06: when the move succeeds but agent auto-start
+      // fails, the route MUST surface the failure as `ok:false` with
+      // `error.code === 'AGENT_START_FAILED'`. Previously it returned
+      // `ok:true` with a hidden `data.agentError` field, masking the
+      // failure from any client that keys on `result.ok` (the canonical
+      // pattern across the entire client). The service has already
+      // reverted the column to backlog by this point.
       const { app, taskService } = createTestApp();
-      const movedTask = { id: 'task-1', column: 'in_progress' };
+      const revertedTask = { id: 'task-1', column: 'backlog' };
       taskService.moveColumn.mockResolvedValue({
         ok: true,
-        value: { task: movedTask, agentError: 'No idle agents available' },
+        value: { task: revertedTask, agentError: 'No idle agents available' },
       });
 
       const res = await request(app, 'PATCH', '/api/tasks/task-1/move', {
         column: 'in_progress',
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(500);
       const json = await res.json();
-      expect(json.ok).toBe(true);
-      expect(json.data.agentError).toBe('No idle agents available');
+      expect(json.ok).toBe(false);
+      expect(json.error.code).toBe('AGENT_START_FAILED');
+      expect(json.error.message).toBe('No idle agents available');
+      // The reverted task is included in details so the client can patch
+      // local state without a separate fetch.
+      expect(json.error.details.task.column).toBe('backlog');
+      expect(json.error.details.taskId).toBe('task-1');
     });
   });
 
@@ -549,7 +561,7 @@ describe('Tasks API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
       expect(json.error.message).toContain('reason');
     });
 
@@ -563,7 +575,7 @@ describe('Tasks API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when reason is whitespace-only', async () => {
@@ -576,7 +588,7 @@ describe('Tasks API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when reason is non-string type', async () => {
@@ -589,7 +601,7 @@ describe('Tasks API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 for invalid id', async () => {

--- a/src/server/routes/__tests__/templates.test.ts
+++ b/src/server/routes/__tests__/templates.test.ts
@@ -141,7 +141,7 @@ describe('Templates API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when name is missing', async () => {
@@ -155,7 +155,7 @@ describe('Templates API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when scope is missing', async () => {
@@ -169,7 +169,7 @@ describe('Templates API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
       expect(json.error.message).toContain('scope');
     });
 
@@ -185,7 +185,7 @@ describe('Templates API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when githubUrl is missing', async () => {
@@ -199,7 +199,7 @@ describe('Templates API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('MISSING_PARAMS');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
       expect(json.error.message).toContain('githubUrl');
     });
 
@@ -338,7 +338,7 @@ describe('Templates API Routes', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.ok).toBe(false);
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns error when service update fails', async () => {

--- a/src/server/routes/__tests__/workflows.test.ts
+++ b/src/server/routes/__tests__/workflows.test.ts
@@ -324,7 +324,7 @@ describe('Workflows API Routes', () => {
 
       expect(res.status).toBe(400);
       const json = await res.json();
-      expect(json.error.code).toBe('INVALID_JSON');
+      expect(json.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 404 when workflow not found', async () => {

--- a/src/server/routes/agents.ts
+++ b/src/server/routes/agents.ts
@@ -5,8 +5,14 @@
 import { Hono } from 'hono';
 import type { AgentConfig } from '../../db/schema';
 import type { AgentService } from '../../services/agent.service.js';
-import { errorResponse, isValidId, json, requireQueryId, validateIdParam } from '../shared.js';
-import { createAgentSchema, parseJsonBody } from '../validation.js';
+import { errorResponse, json, requireQueryId, validateIdParam } from '../shared.js';
+import {
+  agentResumeSchema,
+  agentStartSchema,
+  createAgentSchema,
+  parseJsonBody,
+  updateAgentSchema,
+} from '../validation.js';
 
 interface AgentsDeps {
   agentService: AgentService;
@@ -71,23 +77,13 @@ export function createAgentsRoutes({ agentService }: AgentsDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: { config?: Partial<AgentConfig> } & Partial<AgentConfig>;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, updateAgentSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
-    const updateInput = body.config ?? body;
-    if (!updateInput || Object.keys(updateInput).length === 0) {
-      return json(
-        { ok: false, error: { code: 'MISSING_PARAMS', message: 'config is required' } },
-        400
-      );
-    }
+    // Accept either `{ config: {...} }` (wrapped) or flat AgentConfig fields.
+    const { config, ...flatFields } = body;
+    const updateInput: Partial<AgentConfig> = config ?? (flatFields as Partial<AgentConfig>);
 
     const result = await agentService.update(id, updateInput);
 
@@ -117,26 +113,15 @@ export function createAgentsRoutes({ agentService }: AgentsDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: { taskId?: string } | null = null;
-    try {
-      if (c.req.header('Content-Type')?.includes('application/json')) {
-        body = await c.req.json();
-      }
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
+    // Body is optional — only validate when Content-Type indicates JSON.
+    let taskId: string | undefined;
+    if (c.req.header('Content-Type')?.includes('application/json')) {
+      const parsed = await parseJsonBody(c, agentStartSchema);
+      if (!parsed.ok) return parsed.response;
+      taskId = parsed.data.taskId;
     }
 
-    if (body?.taskId && !isValidId(body.taskId)) {
-      return json(
-        { ok: false, error: { code: 'INVALID_ID', message: 'Invalid taskId format' } },
-        400
-      );
-    }
-
-    const result = await agentService.start(id, body?.taskId);
+    const result = await agentService.start(id, taskId);
 
     if (!result.ok) {
       return errorResponse(result);
@@ -192,19 +177,15 @@ export function createAgentsRoutes({ agentService }: AgentsDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: { feedback?: string } | null = null;
-    try {
-      if (c.req.header('Content-Type')?.includes('application/json')) {
-        body = await c.req.json();
-      }
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
+    // Body is optional — only validate when Content-Type indicates JSON.
+    let feedback: string | undefined;
+    if (c.req.header('Content-Type')?.includes('application/json')) {
+      const parsed = await parseJsonBody(c, agentResumeSchema);
+      if (!parsed.ok) return parsed.response;
+      feedback = parsed.data.feedback;
     }
 
-    const result = await agentService.resume(id, body?.feedback);
+    const result = await agentService.resume(id, feedback);
 
     if (!result.ok) {
       return errorResponse(result);

--- a/src/server/routes/cli-monitor.ts
+++ b/src/server/routes/cli-monitor.ts
@@ -12,6 +12,7 @@ import { createLogger } from '../../lib/logging/logger.js';
 import type { CliMonitorService } from '../../services/cli-monitor/cli-monitor.service.js';
 import type { CliSession } from '../../services/cli-monitor/types.js';
 import { parseLimit, parseOffset, requireQueryParam } from '../shared.js';
+import { parseJsonBody } from '../validation.js';
 
 const logger = createLogger('routes:cli-monitor');
 
@@ -183,23 +184,6 @@ const CLI_MONITOR_SSE_ROUTE = '/api/cli-monitor/stream';
 
 // ── Helpers ──
 
-function validationError(
-  c: { json: (data: unknown, status: number) => Response },
-  issues: z.ZodIssue[]
-) {
-  return c.json(
-    {
-      ok: false,
-      error: { code: 'VALIDATION_ERROR', message: issues[0]?.message ?? 'Invalid payload' },
-    },
-    400
-  );
-}
-
-function invalidJsonError(c: { json: (data: unknown, status: number) => Response }) {
-  return c.json({ ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON body' } }, 400);
-}
-
 function checkBodySize(c: {
   req: { header: (name: string) => string | undefined };
   json: (data: unknown, status: number) => Response;
@@ -223,8 +207,10 @@ interface CliMonitorDeps {
   cliMonitorService: CliMonitorService;
 }
 
-/** Parse and validate a JSON POST body against a Zod schema.
- *  Returns the parsed data on success, or an error Response on failure. */
+/** Parse and validate a JSON POST body against a Zod schema, with cli-monitor
+ *  5MB body-size limit applied before parsing. Returns parsed data or an
+ *  error Response. Delegates JSON parse + zod validation to the canonical
+ *  `parseJsonBody` helper to ensure consistent error envelopes. */
 async function parseBody<T>(
   c: {
     req: { header: (name: string) => string | undefined; json: () => Promise<unknown> };
@@ -234,16 +220,8 @@ async function parseBody<T>(
 ): Promise<T | Response> {
   const sizeError = checkBodySize(c);
   if (sizeError) return sizeError;
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return invalidJsonError(c);
-  }
-  const parsed = schema.safeParse(body);
-  if (!parsed.success) {
-    return validationError(c, parsed.error.issues);
-  }
+  const parsed = await parseJsonBody(c, schema);
+  if (!parsed.ok) return parsed.response;
   return parsed.data;
 }
 

--- a/src/server/routes/codespaces.ts
+++ b/src/server/routes/codespaces.ts
@@ -7,7 +7,6 @@
 import path from 'node:path';
 import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
-import { z } from 'zod';
 import { agents } from '../../db/schema';
 import { createLogger } from '../../lib/logging/logger.js';
 import { deriveGitHubFromPath } from '../../lib/sandbox/git-token-resolver.js';
@@ -15,26 +14,9 @@ import type { CodespaceService } from '../../services/codespace.service.js';
 import type { TemplateService } from '../../services/template.service.js';
 import type { Database } from '../../types/database.js';
 import { json, parseLimit, validateIdParam } from '../shared.js';
+import { createCodespaceSchema, parseJsonBody, updateCodespaceSchema } from '../validation.js';
 
 const logger = createLogger('routes:codespaces');
-
-// Validation schemas
-const createCodespaceSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  path: z.string().min(1, 'Path is required'),
-  description: z.string().optional(),
-  projectFolderId: z.string().min(1, 'projectFolderId is required'),
-});
-
-const updateCodespaceSchema = z.object({
-  name: z.string().min(1).optional(),
-  description: z.string().optional(),
-  maxConcurrentAgents: z.number().int().positive().optional(),
-  config: z.record(z.string(), z.unknown()).optional(),
-  projectFolderId: z.string().min(1).optional(),
-  githubOwner: z.string().min(1).max(200).optional(),
-  githubRepo: z.string().min(1).max(200).optional(),
-});
 
 interface CodespacesDeps {
   codespaceService: CodespaceService;
@@ -79,29 +61,8 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
 
   // POST /api/codespaces
   app.post('/', async (c) => {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = createCodespaceSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'Invalid request',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, createCodespaceSchema);
+    if (!parsed.ok) return parsed.response;
 
     // AR-033: Validate path at creation time, not just deletion time.
     // Ensures the path resolves to a safe location, preventing registration of system
@@ -252,29 +213,8 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = updateCodespaceSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'Invalid request',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, updateCodespaceSchema);
+    if (!parsed.ok) return parsed.response;
 
     const result = await codespaceService.update(id, {
       name: parsed.data.name,

--- a/src/server/routes/marketplaces.ts
+++ b/src/server/routes/marketplaces.ts
@@ -6,6 +6,7 @@ import { Hono } from 'hono';
 import { createLogger } from '../../lib/logging/logger.js';
 import type { MarketplaceService } from '../../services/marketplace.service.js';
 import { errorResponse, json, parseLimit, validateIdParam } from '../shared.js';
+import { createMarketplaceSchema, parseJsonBody } from '../validation.js';
 
 const logger = createLogger('routes:marketplaces');
 
@@ -52,38 +53,18 @@ export function createMarketplacesRoutes({ marketplaceService }: MarketplacesDep
 
   // POST /api/marketplaces
   app.post('/', async (c) => {
-    let body: {
-      name: string;
-      githubUrl?: string;
-      githubOwner?: string;
-      githubRepo?: string;
-      branch?: string;
-      pluginsPath?: string;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, createMarketplaceSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
-    if (!body.name) {
-      return json({ ok: false, error: { code: 'MISSING_NAME', message: 'Name is required' } }, 400);
-    }
-
-    if (!body.githubUrl && (!body.githubOwner || !body.githubRepo)) {
-      return json(
-        {
-          ok: false,
-          error: { code: 'MISSING_REPO', message: 'GitHub URL or owner/repo required' },
-        },
-        400
-      );
-    }
-
-    const result = await marketplaceService.create(body);
+    const result = await marketplaceService.create({
+      name: body.name,
+      githubUrl: body.githubUrl,
+      githubOwner: body.githubOwner,
+      githubRepo: body.githubRepo,
+      branch: body.branch,
+      pluginsPath: body.pluginsPath,
+    });
     if (!result.ok) {
       return errorResponse(result);
     }

--- a/src/server/routes/memory.ts
+++ b/src/server/routes/memory.ts
@@ -7,7 +7,6 @@
 
 import { and, eq, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
-import { z } from 'zod';
 import { codespaces, sessionEvents, tasks } from '../../db/schema/index.js';
 import { jsonExtractText } from '../../lib/db/dialect.js';
 import { createLogger } from '../../lib/logging/logger.js';
@@ -16,34 +15,16 @@ import type { MemoryService } from '../../services/memory/index.js';
 import type { SkillTrackingService } from '../../services/memory/skill-tracking.service.js';
 import type { Database } from '../../types/database.js';
 import { json } from '../shared.js';
+import {
+  createMemoryInsightSchema,
+  dreamSkillOverrideSchema,
+  memoryModifySuggestionSchema,
+  memorySearchSchema,
+  memorySuggestionActionSchema,
+  parseJsonBody,
+} from '../validation.js';
 
 const log = createLogger('MemoryRoutes');
-
-// Validation schemas
-const createInsightSchema = z.object({
-  content: z.string().min(1).max(4096),
-  source: z.enum(['manual', 'agent_derived', 'dream']).optional().default('manual'),
-  skillId: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-  category: z
-    .enum(['pattern', 'anti_pattern', 'decision', 'architecture', 'error_lesson'])
-    .optional(),
-});
-
-const searchSchema = z.object({
-  query: z.string().min(1).max(1024),
-  limit: z.number().min(1).max(50).optional(),
-});
-
-const suggestionActionSchema = z.object({
-  userNotes: z.string().optional(),
-});
-
-const modifySuggestionSchema = z.object({
-  modifiedContent: z.string().min(1),
-  userNotes: z.string().optional(),
-});
 
 /** Parse and clamp pagination query params. */
 function parsePagination(
@@ -144,29 +125,8 @@ export function createMemoryRoutes({
     c: { req: { json: () => Promise<unknown> } },
     codespaceId: string | null
   ): Promise<Response> {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = searchSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'query is required',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, memorySearchSchema);
+    if (!parsed.ok) return parsed.response;
 
     return wrapHandler('Failed to search', async () => {
       const result = await memoryService.search(codespaceId, parsed.data.query, parsed.data.limit);
@@ -273,12 +233,29 @@ export function createMemoryRoutes({
   );
 
   app.put('/dream-config/skills/:skillId', async (c) => {
-    let body: unknown;
+    // Body shape: either `null`, `{}` (clear override), or
+    // `{ enabled?, model?, minRuns? }`. Use the structured zod schema to
+    // validate populated payloads; the null/empty-object case is treated as
+    // "clear the override" (matching the previous behaviour).
+    //
+    // HONO-ALLOW-UNTYPED: zod cannot represent a JSON literal `null` at the
+    // root of a request body. We accept null/{}/object here, then validate
+    // the populated case via `dreamSkillOverrideSchema.safeParse` below.
+    let rawBody: unknown;
     try {
-      body = await c.req.json();
-    } catch {
+      rawBody = await c.req.json();
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        return json(
+          { ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid JSON' } },
+          400
+        );
+      }
       return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
+        {
+          ok: false,
+          error: { code: 'VALIDATION_ERROR', message: 'Failed to read request body' },
+        },
         400
       );
     }
@@ -286,11 +263,31 @@ export function createMemoryRoutes({
     const skillId = c.req.param('skillId');
 
     // null body OR empty object means clear the override (client sends {} when null
-    // cannot be serialized via JSON, e.g. `override ?? {}`)
-    const override =
-      body === null || (typeof body === 'object' && Object.keys(body as object).length === 0)
-        ? null
-        : (body as { enabled?: boolean; model?: string; minRuns?: number });
+    // cannot be serialized via JSON, e.g. `override ?? {}`).
+    const isClearOverride =
+      rawBody === null ||
+      (typeof rawBody === 'object' &&
+        rawBody !== null &&
+        !Array.isArray(rawBody) &&
+        Object.keys(rawBody as object).length === 0);
+
+    let override: { enabled?: boolean; model?: string; minRuns?: number } | null = null;
+    if (!isClearOverride) {
+      const parsed = dreamSkillOverrideSchema.safeParse(rawBody);
+      if (!parsed.success) {
+        return json(
+          {
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: parsed.error.issues[0]?.message ?? 'Invalid skill override',
+            },
+          },
+          400
+        );
+      }
+      override = parsed.data ?? null;
+    }
 
     return wrapHandler('Failed to set dream skill override', async () => {
       const result = await dreamService.setSkillOverride(skillId, override);
@@ -423,29 +420,8 @@ export function createMemoryRoutes({
 
   // POST /api/memory/codespaces/:codespaceId/insights
   app.post('/codespaces/:codespaceId/insights', async (c) => {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = createInsightSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'content is required',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, createMemoryInsightSchema);
+    if (!parsed.ok) return parsed.response;
 
     return wrapHandler('Failed to create insight', async () => {
       const codespaceId = c.req.param('codespaceId');
@@ -567,20 +543,27 @@ export function createMemoryRoutes({
     handleGetSuggestions(c, c.req.param('codespaceId'))
   );
 
-  // Accept and reject share identical structure — only the service method differs
+  // Accept and reject share identical structure — only the service method differs.
+  // Body is optional; userNotes is the only valid field. When Content-Type is
+  // not application/json (or omitted), we treat the body as missing and skip
+  // validation — matching the previous behaviour.
   async function handleSuggestionAction(
-    c: { req: { param: (k: string) => string; json: () => Promise<unknown> } },
+    c: {
+      req: {
+        param: (k: string) => string;
+        header: (name: string) => string | undefined;
+        json: () => Promise<unknown>;
+      };
+    },
     action: 'accept' | 'reject'
   ): Promise<Response> {
-    let body: Record<string, unknown> = {};
-    try {
-      body = (await c.req.json()) as Record<string, unknown>;
-    } catch {
-      // body is optional
+    let userNotes: string | undefined;
+    if (c.req.header('Content-Type')?.includes('application/json')) {
+      const parsed = await parseJsonBody(c, memorySuggestionActionSchema);
+      if (!parsed.ok) return parsed.response;
+      userNotes = parsed.data.userNotes;
     }
 
-    const parsed = suggestionActionSchema.safeParse(body);
-    const userNotes = parsed.success ? parsed.data.userNotes : undefined;
     const serviceFn =
       action === 'accept'
         ? dreamService.acceptSuggestion.bind(dreamService)
@@ -597,29 +580,8 @@ export function createMemoryRoutes({
   app.patch('/suggestions/:id/reject', (c) => handleSuggestionAction(c, 'reject'));
 
   app.patch('/suggestions/:id/modify', async (c) => {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = modifySuggestionSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'modifiedContent is required',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, memoryModifySuggestionSchema);
+    if (!parsed.ok) return parsed.response;
 
     return wrapHandler('Failed to modify suggestion', async () => {
       const result = await dreamService.modifySuggestion(

--- a/src/server/routes/sandbox-configs.ts
+++ b/src/server/routes/sandbox-configs.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { SANDBOX_TYPES } from '../../db/schema/shared/enums.js';
 import type { SandboxConfigService } from '../../services/sandbox-config.service.js';
 import { errorResponse, json, parseLimit, parseOffset, validateIdParam } from '../shared.js';
+import { parseJsonBody } from '../validation.js';
 import { validateNomadAddress } from './sandbox-nomad.js';
 
 const sandboxConfigBodySchema = z.object({
@@ -95,28 +96,8 @@ export function createSandboxConfigRoutes({ sandboxConfigService }: SandboxConfi
 
   // POST /api/sandbox-configs
   app.post('/', async (c) => {
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Request body must be valid JSON' } },
-        400
-      );
-    }
-    const parsed = sandboxConfigCreateSchema.safeParse(rawBody);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, sandboxConfigCreateSchema);
+    if (!parsed.ok) return parsed.response;
     const body = parsed.data;
     if (body.nomadAddress) {
       const addrValidation = await validateNomadAddress(body.nomadAddress);
@@ -163,28 +144,8 @@ export function createSandboxConfigRoutes({ sandboxConfigService }: SandboxConfi
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Request body must be valid JSON' } },
-        400
-      );
-    }
-    const parsed = sandboxConfigBodySchema.safeParse(rawBody);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, sandboxConfigBodySchema);
+    if (!parsed.ok) return parsed.response;
     const body = parsed.data;
     if (body.nomadAddress) {
       const addrValidation = await validateNomadAddress(body.nomadAddress);

--- a/src/server/routes/sandbox-nomad.ts
+++ b/src/server/routes/sandbox-nomad.ts
@@ -10,6 +10,7 @@ import { Hono } from 'hono';
 import { createLogger } from '../../lib/logging/logger.js';
 import type { Database } from '../../types/database.js';
 import { json } from '../shared.js';
+import { parseJsonBody, sandboxNomadValidateSchema } from '../validation.js';
 
 const log = createLogger('SandboxNomadRoutes');
 
@@ -381,22 +382,9 @@ export function createNomadRoutes(deps?: NomadRouteDeps) {
 
   // POST /api/sandbox/nomad/validate - Validate connection
   app.post('/validate', async (c) => {
-    let body: { address: string; token?: string; namespace?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Request body must be valid JSON' } },
-        400
-      );
-    }
-
-    if (!body.address) {
-      return json(
-        { ok: false, error: { code: 'MISSING_PARAMS', message: 'Nomad address is required' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, sandboxNomadValidateSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
     // Validate address to prevent SSRF
     const addrValidation = await validateNomadAddress(body.address);

--- a/src/server/routes/sandbox.ts
+++ b/src/server/routes/sandbox.ts
@@ -16,6 +16,7 @@ import { createLogger } from '../../lib/logging/logger.js';
 import type { SandboxConfigService } from '../../services/sandbox-config.service.js';
 import type { Database } from '../../types/database.js';
 import { errorResponse, json, parseLimit, parseOffset, validateIdParam } from '../shared.js';
+import { parseJsonBody, sandboxNomadValidateSchema } from '../validation.js';
 
 const sandboxConfigBodySchema = z.object({
   name: z.string().min(1).max(200).optional(),
@@ -102,28 +103,8 @@ export function createSandboxRoutes({ sandboxConfigService }: SandboxDeps) {
 
   // POST /api/sandbox-configs
   app.post('/', async (c) => {
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Request body must be valid JSON' } },
-        400
-      );
-    }
-    const parsed = sandboxConfigCreateSchema.safeParse(rawBody);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, sandboxConfigCreateSchema);
+    if (!parsed.ok) return parsed.response;
     const body = parsed.data;
     if (body.nomadAddress) {
       const addrValidation = await validateNomadAddress(body.nomadAddress);
@@ -170,28 +151,8 @@ export function createSandboxRoutes({ sandboxConfigService }: SandboxDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let rawBody: unknown;
-    try {
-      rawBody = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Request body must be valid JSON' } },
-        400
-      );
-    }
-    const parsed = sandboxConfigBodySchema.safeParse(rawBody);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, sandboxConfigBodySchema);
+    if (!parsed.ok) return parsed.response;
     const body = parsed.data;
     if (body.nomadAddress) {
       const addrValidation = await validateNomadAddress(body.nomadAddress);
@@ -1285,22 +1246,9 @@ export function createNomadRoutes(deps?: NomadRouteDeps) {
 
   // POST /api/sandbox/nomad/validate - Validate connection
   app.post('/validate', async (c) => {
-    let body: { address: string; token?: string; namespace?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Request body must be valid JSON' } },
-        400
-      );
-    }
-
-    if (!body.address) {
-      return json(
-        { ok: false, error: { code: 'MISSING_PARAMS', message: 'Nomad address is required' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, sandboxNomadValidateSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
     // Validate address to prevent SSRF
     const addrValidation = await validateNomadAddress(body.address);

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -5,11 +5,11 @@
  */
 
 import { Hono } from 'hono';
-import { z } from 'zod';
 import { createLogger } from '../../lib/logging/logger';
 import { isDigestPinnedImage } from '../../lib/sandbox/types.js';
 import type { SettingsService } from '../../services/settings.service.js';
 import { json } from '../shared.js';
+import { parseJsonBody, updateSettingsSchema } from '../validation.js';
 
 const log = createLogger('SettingsRoutes');
 
@@ -49,11 +49,6 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 const SENSITIVE_FIELDS: Record<string, { secretKey: string; flagKey: string }> = {
   'sandbox.nomad': { secretKey: 'token', flagKey: 'hasToken' },
 };
-
-// Validation schemas
-const updateSettingsSchema = z.object({
-  settings: z.record(z.string(), z.unknown()),
-});
 
 interface SettingsDeps {
   settingsService: SettingsService;
@@ -111,29 +106,8 @@ export function createSettingsRoutes({ settingsService }: SettingsDeps) {
 
   // PUT /api/settings
   app.put('/', async (c) => {
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = updateSettingsSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'settings object is required',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, updateSettingsSchema);
+    if (!parsed.ok) return parsed.response;
 
     const settingsToUpdate = parsed.data.settings;
 

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -8,9 +8,12 @@ import { createLogger } from '../../lib/logging/logger.js';
 import type { TaskService } from '../../services/task.service.js';
 import { errorResponse, json, parseLimit, requireQueryId, validateIdParam } from '../shared.js';
 import {
+  approveTaskSchema,
   createTaskSchema,
   moveTaskSchema,
   parseJsonBody,
+  rejectPlanSchema,
+  rejectTaskSchema,
   taskColumnSchema,
   updateTaskSchema,
 } from '../validation.js';
@@ -198,6 +201,11 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
 
   // PATCH /api/tasks/:id/move - Move task to different column
   // When moving to in_progress, optionally auto-start an agent
+  //
+  // F07-06: when agent auto-start fails, return `ok:false` with a structured
+  // error so the UI surfaces the failure. `taskService.moveColumn()` already
+  // reverts the task to `backlog` when agent start fails, so the response
+  // also signals the new column via `details.task`.
   app.patch('/:id/move', async (c) => {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
@@ -214,13 +222,27 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
 
     const { task: updatedTask, agentError } = result.value;
 
-    // Return success for the move, but include agent error info if present
+    // F07-06: agent auto-start failed → propagate as `ok:false` with a 500
+    // status. The service has already reverted the column to `backlog` (or
+    // logged a fatal warning if the revert itself failed). The previous
+    // shape (`ok:true` with embedded `agentError`) hid the failure from
+    // clients that key on `result.ok`.
     if (agentError) {
       logger.error(`Failed to start agent for task ${id}`, { data: { agentError } });
-      return json({
-        ok: true,
-        data: { task: updatedTask, agentError },
-      });
+      return json(
+        {
+          ok: false,
+          error: {
+            code: 'AGENT_START_FAILED',
+            message: agentError,
+            details: {
+              taskId: id,
+              task: updatedTask,
+            },
+          },
+        },
+        500
+      );
     }
 
     return json({ ok: true, data: { task: updatedTask } });
@@ -245,16 +267,15 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    try {
-      // Parse optional rejection reason from body
-      let reason: string | undefined;
-      try {
-        const body = (await c.req.json()) as { reason?: string };
-        reason = typeof body.reason === 'string' ? body.reason : undefined;
-      } catch {
-        // No body or invalid JSON — reason is optional
-      }
+    // Body is optional — only validate when Content-Type indicates JSON.
+    let reason: string | undefined;
+    if (c.req.header('Content-Type')?.includes('application/json')) {
+      const parsed = await parseJsonBody(c, rejectPlanSchema);
+      if (!parsed.ok) return parsed.response;
+      reason = parsed.data?.reason;
+    }
 
+    try {
       const result = await taskService.rejectPlan(id, reason);
 
       if (!result.ok) {
@@ -276,24 +297,17 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    try {
-      let approvedBy: string | undefined;
-      let createMergeCommit: boolean | undefined;
-      try {
-        const body = (await c.req.json()) as {
-          approvedBy?: string;
-          createMergeCommit?: boolean;
-        };
-        approvedBy = typeof body.approvedBy === 'string' ? body.approvedBy : undefined;
-        createMergeCommit =
-          typeof body.createMergeCommit === 'boolean' ? body.createMergeCommit : undefined;
-      } catch (parseErr) {
-        // No body or invalid JSON — fields are optional, log for debugging
-        logger.debug('Approve task: body parse skipped (fields are optional)', {
-          error: parseErr,
-        });
-      }
+    // Body is optional — only validate when Content-Type indicates JSON.
+    let approvedBy: string | undefined;
+    let createMergeCommit: boolean | undefined;
+    if (c.req.header('Content-Type')?.includes('application/json')) {
+      const parsed = await parseJsonBody(c, approveTaskSchema);
+      if (!parsed.ok) return parsed.response;
+      approvedBy = parsed.data?.approvedBy;
+      createMergeCommit = parsed.data?.createMergeCommit;
+    }
 
+    try {
       const result = await taskService.approve(id, { approvedBy, createMergeCommit });
 
       if (!result.ok) {
@@ -315,32 +329,32 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    try {
-      let reason: string | undefined;
-      try {
-        const body = (await c.req.json()) as { reason?: string };
-        reason =
-          typeof body.reason === 'string' && body.reason.trim() !== '' ? body.reason : undefined;
-      } catch (parseErr) {
-        // No body or invalid JSON — reason is required but parse failed
-        logger.debug('Reject task: body parse failed (reason is required)', {
-          error: parseErr,
-        });
-      }
-
-      if (!reason) {
-        return json(
-          {
-            ok: false,
-            error: {
-              code: 'INVALID_PARAMS',
-              message: 'A non-empty "reason" field is required when rejecting a task',
-            },
+    // F07-03: reason is required and must be a non-empty trimmed string. The
+    // canonical schema rejects whitespace-only and missing values; clients
+    // that omitted the body previously got a misleading 200.
+    //
+    // No-body / no-Content-Type case: emit a clear "reason is required"
+    // message rather than the generic "invalid JSON" — the only valid
+    // request shape is `{ reason: string }`.
+    const hasJsonBody = c.req.header('Content-Type')?.includes('application/json');
+    if (!hasJsonBody) {
+      return json(
+        {
+          ok: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'A non-empty "reason" field is required when rejecting a task',
           },
-          400
-        );
-      }
+        },
+        400
+      );
+    }
 
+    const parsed = await parseJsonBody(c, rejectTaskSchema);
+    if (!parsed.ok) return parsed.response;
+    const reason = parsed.data.reason;
+
+    try {
       const result = await taskService.reject(id, { reason });
 
       if (!result.ok) {

--- a/src/server/routes/templates.ts
+++ b/src/server/routes/templates.ts
@@ -5,6 +5,7 @@
 import { Hono } from 'hono';
 import type { TemplateService } from '../../services/template.service.js';
 import { errorResponse, json, parseLimit, validateIdParam } from '../shared.js';
+import { createTemplateSchema, parseJsonBody, updateTemplateSchema } from '../validation.js';
 
 interface TemplatesDeps {
   templateService: TemplateService;
@@ -38,52 +39,14 @@ export function createTemplatesRoutes({ templateService }: TemplatesDeps) {
 
   // POST /api/templates
   app.post('/', async (c) => {
-    let body: {
-      name?: string;
-      description?: string;
-      scope?: string;
-      githubUrl?: string;
-      branch?: string;
-      configPath?: string;
-      codespaceId?: string;
-      codespaceIds?: string[];
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    // Validate required fields
-    if (!body.name) {
-      return json(
-        { ok: false, error: { code: 'MISSING_PARAMS', message: 'name is required' } },
-        400
-      );
-    }
-    if (!body.scope || !['org', 'codespace'].includes(body.scope)) {
-      return json(
-        {
-          ok: false,
-          error: { code: 'MISSING_PARAMS', message: 'scope must be "org" or "project"' },
-        },
-        400
-      );
-    }
-    if (!body.githubUrl) {
-      return json(
-        { ok: false, error: { code: 'MISSING_PARAMS', message: 'githubUrl is required' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, createTemplateSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
     const result = await templateService.create({
       name: body.name,
       description: body.description,
-      scope: body.scope as 'org' | 'codespace',
+      scope: body.scope,
       githubUrl: body.githubUrl,
       branch: body.branch,
       configPath: body.configPath,
@@ -130,21 +93,9 @@ export function createTemplatesRoutes({ templateService }: TemplatesDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: {
-      name?: string;
-      description?: string;
-      branch?: string;
-      configPath?: string;
-      codespaceIds?: string[];
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, updateTemplateSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
     const result = await templateService.update(id, {
       name: body.name,

--- a/src/server/routes/terraform.ts
+++ b/src/server/routes/terraform.ts
@@ -17,6 +17,7 @@ import {
 import type { TerraformComposeService } from '../../services/terraform-compose.service.js';
 import type { TerraformRegistryService } from '../../services/terraform-registry.service.js';
 import { errorResponse, json, validateIdParam } from '../shared.js';
+import { parseJsonBody, terraformValidateSchema } from '../validation.js';
 
 interface TerraformDeps {
   terraformRegistryService: TerraformRegistryService;
@@ -88,39 +89,13 @@ export function createTerraformRoutes({
 
   // POST /registries — create registry
   app.post('/registries', async (c) => {
-    let body: {
-      name: string;
-      orgName: string;
-      apiToken: string;
-      syncIntervalMinutes?: number;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
     const denied = requireTerraformAdmin(c);
     if (denied) {
       return denied;
     }
 
-    const parsed = createRegistrySchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'Invalid request',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, createRegistrySchema);
+    if (!parsed.ok) return parsed.response;
 
     const result = await terraformRegistryService.createRegistry(parsed.data);
     if (!result.ok) {
@@ -166,39 +141,13 @@ export function createTerraformRoutes({
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: {
-      name?: string;
-      orgName?: string;
-      apiToken?: string;
-      syncIntervalMinutes?: number | null;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
     const denied = requireTerraformAdmin(c);
     if (denied) {
       return denied;
     }
 
-    const parsed = updateRegistrySchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'Invalid request',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, updateRegistrySchema);
+    if (!parsed.ok) return parsed.response;
 
     const result = await terraformRegistryService.updateRegistry(id, parsed.data);
     if (!result.ok) {
@@ -271,22 +220,9 @@ export function createTerraformRoutes({
 
   // POST /validate — validate generated HCL code using @cdktf/hcl2json
   app.post('/validate', async (c) => {
-    let body: { code: string; tfvars?: string };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    if (!body.code || typeof body.code !== 'string') {
-      return json(
-        { ok: false, error: { code: 'VALIDATION_ERROR', message: 'code field is required' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, terraformValidateSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
     try {
       const result = await terraformComposeService.validateCode(body.code, body.tfvars);
@@ -305,33 +241,8 @@ export function createTerraformRoutes({
 
   // POST /compose — start a compose job (returns immediately with sessionId)
   app.post('/compose', async (c) => {
-    let body: {
-      messages: Array<{ role: 'user' | 'assistant'; content: string }>;
-      sessionId?: string;
-      registryId?: string;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = composeRequestSchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'Invalid request',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, composeRequestSchema);
+    if (!parsed.ok) return parsed.response;
 
     const result = await terraformComposeService.startCompose(
       parsed.data.sessionId,

--- a/src/server/routes/workflow-designer.ts
+++ b/src/server/routes/workflow-designer.ts
@@ -24,6 +24,7 @@ import { workflowEdgeSchema, workflowNodeSchema } from '../../lib/workflow-dsl/t
 import type { SettingsService } from '../../services/settings.service.js';
 import type { TemplateService } from '../../services/template.service.js';
 import { json } from '../shared.js';
+import { parseJsonBody } from '../validation.js';
 
 interface WorkflowDesignerDeps {
   templateService: TemplateService;
@@ -395,28 +396,8 @@ export function createWorkflowDesignerRoutes({
 
   // POST /api/workflow-designer/analyze
   app.post('/analyze', async (c) => {
-    // Parse request body
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    // Validate request
-    const parseResult = analyzeWorkflowRequestSchema.safeParse(body);
-    if (!parseResult.success) {
-      return json(
-        {
-          ok: false,
-          error: { code: 'VALIDATION_ERROR', message: parseResult.error.message },
-        },
-        400
-      );
-    }
+    const parseResult = await parseJsonBody(c, analyzeWorkflowRequestSchema);
+    if (!parseResult.ok) return parseResult.response;
 
     const { templateId, skills, commands, agents: agentsData, name } = parseResult.data;
 

--- a/src/server/routes/workflows.ts
+++ b/src/server/routes/workflows.ts
@@ -8,7 +8,7 @@ import { Hono } from 'hono';
 import { createWorkflowSchema } from '../../lib/api/schemas.js';
 import type { WorkflowService } from '../../services/workflow.service.js';
 import { json, parseLimit, parseOffset, validateIdParam } from '../shared.js';
-import { parseJsonBody } from '../validation.js';
+import { parseJsonBody, updateWorkflowSchema } from '../validation.js';
 
 interface WorkflowsDeps {
   workflowService: WorkflowService;
@@ -94,29 +94,9 @@ export function createWorkflowsRoutes({ workflowService }: WorkflowsDeps) {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    let body: {
-      name?: string;
-      description?: string;
-      nodes?: unknown[];
-      edges?: unknown[];
-      viewport?: { x: number; y: number; zoom: number };
-      status?: string;
-      tags?: string[];
-      sourceTemplateId?: string | null;
-      sourceTemplateName?: string | null;
-      thumbnail?: string | null;
-      aiGenerated?: boolean;
-      aiModel?: string | null;
-      aiConfidence?: number | null;
-    };
-    try {
-      body = await c.req.json();
-    } catch {
-      return json(
-        { ok: false, error: { code: 'INVALID_JSON', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, updateWorkflowSchema);
+    if (!parsed.ok) return parsed.response;
+    const body = parsed.data;
 
     const result = await workflowService.update(id, {
       name: body.name,
@@ -124,7 +104,7 @@ export function createWorkflowsRoutes({ workflowService }: WorkflowsDeps) {
       nodes: body.nodes,
       edges: body.edges,
       viewport: body.viewport,
-      status: body.status as 'draft' | 'published' | 'archived' | undefined,
+      status: body.status,
       tags: body.tags,
       sourceTemplateId: body.sourceTemplateId,
       sourceTemplateName: body.sourceTemplateName,

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -92,6 +92,51 @@ export const createAgentSchema = z.object({
   config: z.record(z.string(), z.unknown()).optional(),
 });
 
+/**
+ * Schema for `PATCH /api/agents/:id` — accepts either a flat AgentConfig shape
+ * (`{ allowedTools, maxTurns, ... }`) or a wrapped variant (`{ config: {...} }`).
+ * The existing route accepts both forms; both are validated to bound string
+ * lengths, array sizes, and number ranges.
+ */
+const agentConfigFieldsSchema = z
+  .object({
+    allowedTools: z.array(z.string().max(200)).max(200).optional(),
+    maxTurns: z.number().int().min(1).max(1000).optional(),
+    model: z.string().max(200).optional(),
+    systemPrompt: z.string().max(20000).optional(),
+    temperature: z.number().min(0).max(2).optional(),
+  })
+  .partial();
+
+export const updateAgentSchema = agentConfigFieldsSchema
+  .extend({
+    config: agentConfigFieldsSchema.optional(),
+  })
+  .refine(
+    (data) => {
+      const { config, ...rest } = data;
+      return (
+        (config && Object.keys(config).length > 0) ||
+        Object.values(rest).some((v) => v !== undefined)
+      );
+    },
+    { message: 'config is required' }
+  );
+
+/** Schema for `POST /api/agents/:id/start` — only optional taskId for now. */
+export const agentStartSchema = z
+  .object({
+    taskId: idSchema.optional(),
+  })
+  .strict();
+
+/** Schema for `POST /api/agents/:id/resume` — feedback bounded to 10000 chars. */
+export const agentResumeSchema = z
+  .object({
+    feedback: z.string().max(10000).optional(),
+  })
+  .strict();
+
 // ─── Session Schemas ─────────────────────────────────
 
 export const createSessionSchema = z.object({
@@ -202,6 +247,198 @@ export const updateProfileSchema = z
   .refine((data) => Object.values(data).some((v) => v !== undefined), {
     message: 'At least one field must be provided',
   });
+
+// ─── Codespace Schemas ───────────────────────────────
+
+export const createCodespaceSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200),
+  path: z.string().min(1, 'Path is required').max(2048),
+  description: z.string().max(2000).optional(),
+  projectFolderId: idSchema,
+});
+
+export const updateCodespaceSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).optional(),
+    maxConcurrentAgents: z.number().int().positive().optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
+    projectFolderId: idSchema.optional(),
+    githubOwner: z.string().min(1).max(200).optional(),
+    githubRepo: z.string().min(1).max(200).optional(),
+  })
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
+    message: 'At least one field must be provided',
+  });
+
+// ─── Template Schemas ────────────────────────────────
+
+export const createTemplateSchema = z.object({
+  name: z.string().min(1, 'name is required').max(200),
+  description: z.string().max(2000).optional(),
+  scope: z.enum(['org', 'codespace'], {
+    message: 'scope must be "org" or "codespace"',
+  }),
+  githubUrl: z
+    .string({ message: 'githubUrl is required' })
+    .min(1, 'githubUrl is required')
+    .max(1000),
+  branch: z.string().max(200).optional(),
+  configPath: z.string().max(500).optional(),
+  codespaceId: idSchema.optional(),
+  codespaceIds: z.array(idSchema).max(100).optional(),
+});
+
+export const updateTemplateSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).optional(),
+    branch: z.string().max(200).optional(),
+    configPath: z.string().max(500).optional(),
+    codespaceIds: z.array(idSchema).max(100).optional(),
+  })
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
+    message: 'At least one field must be provided',
+  });
+
+// ─── Marketplace Schemas ─────────────────────────────
+
+export const createMarketplaceSchema = z
+  .object({
+    name: z.string().min(1, 'Name is required').max(200),
+    githubUrl: z.string().max(1000).optional(),
+    githubOwner: z.string().max(200).optional(),
+    githubRepo: z.string().max(200).optional(),
+    branch: z.string().max(200).optional(),
+    pluginsPath: z.string().max(500).optional(),
+  })
+  .refine((data) => Boolean(data.githubUrl) || Boolean(data.githubOwner && data.githubRepo), {
+    message: 'GitHub URL or owner/repo required',
+  });
+
+// ─── API Key Schemas ─────────────────────────────────
+
+export const saveApiKeySchema = z.object({
+  key: z.string().min(1, 'API key is required').max(10000),
+});
+
+// ─── Settings Schemas ────────────────────────────────
+
+export const updateSettingsSchema = z.object({
+  settings: z.record(z.string(), z.unknown()),
+});
+
+// ─── Memory Schemas ──────────────────────────────────
+
+export const createMemoryInsightSchema = z.object({
+  content: z.string().min(1).max(4096),
+  source: z.enum(['manual', 'agent_derived', 'dream']).optional().default('manual'),
+  skillId: z.string().max(200).optional(),
+  tags: z.array(z.string().max(100)).max(50).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  category: z
+    .enum(['pattern', 'anti_pattern', 'decision', 'architecture', 'error_lesson'])
+    .optional(),
+});
+
+export const memorySearchSchema = z.object({
+  query: z.string().min(1).max(1024),
+  limit: z.number().min(1).max(50).optional(),
+});
+
+export const memorySuggestionActionSchema = z.object({
+  userNotes: z.string().max(10000).optional(),
+});
+
+export const memoryModifySuggestionSchema = z.object({
+  modifiedContent: z.string().min(1).max(50000),
+  userNotes: z.string().max(10000).optional(),
+});
+
+/**
+ * Per-skill dream config override. The `null` case (clear-override) is handled
+ * outside zod because zod cannot represent JSON `null` as a top-level body.
+ */
+export const dreamSkillOverrideSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    model: z.string().max(200).optional(),
+    minRuns: z.number().int().min(1).max(1000).optional(),
+  })
+  .strict()
+  .optional();
+
+// ─── Task action body schemas ────────────────────────
+
+export const rejectPlanSchema = z
+  .object({
+    reason: z.string().max(10000).optional(),
+  })
+  .strict()
+  .optional();
+
+export const approveTaskSchema = z
+  .object({
+    approvedBy: z.string().max(200).optional(),
+    createMergeCommit: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
+export const rejectTaskSchema = z.object({
+  reason: z
+    .string()
+    .min(1, 'A non-empty "reason" field is required when rejecting a task')
+    .max(10000)
+    .refine((v) => v.trim() !== '', {
+      message: 'A non-empty "reason" field is required when rejecting a task',
+    }),
+});
+
+// ─── Terraform Schemas (validate body) ───────────────
+
+export const terraformValidateSchema = z.object({
+  code: z.string().min(1, 'code field is required').max(500_000),
+  tfvars: z.string().max(500_000).optional(),
+});
+
+// ─── Workflow update schema (PATCH) ──────────────────
+
+export const workflowStatusUpdateSchema = z.enum(['draft', 'published', 'archived']);
+
+export const updateWorkflowSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).optional(),
+    nodes: z.array(z.unknown()).optional(),
+    edges: z.array(z.unknown()).optional(),
+    viewport: z
+      .object({
+        x: z.number(),
+        y: z.number(),
+        zoom: z.number(),
+      })
+      .optional(),
+    status: workflowStatusUpdateSchema.optional(),
+    tags: z.array(z.string().max(100)).max(50).optional(),
+    sourceTemplateId: z.string().nullable().optional(),
+    sourceTemplateName: z.string().max(200).nullable().optional(),
+    thumbnail: z.string().max(5000).nullable().optional(),
+    aiGenerated: z.boolean().optional(),
+    aiModel: z.string().max(200).nullable().optional(),
+    aiConfidence: z.number().min(0).max(100).nullable().optional(),
+  })
+  .refine((data) => Object.values(data).some((v) => v !== undefined), {
+    message: 'At least one field must be provided',
+  });
+
+// ─── Sandbox Nomad Schemas ───────────────────────────
+
+export const sandboxNomadValidateSchema = z.object({
+  address: z.string().min(1, 'Nomad address is required').max(2048),
+  token: z.string().max(2048).optional(),
+  namespace: z.string().max(200).optional(),
+});
 
 // ─── Helper ──────────────────────────────────────────
 

--- a/tests/integration/route-api-keys.test.ts
+++ b/tests/integration/route-api-keys.test.ts
@@ -117,7 +117,7 @@ describe('API Keys Routes (IT-420)', () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('IT-427: POST /:service returns 400 for missing key field', async () => {

--- a/tests/integration/route-cli-monitor.test.ts
+++ b/tests/integration/route-cli-monitor.test.ts
@@ -169,7 +169,7 @@ describe('CLI Monitor Routes (IT-500)', () => {
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.ok).toBe(false);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('IT-504: returns 400 for empty daemonId', async () => {

--- a/tests/integration/route-codespaces.test.ts
+++ b/tests/integration/route-codespaces.test.ts
@@ -203,7 +203,7 @@ describe('Codespaces Routes (IT-1150)', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('IT-1158: POST / returns service error code for duplicate path', async () => {
@@ -368,7 +368,7 @@ describe('Codespaces Routes (IT-1150)', () => {
 
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // ─── DELETE /:id ──────────────────────────────────────

--- a/tests/integration/route-memory.test.ts
+++ b/tests/integration/route-memory.test.ts
@@ -224,7 +224,7 @@ describe('Memory Routes (IT-1200)', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // ─── DELETE /insights/:insightId ───────────────────────
@@ -346,7 +346,7 @@ describe('Memory Routes (IT-1200)', () => {
 
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // ─── POST /codespaces/:id/search (scoped) ─────────────
@@ -574,7 +574,7 @@ describe('Memory Routes (IT-1200)', () => {
 
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   // ─── Dream config skill overrides ─────────────────────

--- a/tests/integration/route-sandbox-configs.test.ts
+++ b/tests/integration/route-sandbox-configs.test.ts
@@ -80,7 +80,7 @@ describe('Sandbox Config Routes (IT-400)', () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('IT-404: POST / returns 400 for invalid nomadAddress (SSRF-blocked metadata endpoint)', async () => {
@@ -242,7 +242,7 @@ describe('Sandbox Config Routes (IT-400)', () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('IT-415: PATCH /:id rejects invalid nomadAddress', async () => {

--- a/tests/integration/route-sandbox-nomad.test.ts
+++ b/tests/integration/route-sandbox-nomad.test.ts
@@ -163,7 +163,7 @@ describe('Nomad Sandbox Routes (IT-580)', () => {
 
       expect(response.status).toBe(400);
       const body = await response.json();
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('IT-599: returns 400 when address is missing', async () => {
@@ -173,7 +173,8 @@ describe('Nomad Sandbox Routes (IT-580)', () => {
 
       expect(response.status).toBe(400);
       const body = await response.json();
-      expect(body.error.code).toBe('MISSING_PARAMS');
+      // arch29-W2-H / F07-15: standardised to VALIDATION_ERROR.
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('IT-600: returns 400 for SSRF-blocked address', async () => {

--- a/tests/integration/route-sandbox.test.ts
+++ b/tests/integration/route-sandbox.test.ts
@@ -440,7 +440,7 @@ describe('Sandbox Routes (IT-1000)', () => {
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.ok).toBe(false);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('IT-1031: POST / rejects missing required name', async () => {
@@ -522,7 +522,7 @@ describe('Sandbox Routes (IT-1000)', () => {
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.ok).toBe(false);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('IT-1037: POST / validates Zod constraints (memoryMb range)', async () => {
@@ -591,7 +591,8 @@ describe('Sandbox Routes (IT-1000)', () => {
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.ok).toBe(false);
-      expect(body.error.code).toBe('MISSING_PARAMS');
+      // arch29-W2-H / F07-15: standardised to VALIDATION_ERROR.
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
   });
 });

--- a/tests/integration/route-tasks.test.ts
+++ b/tests/integration/route-tasks.test.ts
@@ -346,11 +346,17 @@ describe('Tasks Routes (IT-1350)', () => {
     expect(body.data.agentError).toBeUndefined();
   });
 
-  it('IT-1368: PATCH /:id/move returns task with agentError on partial failure', async () => {
+  it('IT-1368: PATCH /:id/move returns ok:false with AGENT_START_FAILED on partial failure', async () => {
+    // arch29-W2-H / F07-06: when the move succeeds but agent auto-start
+    // fails, the route MUST return `ok:false` with
+    // `error.code === 'AGENT_START_FAILED'` (HTTP 500). The previous
+    // shape (`ok:true` with embedded `agentError`) hid the failure from
+    // any client that keys on `result.ok`. The service has already
+    // reverted the column to `backlog` by this point.
     mockService.moveColumn.mockResolvedValue({
       ok: true,
       value: {
-        task: { id: 'task-1', column: 'in_progress' },
+        task: { id: 'task-1', column: 'backlog' },
         agentError: 'Failed to start agent: no sandbox configured',
       },
     });
@@ -363,10 +369,12 @@ describe('Tasks Routes (IT-1350)', () => {
       })
     );
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.data.agentError).toBe('Failed to start agent: no sandbox configured');
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('AGENT_START_FAILED');
+    expect(body.error.message).toBe('Failed to start agent: no sandbox configured');
+    expect(body.error.details.task.column).toBe('backlog');
   });
 
   it('IT-1369: PATCH /:id/move returns 400 for invalid column', async () => {

--- a/tests/integration/route-workflow-designer.test.ts
+++ b/tests/integration/route-workflow-designer.test.ts
@@ -85,7 +85,7 @@ describe('Workflow Designer Routes (IT-650)', () => {
 
       expect(response.status).toBe(400);
       const body = await response.json();
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('IT-652: returns 400 when no content source provided', async () => {

--- a/tests/routes/settings.test.ts
+++ b/tests/routes/settings.test.ts
@@ -264,7 +264,7 @@ describe('PUT /api/settings', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when settings object is missing', async () => {

--- a/tests/routes/terraform.test.ts
+++ b/tests/routes/terraform.test.ts
@@ -210,7 +210,7 @@ describe('terraform routes', () => {
 
       expect(res.status).toBe(400);
       expect(body.ok).toBe(false);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when name is missing', async () => {
@@ -532,7 +532,7 @@ describe('terraform routes', () => {
       const body = await res.json();
 
       expect(res.status).toBe(400);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 for invalid syncIntervalMinutes (too low)', async () => {
@@ -866,7 +866,7 @@ describe('terraform routes', () => {
       const body = await res.json();
 
       expect(res.status).toBe(400);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when code field is missing', async () => {
@@ -994,7 +994,7 @@ describe('terraform routes', () => {
       const body = await res.json();
 
       expect(res.status).toBe(400);
-      expect(body.error.code).toBe('INVALID_JSON');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when messages is empty', async () => {

--- a/tests/routes/workflow-designer.test.ts
+++ b/tests/routes/workflow-designer.test.ts
@@ -163,7 +163,7 @@ describe('POST /api/workflow-designer/analyze - Generate workflow', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.ok).toBe(false);
-    expect(body.error.code).toBe('INVALID_JSON');
+    expect(body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when no templateId or content provided', async () => {


### PR DESCRIPTION
## Summary

Closes the F07-03 and F07-06 findings from the April 29 architecture review.

- **F07-03 (P1)** — Migrate all 31 raw `c.req.json()` callers across `src/server/routes/` to `parseJsonBody(c, schema)`, the canonical helper in `src/server/validation.ts` that combines JSON parsing + Zod schema validation in a single step. Hand-typed casts that previously bypassed Zod (e.g. `body: { config?: ..., name?: ... }`) are now bounded at the schema boundary — clients can no longer send `{name: 'x'.repeat(1_000_000)}` to `PATCH /api/agents/:id` and have it land in the DB.
- **F07-06 (P1)** — `PATCH /api/tasks/:id/move` now returns `{ok: false, error: {code: 'AGENT_START_FAILED', message, details: {taskId, task}}}` with HTTP 500 when `taskService.moveColumn()` reports `agentError`. Previously the route returned `{ok: true, data: {task, agentError}}`, hiding the failure from any client that keys on `result.ok` (the canonical pattern across the entire client). The service has already reverted the column to `backlog` by this point, so the reverted task is included in `details` so clients can update local state without a separate fetch.
- **CI grep gate** — Add `scripts/check-api-write-validation.sh`, wired into the `lint-and-typecheck` CI job, that fails the build if any new bare `c.req.json()` is added to `src/server/routes/`. One allow-listed site (`memory.ts:246` — PUT `/dream-config/skills/:skillId`) remains because the body shape includes a JSON literal `null` to clear an override, which zod cannot represent at the root.
- **Error code standardisation (F07-15 follow-on)** — `parseJsonBody` returns `VALIDATION_ERROR` for both JSON parse failures and zod validation failures, replacing the inconsistent mix of `INVALID_JSON`, `MISSING_PARAMS`, `MISSING_NAME`, `MISSING_REPO`, `INVALID_PARAMS`. Existing tests updated.

### New canonical schemas in `validation.ts`

`updateAgentSchema`, `agentStartSchema`, `agentResumeSchema`, `createCodespaceSchema`, `updateCodespaceSchema`, `createTemplateSchema`, `updateTemplateSchema`, `createMarketplaceSchema`, `saveApiKeySchema`, `updateSettingsSchema`, `createMemoryInsightSchema`, `memorySearchSchema`, `memorySuggestionActionSchema`, `memoryModifySuggestionSchema`, `dreamSkillOverrideSchema`, `rejectPlanSchema`, `approveTaskSchema`, `rejectTaskSchema`, `terraformValidateSchema`, `updateWorkflowSchema`, `sandboxNomadValidateSchema`.

### Migration list (31 sites across 16 files)

| File | Sites |
|---|---|
| `agents.ts` | PATCH `/:id`, POST `/:id/start`, POST `/:id/resume` |
| `api-keys.ts` | POST `/:service` |
| `cli-monitor.ts` | local `parseBody` helper now delegates to `parseJsonBody` |
| `codespaces.ts` | POST `/`, PATCH `/:id` |
| `marketplaces.ts` | POST `/` |
| `memory.ts` | POST `/search` (×2), POST `/codespaces/:id/insights`, PATCH `/suggestions/:id/{accept,reject}`, PATCH `/suggestions/:id/modify`; allow-listed PUT `/dream-config/skills/:skillId` |
| `sandbox-configs.ts` | POST `/`, PATCH `/:id` |
| `sandbox-nomad.ts` | POST `/validate` |
| `sandbox.ts` | POST sandbox-config, PATCH sandbox-config, POST nomad/validate |
| `settings.ts` | PUT `/` |
| `tasks.ts` | reject-plan, approve, reject (+ F07-06 move shape) |
| `templates.ts` | POST `/`, PATCH `/:id` |
| `terraform.ts` | POST `/registries`, PATCH `/registries/:id`, POST `/validate`, POST `/compose` |
| `workflow-designer.ts` | POST `/analyze` |
| `workflows.ts` | PATCH `/:id` |

### Status vs April 29 review

- F07-03 — closed by mass migration + CI grep gate.
- F07-06 — closed by error-bubbling fix in `tasks/:id/move`.
- F07-15 — partially addressed: `VALIDATION_ERROR` is now the standard for body validation failures across all migrated routes.

## Test plan

Before:
- `tests/integration/route-tasks.test.ts` IT-1368 expected `{ok: true, data: {task, agentError}}` (the buggy pre-fix shape).
- `tests/api/tasks.test.ts` "moves a task between columns" returned `data.task.column === 'in_progress'` even when agent never started.

After:
- IT-1368 now expects `{ok: false, error: {code: 'AGENT_START_FAILED', message, details: {task, taskId}}}` with HTTP 500.
- New `agents.test.ts` regression test: oversized `systemPrompt` (20001 chars) → 400 VALIDATION_ERROR; `agentService.update` is **not** called. Without the fix, the field would have been forwarded to the DB.
- New `agents.test.ts` regression test: oversized `allowedTools` array (201 items) → 400.

- [x] `bun vitest run --project unit` — 4452 tests pass
- [x] `bun vitest run --project integration` — 2245 tests pass
- [x] `bun vitest run --project db` — 2169 tests pass
- [x] `bun vitest run --project jsdom` — 484 tests pass
- [x] `bun vitest run --project functional` — 84 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx @biomejs/biome check --max-diagnostics=500 --diagnostic-level=error src/ tests/` — clean
- [x] `bash scripts/check-api-write-validation.sh` — passes with 1 allow-listed site (within 2-site budget).

Signed-off-by: Simon Lynch <44986346+srlynch1@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
