### PR TITLE
Revert "fix(arch29-W2-D): AgentCore deletion (#202)" — AgentCore IS in active use

### DIFF
--- a/agent-runner/bun.lock
+++ b/agent-runner/bun.lock
@@ -1,12 +1,13 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@agentpane/agent-runner",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.113",
         "@anthropic-ai/sdk": "^0.90.0",
+        "bedrock-agentcore": "^0.2.2",
         "yaml": "^2.8.3",
         "zod": "4.3.6",
       },
@@ -20,41 +21,235 @@
     "@types/node": "^25.6.0",
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.123", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.123", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.123", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.123", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.123" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-a4TysYoR9DBdkM9Uwh4J5ub7TwKmRPe5hFiWh4En+IKC+qkk5UFkxFM22c//cZjYZKynHX0ah2t6LUqb+najYA=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.113", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.113", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.113", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.113", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.113" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-TMeZeBDTdGNZek2VvRB4zCCFkJHbqKU1dn+OG3wms9h8z/DUKuDAUvjmmQCXP9c4K2ipPS1WmmRJljXRcKfStg=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.123", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tYAXCjlXZQklsUs0J//gip3fZQRzhlH5OCgvNXV70qe7A1iiwHqO2KPGvEHV1L+deEKQoMZmTaCOrQpN6zju3w=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.113", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FymNWXlee9xID6AKU/aWjeIzlMTL7LAtVVL5kg2j3MYm7o8lfTY996cEN1ulWXeF7i3pVbzYtIzE+avhVDauPA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.123", "", { "os": "darwin", "cpu": "x64" }, "sha512-AcUC6sTon6z6HculP87KsAOeTMRLBwpovdhcXUTjXUpo/8nplJ7lBEzWjZCHt8FF1KuN/WBy1Z4bDg/59TQDmA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.113", "", { "os": "darwin", "cpu": "x64" }, "sha512-pST/cJunx8mup8RxnuCTQNmwyli4/LcvmLVPaZgVSYchLQlBCE26bQKZwdoeMc/+F7Gm/eBt8Yz53GTTqV3TMA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.123", "", { "os": "linux", "cpu": "arm64" }, "sha512-7+GnbcF3/aZ8RJ1WmU/ogtPsOpknBAoUPer90MvZuFYBLPT9iI/U7f24gjrOHuYdcbDA5n7jFlhcfIO26F5DJQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.113", "", { "os": "linux", "cpu": "arm64" }, "sha512-QMkDOEfOMg8W/PLAHnp3cU9wLWp/RvJuVlrwn5s4Oei/bP3kxfuV0uLoxXUZZNSnv2lcplxAKUGgOz7Xa0asFw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.123", "", { "os": "linux", "cpu": "arm64" }, "sha512-bYgRiaf2q+yVbGAoUluuhqrEW1zexL34+3HDmK9DneKXa2K2EJpw4M6Sq4XoBD/JezGaemoAP78Xv/M/QUS1OQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.113", "", { "os": "linux", "cpu": "arm64" }, "sha512-nXKJmIrxbgXMIE2fKebJVAFJiFqb6LsyzfxYn/tqgkYNfqk6IBDX+cP6eV5qRE72sNHI1E/ogF72N5MjhNeOHA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.123", "", { "os": "linux", "cpu": "x64" }, "sha512-Xi+Rwk8uP5vWEnawJOlsk179fr0ATLl5J90MlbLj+puKaX5svEq8ljS+P3zq6zHTJeKh9GKLzPf7bc5YJKwcew=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.113", "", { "os": "linux", "cpu": "x64" }, "sha512-/CQz7jiOp98hfrLwDJvmfPXtGCuWFGr+j7Zbi40uHovd5+TXJ1fOZNMEdb4aVKW3KYPbxA1aT6XNP8nAgmuPvA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.123", "", { "os": "linux", "cpu": "x64" }, "sha512-IX95lFKhmmndY/YPfWPsVV+C3rLYJmuuq5wCS53p6jYIkCMxH1iGfhBGF1EUWcXO4Uc8yqXFmQ3aaxMzOOPrwA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.113", "", { "os": "linux", "cpu": "x64" }, "sha512-PGpstZ8mWEQfCjDd+qV/rPsdLLkzFobINPpLr4ALMu8fQMEEs5SsabumGup48fnK3Z19/WlfI9FC1iVzxsE3LQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.123", "", { "os": "win32", "cpu": "arm64" }, "sha512-WDZmAQG1rOiqNLZlSXaCjSWmqJvLk2io+vFQWWqSy2b5HCk9pa3PadLiaLztiihyk81wPhH9Q/44kOxdyfEGMw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.113", "", { "os": "win32", "cpu": "arm64" }, "sha512-NqtFDTVPg7fh+yee7KnsVZ/MZ6VogE+dQcIobEN0NVl03i5pbQAWfSZNOEvhk2XyEaJ4rdk+/9MPED+UThF5gQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.123", "", { "os": "win32", "cpu": "x64" }, "sha512-588xrd1i6d4kXQ6FqwL+cgBiN4evRQSi5DCtPa02CZ3VEbuVQBeFlyPlD8tfWtNNeGZ4NM8kjPNNzZz5omezPA=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.113", "", { "os": "win32", "cpu": "x64" }, "sha512-0VoW/fTkygn/uZqPhOPjmXaVc1H3wkNNJd/fMyWKDR2p76Y9loQPQZk2R5tNRWlK5mDo65F6+Omby0rCx9XtQw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
 
-    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@3.0.0", "", { "dependencies": { "@aws-crypto/util": "^3.0.0", "@aws-sdk/types": "^3.222.0", "tslib": "^1.11.1" } }, "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-agentcore": ["@aws-sdk/client-bedrock-agentcore@3.1014.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.23", "@aws-sdk/credential-provider-node": "^3.972.24", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.24", "@aws-sdk/region-config-resolver": "^3.972.9", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.10", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.12", "@smithy/eventstream-serde-browser": "^4.2.12", "@smithy/eventstream-serde-config-resolver": "^4.3.12", "@smithy/eventstream-serde-node": "^4.2.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.27", "@smithy/middleware-retry": "^4.4.44", "@smithy/middleware-serde": "^4.2.15", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.0", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.43", "@smithy/util-defaults-mode-node": "^4.2.47", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-stream": "^4.5.20", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-QYLYhShhp7HxTDeHafGj7jb2AxpUZTiz8uWOT4gVTzxCJ33B/UEhMn3viCw3Sk/SQOvL0cgEXGBMGUhm3MD6CQ=="],
+
+    "@aws-sdk/client-bedrock-agentcore-control": ["@aws-sdk/client-bedrock-agentcore-control@3.1014.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.23", "@aws-sdk/credential-provider-node": "^3.972.24", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.24", "@aws-sdk/region-config-resolver": "^3.972.9", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.10", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.27", "@smithy/middleware-retry": "^4.4.44", "@smithy/middleware-serde": "^4.2.15", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.0", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.43", "@smithy/util-defaults-mode-node": "^4.2.47", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.2.13", "tslib": "^2.6.2" } }, "sha512-XaVo4KrJ8zUWGJfkTfNOtk4OHhbv/Y25SET4EpwfWUWxHfWEvdecAjNBxfwHF+vGJvaebfsySMKl7vYdf2E6xQ=="],
+
+    "@aws-sdk/client-cognito-identity": ["@aws-sdk/client-cognito-identity@3.1014.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.23", "@aws-sdk/credential-provider-node": "^3.972.24", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.24", "@aws-sdk/region-config-resolver": "^3.972.9", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.10", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.27", "@smithy/middleware-retry": "^4.4.44", "@smithy/middleware-serde": "^4.2.15", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.0", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.43", "@smithy/util-defaults-mode-node": "^4.2.47", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-NvNThzNvdKigwy9gNQnipeefydZ1HGU1kReXl5FPMxclzNgYB0IzwmJSW0mXICdd7PWARUblcfz72LeoOyXs0A=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.973.23", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws-sdk/xml-builder": "^3.972.15", "@smithy/core": "^3.23.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/signature-v4": "^5.3.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-aoJncvD1XvloZ9JLnKqTRL9dBy+Szkryoag9VT+V1TqsuUgIxV9cnBVM/hrDi2vE8bDqLiDR8nirdRcCdtJu0w=="],
+
+    "@aws-sdk/credential-provider-cognito-identity": ["@aws-sdk/credential-provider-cognito-identity@3.972.16", "", { "dependencies": { "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-WLdg4ErAu1Zkf9uPKQFC+UryHjaLTXji5SyBF3pTtqbbYOQHIfmf9Gsvn5zFol1T4SOWE4nDc8entfBAkAVHYQ=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.21", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-BkAfKq8Bd4shCtec1usNz//urPJF/SZy14qJyxkSaRJQ/Vv1gVh0VZSTmS7aE6aLMELkFV5wHHrS9ZcdG8Kxsg=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/types": "^3.973.6", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/node-http-handler": "^4.5.0", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/util-stream": "^4.5.20", "tslib": "^2.6.2" } }, "sha512-4XZ3+Gu5DY8/n8zQFHBgcKTF7hWQl42G6CY9xfXVo2d25FM/lYkpmuzhYopYoPL1ITWkJ2OSBQfYEu5JRfHOhA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/credential-provider-env": "^3.972.21", "@aws-sdk/credential-provider-http": "^3.972.23", "@aws-sdk/credential-provider-login": "^3.972.23", "@aws-sdk/credential-provider-process": "^3.972.21", "@aws-sdk/credential-provider-sso": "^3.972.23", "@aws-sdk/credential-provider-web-identity": "^3.972.23", "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-PZLSmU0JFpNCDFReidBezsgL5ji9jOBry8CnZdw4Jj6d0K2z3Ftnp44NXgADqYx5BLMu/ZHujfeJReaDoV+IwQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-OmE/pSkbMM3dCj1HdOnZ5kXnKK+R/Yz+kbBugraBecp0pGAs21eEURfQRz+1N2gzIHLVyGIP1MEjk/uSrFsngg=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.24", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.21", "@aws-sdk/credential-provider-http": "^3.972.23", "@aws-sdk/credential-provider-ini": "^3.972.23", "@aws-sdk/credential-provider-process": "^3.972.21", "@aws-sdk/credential-provider-sso": "^3.972.23", "@aws-sdk/credential-provider-web-identity": "^3.972.23", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-9Jwi7aps3AfUicJyF5udYadPypPpCwUZ6BSKr/QjRbVCpRVS1wc+1Q6AEZ/qz8J4JraeRd247pSzyMQSIHVebw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.21", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-nRxbeOJ1E1gVA0lNQezuMVndx+ZcuyaW/RB05pUsznN5BxykSlH6KkZ/7Ca/ubJf3i5N3p0gwNO5zgPSCzj+ww=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/token-providers": "3.1014.0", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-APUccADuYPLL0f2htpM8Z4czabSmHOdo4r41W6lKEZdy++cNJ42Radqy6x4TopENzr3hR6WYMyhiuiqtbf/nAA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-H5JNqtIwOu/feInmMMWcK0dL5r897ReEn7n2m16Dd0DPD9gA2Hg8Cq4UDzZ/9OzaLh/uqBM6seixz0U6Fi2Eag=="],
+
+    "@aws-sdk/credential-providers": ["@aws-sdk/credential-providers@3.1014.0", "", { "dependencies": { "@aws-sdk/client-cognito-identity": "3.1014.0", "@aws-sdk/core": "^3.973.23", "@aws-sdk/credential-provider-cognito-identity": "^3.972.16", "@aws-sdk/credential-provider-env": "^3.972.21", "@aws-sdk/credential-provider-http": "^3.972.23", "@aws-sdk/credential-provider-ini": "^3.972.23", "@aws-sdk/credential-provider-login": "^3.972.23", "@aws-sdk/credential-provider-node": "^3.972.24", "@aws-sdk/credential-provider-process": "^3.972.21", "@aws-sdk/credential-provider-sso": "^3.972.23", "@aws-sdk/credential-provider-web-identity": "^3.972.23", "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/types": "^3.973.6", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.12", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-2GM4JBB08RTwHPEVa9+AE+Q3mtyZyv+XS93rdlw5o/Emfu0nseDU6I72cbmKXcMnHXYEN+DdxEF/RvfnB0/GXw=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.24", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@smithy/core": "^3.23.12", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-retry": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-dLTWy6IfAMhNiSEvMr07g/qZ54be6pLqlxVblbF6AzafmmGAzMMj8qMoY9B4+YgT+gY9IcuxZslNh03L6PyMCQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.13", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.23", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.24", "@aws-sdk/region-config-resolver": "^3.972.9", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.10", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.27", "@smithy/middleware-retry": "^4.4.44", "@smithy/middleware-serde": "^4.2.15", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.0", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.43", "@smithy/util-defaults-mode-node": "^4.2.47", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-ptZ1HF4yYHNJX8cgFF+8NdYO69XJKZn7ft0/ynV3c0hCbN+89fAbrLS+fqniU2tW8o9Kfqhj8FUh+IPXb2Qsuw=="],
+
+    "@aws-sdk/protocol-http": ["@aws-sdk/protocol-http@3.374.0", "", { "dependencies": { "@smithy/protocol-http": "^1.1.0", "tslib": "^2.5.0" } }, "sha512-9WpRUbINdGroV3HiZZIBoJvL2ndoWk39OfwxWs2otxByppJZNN14bg/lvCx5e8ggHUti7IBk5rb0nqQZ4m05pg=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/config-resolver": "^4.4.13", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng=="],
+
+    "@aws-sdk/signature-v4": ["@aws-sdk/signature-v4@3.374.0", "", { "dependencies": { "@smithy/signature-v4": "^1.0.1", "tslib": "^2.5.0" } }, "sha512-2xLJvSdzcZZAg0lsDLUAuSQuihzK0dcxIK7WmfuJeF7DGKJFmp9czQmz5f3qiDz6IDQzvgK1M9vtJSVCslJbyQ=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1014.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.23", "@aws-sdk/nested-clients": "^3.996.13", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-gHTHNUoaOGNrSWkl32A7wFsU78jlNTlqMccLu0byUk5CysYYXaxNMIonIVr4YcykC7vgtDS5ABuz83giy6fzJA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.5", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-endpoints": "^3.3.3", "tslib": "^2.6.2" } }, "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.10", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.24", "@aws-sdk/types": "^3.973.6", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-E99zeTscCc+pTMfsvnfi6foPpKmdD1cZfOC7/P8UUrjsoQdg9VEWPRD+xdFduKnfPXwcvby58AlO9jwwF6U96g=="],
+
+    "@aws-sdk/util-utf8-browser": ["@aws-sdk/util-utf8-browser@3.259.0", "", { "dependencies": { "tslib": "^2.3.1" } }, "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.15", "", { "dependencies": { "@smithy/types": "^4.13.1", "fast-xml-parser": "5.5.8", "tslib": "^2.6.2" } }, "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
+
+    "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
+
+    "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
+
+    "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
+
+    "@fastify/sse": ["@fastify/sse@0.4.0", "", { "dependencies": { "fastify-plugin": "^5.0.0" }, "peerDependencies": { "fastify": "^5.x" } }, "sha512-bBV96iT2kHEw6h3i8IMkZGaqA7Gk81ugUzTNctXuE6N2BEC/qBnUuzlD/O17V43OkJP73h0/kf3Bp/asXlSuFA=="],
+
+    "@fastify/websocket": ["@fastify/websocket@11.2.0", "", { "dependencies": { "duplexify": "^4.1.3", "fastify-plugin": "^5.0.0", "ws": "^8.16.0" } }, "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@smithy/abort-controller": ["@smithy/abort-controller@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.13", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg=="],
+
+    "@smithy/core": ["@smithy/core@3.23.12", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-stream": "^4.5.20", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.12", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@1.1.0", "", { "dependencies": { "@aws-crypto/crc32": "3.0.0", "@smithy/types": "^1.2.0", "@smithy/util-hex-encoding": "^1.1.0", "tslib": "^2.5.0" } }, "sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.12", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.12", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA=="],
+
+    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.12", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.15", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.12", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.27", "", { "dependencies": { "@smithy/core": "^3.23.12", "@smithy/middleware-serde": "^4.2.15", "@smithy/node-config-provider": "^4.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-middleware": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.44", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/protocol-http": "^5.3.12", "@smithy/service-error-classification": "^4.2.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.15", "", { "dependencies": { "@smithy/core": "^3.23.12", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.12", "", { "dependencies": { "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.5.0", "", { "dependencies": { "@smithy/abort-controller": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1" } }, "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.7", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.12", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.7", "", { "dependencies": { "@smithy/core": "^3.23.12", "@smithy/middleware-endpoint": "^4.4.27", "@smithy/middleware-stack": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-stream": "^4.5.20", "tslib": "^2.6.2" } }, "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ=="],
+
+    "@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.12", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.43", "", { "dependencies": { "@smithy/property-provider": "^4.2.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.47", "", { "dependencies": { "@smithy/config-resolver": "^4.4.13", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/smithy-client": "^4.12.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.3.3", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.2.12", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.20", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.15", "@smithy/node-http-handler": "^4.5.0", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@smithy/util-waiter": ["@smithy/util-waiter@4.2.13", "", { "dependencies": { "@smithy/abort-controller": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
+
+    "bedrock-agentcore": ["bedrock-agentcore@0.2.2", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/client-bedrock-agentcore": "^3.996.0", "@aws-sdk/client-bedrock-agentcore-control": "^3.996.0", "@aws-sdk/credential-providers": "^3.996.0", "@aws-sdk/protocol-http": "^3.370.0", "@aws-sdk/signature-v4": "^3.370.0", "@fastify/sse": "^0.4.0", "@fastify/websocket": "^11.0.1", "@smithy/protocol-http": "^5.3.5", "@smithy/signature-v4": "^5.3.5", "@smithy/util-utf8": "^4.2.0", "@types/ws": "^8.18.1", "fastify": "^5.7.1", "ws": "^8.18.3", "zod": "^4.1.13" }, "peerDependencies": { "@strands-agents/sdk": ">=0.1.0", "ai": ">=6.0.0-beta", "playwright": ">=1.56.0", "react": ">=18.0.0", "react-dom": ">=18.0.0" }, "optionalPeers": ["@strands-agents/sdk", "ai", "playwright", "react", "react-dom"] }, "sha512-vvahV242X5tYd1XXx8qp1EY/1F57rmuNQf98dw7TwcdS8VbT7gtlY3d/vc6sWk+NkKMaYw5IXry8qKk5jL+Wkg=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -78,11 +273,17 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -96,17 +297,35 @@
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+    "eventsource-parser": ["eventsource-parser@3.0.7", "", {}, "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@8.4.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw=="],
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-json-stringify": ["fast-json-stringify@6.3.0", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^3.0.0", "rfdc": "^1.2.0" } }, "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA=="],
+
+    "fast-querystring": ["fast-querystring@1.1.2", "", { "dependencies": { "fast-decode-uri-component": "^1.0.1" } }, "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
+
+    "fastify": ["fastify@5.8.2", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg=="],
+
+    "fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-my-way": ["find-my-way@9.5.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -124,7 +343,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -134,19 +353,23 @@
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+    "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -166,35 +389,71 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.2.0", "", {}, "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-regex2": ["safe-regex2@5.1.0", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -210,11 +469,27 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strnum": ["strnum@2.2.1", "", {}, "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg=="],
+
+    "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
+
+    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -224,11 +499,15 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
@@ -237,5 +516,55 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
+    "@aws-crypto/crc32/@aws-crypto/util": ["@aws-crypto/util@3.0.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-utf8-browser": "^3.0.0", "tslib": "^1.11.1" } }, "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w=="],
+
+    "@aws-crypto/crc32/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/protocol-http/@smithy/protocol-http": ["@smithy/protocol-http@1.2.0", "", { "dependencies": { "@smithy/types": "^1.2.0", "tslib": "^2.5.0" } }, "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4": ["@smithy/signature-v4@1.1.0", "", { "dependencies": { "@smithy/eventstream-codec": "^1.1.0", "@smithy/is-array-buffer": "^1.1.0", "@smithy/types": "^1.2.0", "@smithy/util-hex-encoding": "^1.1.0", "@smithy/util-middleware": "^1.1.0", "@smithy/util-uri-escape": "^1.1.0", "@smithy/util-utf8": "^1.1.0", "tslib": "^2.5.0" } }, "sha512-fDo3m7YqXBs7neciOePPd/X9LPm5QLlDMdIC4m1H6dgNLnXfLMFNIxEfPyohGA8VW9Wn4X8lygnPSGxDZSmp0Q=="],
+
+    "@smithy/eventstream-codec/@smithy/types": ["@smithy/types@1.2.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA=="],
+
+    "@smithy/eventstream-codec/@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@1.1.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg=="],
+
+    "@smithy/eventstream-serde-universal/@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.12", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.13.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA=="],
+
+    "light-my-request/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
+    "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-sdk/protocol-http/@smithy/protocol-http/@smithy/types": ["@smithy/types@1.2.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/is-array-buffer": ["@smithy/is-array-buffer@1.1.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/types": ["@smithy/types@1.2.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@1.1.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/util-middleware": ["@smithy/util-middleware@1.1.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/util-uri-escape": ["@smithy/util-uri-escape@1.1.0", "", { "dependencies": { "tslib": "^2.5.0" } }, "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/util-utf8": ["@smithy/util-utf8@1.1.0", "", { "dependencies": { "@smithy/util-buffer-from": "^1.1.0", "tslib": "^2.5.0" } }, "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A=="],
+
+    "@smithy/eventstream-serde-universal/@smithy/eventstream-codec/@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-sdk/signature-v4/@smithy/signature-v4/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@1.1.0", "", { "dependencies": { "@smithy/is-array-buffer": "^1.1.0", "tslib": "^2.5.0" } }, "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw=="],
   }
 }

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -9,11 +9,13 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
+    "start:agentcore": "node dist/agentcore-handler.js",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.113",
     "@anthropic-ai/sdk": "^0.90.0",
+    "bedrock-agentcore": "^0.2.2",
     "yaml": "^2.8.3",
     "zod": "4.3.6"
   },

--- a/agent-runner/src/agentcore-handler.ts
+++ b/agent-runner/src/agentcore-handler.ts
@@ -1,0 +1,600 @@
+#!/usr/bin/env node
+/**
+ * AgentCore Handler — Entry point for running Claude Agent SDK inside an
+ * AWS Bedrock AgentCore microVM.
+ *
+ * The BedrockAgentCoreApp exposes an HTTP server on port 8080.  When the
+ * AgentCore runtime posts to /invocations, the async-generator handler
+ * receives the invocation payload, creates (or resumes) a Claude Agent SDK
+ * session, and yields SSE events back through the runtime's native streaming.
+ *
+ * Each `runtimeSessionId` maps to a dedicated microVM, so state isolation
+ * is guaranteed by the runtime itself.
+ *
+ * Event shapes intentionally mirror the `AgentEvent` interface from
+ * `./event-emitter.ts` so that the AgentPane bridge can handle events from
+ * both Docker-based and AgentCore-based agents uniformly.
+ */
+
+import {
+  type CanUseTool,
+  type SDKSession,
+  unstable_v2_createSession,
+  unstable_v2_resumeSession,
+} from '@anthropic-ai/claude-agent-sdk';
+import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
+import type {
+  AgentCompleteData,
+  AgentErrorData,
+  AgentEventType,
+  AgentMessageData,
+  AgentPlanReadyData,
+  AgentStartedData,
+  AgentTokenData,
+  AgentToolResultData,
+  AgentToolStartData,
+  AgentTurnData,
+} from './event-emitter.js';
+import { createAgentRunnerLogger } from './logger.js';
+// SC-023: Use shared logic extracted from index.ts and agentcore-handler.ts
+import {
+  type ExitPlanModeInput,
+  type ExitPlanModeOptions,
+  extractFileChange,
+  getAssistantText,
+  shouldStop,
+  writeCredentialsFile,
+} from './shared-session.js';
+
+// F10-05: structured runner logger (see index.ts for rationale).
+const log = createAgentRunnerLogger();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Payload sent to /invocations by the AgentPane server. */
+interface InvocationPayload {
+  /** The prompt / task description. */
+  prompt: string;
+  /** AgentPane task ID. */
+  taskId: string;
+  /** AgentPane session ID for event correlation. */
+  sessionId: string;
+  /** Claude model to use. */
+  model?: string;
+  /** Maximum conversation turns. */
+  maxTurns?: number;
+  /** Agent phase: 'plan' for planning, 'execute' for execution. */
+  phase?: 'plan' | 'execute';
+  /** SDK session ID to resume (for execution after plan approval). */
+  sdkSessionId?: string;
+  /** Allowed bash prompts from a previous ExitPlanMode call. */
+  allowedPrompts?: Array<{ tool: string; prompt: string }>;
+  /** Working directory inside the microVM. */
+  cwd?: string;
+  /** OAuth token for Claude authentication. */
+  oauthToken?: string;
+  /** theme-03 F11: real OAuth expiry (ms since epoch) from the host registry. */
+  oauthExpiresAt?: number;
+  /** theme-03 F11: OAuth refresh token when the host has one. */
+  oauthRefreshToken?: string | null;
+  /** Path to a sentinel file — when it exists the agent stops. */
+  stopFile?: string;
+}
+
+/** Shape yielded from the async generator — matches AgentCore SSE expectations. */
+interface SSEEvent {
+  type: AgentEventType;
+  timestamp: number;
+  taskId: string;
+  sessionId: string;
+  data: Record<string, unknown>;
+}
+
+// SC-023: File-change detection, credentials, stop-file, and ExitPlanMode
+// types are now imported from shared-session.ts (see imports above).
+
+// ---------------------------------------------------------------------------
+// Helper: build an SSE event object
+// ---------------------------------------------------------------------------
+
+function makeEvent(
+  type: AgentEventType,
+  taskId: string,
+  sessionId: string,
+  data: Record<string, unknown>
+): SSEEvent {
+  return { type, timestamp: Date.now(), taskId, sessionId, data };
+}
+
+// SC-023: getAssistantText is now imported from shared-session.ts
+
+/** Drain all events from a queue, returning them as an array. */
+function drainQueue(queue: SSEEvent[]): SSEEvent[] {
+  const items = queue.splice(0, queue.length);
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Core invocation handler
+// ---------------------------------------------------------------------------
+
+async function* handleInvocation(
+  payload: InvocationPayload,
+  _context: unknown
+): AsyncGenerator<SSEEvent> {
+  const {
+    prompt,
+    taskId,
+    sessionId,
+    model = 'claude-sonnet-4-6',
+    maxTurns = 50,
+    phase = 'execute',
+    sdkSessionId,
+    allowedPrompts,
+    oauthToken,
+    oauthExpiresAt,
+    oauthRefreshToken,
+    stopFile,
+  } = payload;
+
+  // -- Helpers that close over taskId / sessionId -------------------------
+  const evt = (type: AgentEventType, data: Record<string, unknown>) =>
+    makeEvent(type, taskId, sessionId, data);
+
+  // -- Validate -----------------------------------------------------------
+  if (!prompt || !taskId || !sessionId) {
+    yield evt('agent:error', {
+      error: 'Missing required fields: prompt, taskId, sessionId',
+      code: 'INVALID_PAYLOAD',
+      turnCount: 0,
+    });
+    return;
+  }
+
+  // -- Write OAuth credentials --------------------------------------------
+  const token = oauthToken || process.env.CLAUDE_OAUTH_TOKEN;
+  if (!token) {
+    yield evt('agent:error', {
+      error: 'No OAuth token — provide oauthToken in payload or CLAUDE_OAUTH_TOKEN env',
+      code: 'MISSING_TOKEN',
+      turnCount: 0,
+    });
+    return;
+  }
+
+  try {
+    // theme-03 F11: pass through real OAuth metadata from the host when
+    // available so the SDK does not see a fictitious 24h expiry. Prefer the
+    // per-invocation payload; fall back to process env vars for backwards
+    // compatibility with hosts that still propagate via env.
+    const rawEnvExpiresAt = process.env.CLAUDE_OAUTH_EXPIRES_AT;
+    const parsedEnvExpiresAt = rawEnvExpiresAt ? Number(rawEnvExpiresAt) : undefined;
+    const envExpiresAt =
+      parsedEnvExpiresAt && Number.isFinite(parsedEnvExpiresAt) && parsedEnvExpiresAt > 0
+        ? parsedEnvExpiresAt
+        : undefined;
+    const expiresAt =
+      oauthExpiresAt && Number.isFinite(oauthExpiresAt) && oauthExpiresAt > 0
+        ? oauthExpiresAt
+        : envExpiresAt;
+    const refreshToken = oauthRefreshToken ?? process.env.CLAUDE_OAUTH_REFRESH_TOKEN ?? null;
+    await writeCredentialsFile(token, { expiresAt, refreshToken });
+  } catch (credErr) {
+    yield evt('agent:error', {
+      error: `Credential setup failed: ${credErr instanceof Error ? credErr.message : String(credErr)}`,
+      code: 'CREDENTIAL_ERROR',
+      turnCount: 0,
+    });
+    return;
+  }
+
+  // -- Emit started -------------------------------------------------------
+  yield evt('agent:started', { model, maxTurns, phase } satisfies AgentStartedData & {
+    phase: string;
+  });
+
+  log.error(`[agentcore-handler] Phase: ${phase}, model: ${model}, maxTurns: ${maxTurns}`);
+
+  // -- Tool tracking (mirrors index.ts) -----------------------------------
+  const activeTools = new Map<string, { toolName: string; startTime: number }>();
+  const pendingToolResults: SSEEvent[] = [];
+
+  const trackToolResult = (toolId: string, isError = false, result = '') => {
+    const tool = activeTools.get(toolId);
+    if (!tool) return;
+    const durationMs = Date.now() - tool.startTime;
+    pendingToolResults.push(
+      evt('agent:tool:result', {
+        toolName: tool.toolName,
+        toolId,
+        result,
+        isError,
+        durationMs,
+      } satisfies AgentToolResultData)
+    );
+    activeTools.delete(toolId);
+  };
+
+  const flushAllToolResults = () => {
+    for (const [toolId] of activeTools) {
+      trackToolResult(toolId, false, 'completed');
+    }
+  };
+
+  // -- Plan-mode state (only used when phase === 'plan') ------------------
+  let exitPlanModeDetected = false;
+  let exitPlanModeOptions: ExitPlanModeOptions | undefined;
+  let exitPlanModePlan: string | undefined;
+
+  // -- canUseTool callback ------------------------------------------------
+  const pendingToolStarts: SSEEvent[] = [];
+  const pendingFileChanges: SSEEvent[] = [];
+
+  const canUseTool: CanUseTool = async (toolName, input, options) => {
+    activeTools.set(options.toolUseID, { toolName, startTime: Date.now() });
+
+    // Queue tool:start event (will be yielded in main loop)
+    pendingToolStarts.push(
+      evt('agent:tool:start', {
+        toolName,
+        toolId: options.toolUseID,
+        input: (input as Record<string, unknown>) ?? {},
+      } satisfies AgentToolStartData)
+    );
+
+    // Detect file modifications
+    const fileChange = extractFileChange(toolName, (input as Record<string, unknown>) ?? {});
+    if (fileChange) {
+      pendingFileChanges.push(evt('agent:file_changed', { ...fileChange }));
+    }
+
+    // Capture ExitPlanMode in planning phase
+    if (phase === 'plan' && toolName === 'ExitPlanMode') {
+      const planInput = input as ExitPlanModeInput | undefined;
+      exitPlanModeOptions = planInput;
+      exitPlanModeDetected = true;
+      exitPlanModePlan = typeof planInput?.plan === 'string' ? planInput.plan : undefined;
+      log.error(
+        `[agentcore-handler] ExitPlanMode captured — plan: ${exitPlanModePlan ? `${exitPlanModePlan.length} chars` : 'none'}`
+      );
+    }
+
+    // In execution phase, auto-approve Bash commands that match allowedPrompts from planning
+    if (phase === 'execute' && toolName === 'Bash' && allowedPrompts) {
+      const bashInput = input as { command?: string } | undefined;
+      if (bashInput?.command) {
+        const isAllowed = allowedPrompts.some(
+          (ap) => ap.tool === 'Bash' && ap.prompt === bashInput.command
+        );
+        if (isAllowed) {
+          log.error(`[agentcore-handler] Auto-approved Bash command from allowedPrompts`);
+        }
+      }
+    }
+
+    return { behavior: 'allow' as const, toolUseID: options.toolUseID };
+  };
+
+  // -- Create / resume SDK session ----------------------------------------
+  let session: SDKSession | undefined;
+  let sessionResumed = false;
+
+  try {
+    const permissionMode = phase === 'plan' ? 'plan' : 'bypassPermissions';
+    log.error(`[agentcore-handler] Creating SDK session (permissionMode: ${permissionMode})...`);
+
+    if (sdkSessionId && phase === 'execute') {
+      try {
+        session = unstable_v2_resumeSession(sdkSessionId, {
+          model,
+          env: { ...process.env },
+          permissionMode,
+          canUseTool,
+        });
+        sessionResumed = true;
+        log.error(`[agentcore-handler] Resumed SDK session: ${sdkSessionId}`);
+      } catch (resumeErr) {
+        const msg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+        log.warn(`[agentcore-handler] Resume failed, creating fresh session: ${msg}`);
+        yield evt('agent:message', {
+          role: 'assistant',
+          content: `Previous session could not be resumed (${msg}). Starting fresh execution with full plan context.`,
+        } satisfies AgentMessageData);
+      }
+    }
+
+    if (!session) {
+      session = unstable_v2_createSession({
+        model,
+        env: { ...process.env },
+        permissionMode,
+        canUseTool,
+      });
+    }
+    log.error('[agentcore-handler] SDK session ready');
+  } catch (sessionErr) {
+    const errMsg = sessionErr instanceof Error ? sessionErr.message : String(sessionErr);
+    log.error('[agentcore-handler] SDK session creation failed:', { errMsg: errMsg });
+    yield evt('agent:error', {
+      error: `SDK session creation failed: ${errMsg}`,
+      code: 'SDK_SESSION_FAILED',
+      turnCount: 0,
+    } satisfies AgentErrorData);
+    return;
+  }
+
+  if (!session) {
+    yield evt('agent:error', {
+      error: 'Session not initialized',
+      code: 'SDK_SESSION_FAILED',
+      turnCount: 0,
+    });
+    return;
+  }
+
+  // -- Stream processing --------------------------------------------------
+  let turn = 0;
+  let accumulatedText = '';
+  let capturedSdkSessionId: string | undefined;
+  let sessionClosed = false;
+
+  const closeSession = () => {
+    if (!sessionClosed && session) {
+      sessionClosed = true;
+      session.close();
+    }
+  };
+
+  try {
+    // Send prompt — use abbreviated prompt when resuming a planned session
+    const sendPrompt = sessionResumed
+      ? 'The plan has been approved. Please proceed with the implementation.'
+      : prompt;
+
+    await session.send(sendPrompt);
+    log.error(`[agentcore-handler] Processing SDK stream (${phase})...`);
+
+    let messageCount = 0;
+
+    for await (const msg of session.stream()) {
+      messageCount++;
+
+      // Yield any queued tool events from canUseTool callback
+      yield* drainQueue(pendingToolStarts);
+      yield* drainQueue(pendingFileChanges);
+      yield* drainQueue(pendingToolResults);
+
+      // Check for cancellation
+      if (await shouldStop(stopFile)) {
+        log.error('[agentcore-handler] Stop file detected, cancelling...');
+        yield evt('agent:cancelled', { turnCount: turn });
+        closeSession();
+        return;
+      }
+
+      // -- system: capture SDK session ID ---------------------------------
+      if (msg.type === 'system') {
+        const sysMsg = msg as { subtype?: string };
+        if (sysMsg.subtype === 'init') {
+          capturedSdkSessionId = session.sessionId;
+          log.error(`[agentcore-handler] SDK session ID: ${capturedSdkSessionId}`);
+        }
+      }
+
+      // -- stream_event: token deltas and turn tracking -------------------
+      if (msg.type === 'stream_event') {
+        const event = msg.event as {
+          type: string;
+          delta?: { type: string; text?: string };
+          message?: { model?: string };
+        };
+
+        // Turn tracking on message_start
+        if (event.type === 'message_start') {
+          turn++;
+          log.error(`[agentcore-handler] Turn ${turn}/${maxTurns}`);
+          yield evt('agent:turn', {
+            turn,
+            maxTurns,
+            remaining: maxTurns - turn,
+          } satisfies AgentTurnData);
+
+          if (turn >= maxTurns) {
+            log.error('[agentcore-handler] Turn limit reached');
+            yield evt('agent:complete', {
+              status: 'turn_limit',
+              turnCount: turn,
+              result: `Turn limit reached (${maxTurns}).${phase === 'plan' ? ' Planning incomplete.' : ' Task may need manual completion.'}`,
+            } satisfies AgentCompleteData);
+            closeSession();
+            return;
+          }
+        }
+
+        // Text deltas
+        if (
+          event.type === 'content_block_delta' &&
+          event.delta?.type === 'text_delta' &&
+          event.delta.text
+        ) {
+          const delta = event.delta.text;
+          accumulatedText += delta;
+          yield evt('agent:token', {
+            delta,
+          } satisfies AgentTokenData);
+        }
+      }
+
+      // -- tool_progress --------------------------------------------------
+      if (msg.type === 'tool_progress') {
+        const toolMsg = msg as {
+          tool_use_id: string;
+          tool_name: string;
+          elapsed_time_seconds: number;
+        };
+        if (!activeTools.has(toolMsg.tool_use_id)) {
+          activeTools.set(toolMsg.tool_use_id, {
+            toolName: toolMsg.tool_name,
+            startTime: Date.now(),
+          });
+          yield evt('agent:tool:start', {
+            toolName: toolMsg.tool_name,
+            toolId: toolMsg.tool_use_id,
+            input: {},
+          } satisfies AgentToolStartData);
+        }
+      }
+
+      // -- rate_limit_event (SDK v0.2.76+) ---------------------------------
+      if (msg.type === 'rate_limit_event') {
+        const rateLimitMsg = msg as {
+          rate_limit_info: { status: string; resetsAt?: number };
+        };
+        log.error(`[agentcore-handler] Rate limit: ${rateLimitMsg.rate_limit_info.status}`);
+      }
+
+      // -- tool_use_summary -----------------------------------------------
+      if (msg.type === 'tool_use_summary') {
+        const toolSummary = msg as {
+          summary: string;
+          preceding_tool_use_ids: string[];
+        };
+
+        for (const toolId of toolSummary.preceding_tool_use_ids) {
+          const startInfo = activeTools.get(toolId);
+          if (startInfo) {
+            activeTools.delete(toolId);
+            const durationMs = Date.now() - startInfo.startTime;
+            yield evt('agent:tool:result', {
+              toolName: startInfo.toolName,
+              toolId,
+              result: toolSummary.summary ?? '',
+              isError: false,
+              durationMs,
+            } satisfies AgentToolResultData);
+
+            if (startInfo.toolName === 'ExitPlanMode') {
+              log.error('[agentcore-handler] ExitPlanMode tool completed — waiting for result');
+            }
+          }
+        }
+      }
+
+      // -- assistant message ----------------------------------------------
+      if (msg.type === 'assistant') {
+        // Flush remaining tool results
+        flushAllToolResults();
+        yield* drainQueue(pendingToolResults);
+
+        const text = getAssistantText(msg);
+        if (text) {
+          accumulatedText = text;
+          yield evt('agent:message', {
+            role: 'assistant',
+            content: text,
+          } satisfies AgentMessageData);
+        }
+      }
+
+      // -- result (stream end) --------------------------------------------
+      if (msg.type === 'result') {
+        flushAllToolResults();
+        yield* drainQueue(pendingToolResults);
+        closeSession();
+
+        if (phase === 'plan') {
+          // Planning phase: emit plan_ready if ExitPlanMode was called
+          if (exitPlanModeDetected || exitPlanModeOptions !== undefined || accumulatedText) {
+            const planContent = exitPlanModePlan || accumulatedText;
+            log.error(
+              `[agentcore-handler] Emitting plan_ready (source: ${exitPlanModePlan ? 'ExitPlanModeInput' : 'accumulated'}, length: ${planContent.length})`
+            );
+            yield evt('agent:plan_ready', {
+              plan: planContent,
+              turnCount: turn,
+              sdkSessionId: capturedSdkSessionId ?? '',
+              allowedPrompts: exitPlanModeOptions?.allowedPrompts,
+            } satisfies AgentPlanReadyData);
+          } else {
+            yield evt('agent:complete', {
+              status: 'completed',
+              turnCount: turn,
+              result: accumulatedText || 'Planning completed without explicit plan',
+            } satisfies AgentCompleteData);
+          }
+        } else {
+          // Execution phase
+          const result = msg as { text?: string; subtype?: string; is_error?: boolean };
+          if (result.is_error) {
+            yield evt('agent:complete', {
+              status: 'turn_limit',
+              turnCount: turn,
+              result: result.text ?? 'Task ended with error',
+            } satisfies AgentCompleteData);
+          } else {
+            yield evt('agent:complete', {
+              status: 'completed',
+              turnCount: turn,
+              result: result.text ?? (accumulatedText || 'Task completed'),
+            } satisfies AgentCompleteData);
+          }
+        }
+        return;
+      }
+    }
+
+    // Stream ended without explicit result
+    log.error(`[agentcore-handler] Stream ended. Messages: ${messageCount}, turns: ${turn}`);
+    flushAllToolResults();
+    yield* drainQueue(pendingToolResults);
+    closeSession();
+
+    if (phase === 'plan' && accumulatedText) {
+      yield evt('agent:plan_ready', {
+        plan: accumulatedText,
+        turnCount: turn,
+        sdkSessionId: capturedSdkSessionId ?? '',
+        allowedPrompts: exitPlanModeOptions?.allowedPrompts,
+      } satisfies AgentPlanReadyData);
+    } else {
+      yield evt('agent:complete', {
+        status: 'completed',
+        turnCount: turn,
+        result: accumulatedText || `${phase === 'plan' ? 'Planning' : 'Task'} completed`,
+      } satisfies AgentCompleteData);
+    }
+  } catch (error) {
+    flushAllToolResults();
+    yield* drainQueue(pendingToolResults);
+
+    const message = error instanceof Error ? error.message : String(error);
+    const errorCode = (error as { code?: string }).code;
+    log.error(`[agentcore-handler] ${phase} error:`, { message: message });
+    if (error instanceof Error && error.stack) {
+      log.error('[agentcore-handler] Stack:', { stack: error.stack });
+    }
+
+    yield evt('agent:error', {
+      error: message,
+      code: errorCode || (phase === 'plan' ? 'PLANNING_ERROR' : 'STREAM_ERROR'),
+      turnCount: turn,
+    } satisfies AgentErrorData);
+
+    closeSession();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BedrockAgentCoreApp bootstrap
+// ---------------------------------------------------------------------------
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    process: handleInvocation as (payload: unknown, context: unknown) => AsyncGenerator<SSEEvent>,
+  },
+});
+
+log.error('[agentcore-handler] Starting BedrockAgentCoreApp on port 8080...');
+app.run();

--- a/agent-runner/src/shared-session.ts
+++ b/agent-runner/src/shared-session.ts
@@ -1,12 +1,15 @@
 /**
- * Shared session helpers used by the Docker agent-runner (index.ts).
+ * SC-023: Shared logic extracted from index.ts and agentcore-handler.ts.
  *
- * Concerns:
+ * Both the Docker agent-runner (index.ts) and the AgentCore handler
+ * (agentcore-handler.ts) duplicate the following concerns:
  *   - OAuth credential file writing
  *   - Stop-file checking for cancellation
  *   - Assistant text extraction from SDK messages
  *   - File-change detection from tool calls
  *   - ExitPlanMode type definitions
+ *
+ * This module provides shared implementations to eliminate that duplication.
  */
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.113",
         "@anthropic-ai/sdk": "^0.90.0",
+        "@aws-sdk/client-sts": "^3.1032.0",
         "@cdktf/hcl2json": "^0.21.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -114,6 +115,68 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-sts": ["@aws-sdk/client-sts@3.1032.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.1", "@aws-sdk/credential-provider-node": "^3.972.32", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.31", "@aws-sdk/region-config-resolver": "^3.972.12", "@aws-sdk/signature-v4-multi-region": "^3.996.18", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.7", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.17", "@smithy/config-resolver": "^4.4.16", "@smithy/core": "^3.23.15", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.30", "@smithy/middleware-retry": "^4.5.3", "@smithy/middleware-serde": "^4.2.18", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.5.3", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.47", "@smithy/util-defaults-mode-node": "^4.2.52", "@smithy/util-endpoints": "^3.4.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FCLc5VWb+yz1xb/Jv0sXFGqIIs+bHZQWBKbPQKCuypF3wU/7UFygXuSXo9uJfwISKNGVHJwp+0136f8mqmzRcA=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.1", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.18", "@smithy/core": "^3.23.15", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/types": "^3.973.8", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.5.3", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.23", "tslib": "^2.6.2" } }, "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.31", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/credential-provider-env": "^3.972.27", "@aws-sdk/credential-provider-http": "^3.972.29", "@aws-sdk/credential-provider-login": "^3.972.31", "@aws-sdk/credential-provider-process": "^3.972.27", "@aws-sdk/credential-provider-sso": "^3.972.31", "@aws-sdk/credential-provider-web-identity": "^3.972.31", "@aws-sdk/nested-clients": "^3.996.21", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.31", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/nested-clients": "^3.996.21", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.32", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.27", "@aws-sdk/credential-provider-http": "^3.972.29", "@aws-sdk/credential-provider-ini": "^3.972.31", "@aws-sdk/credential-provider-process": "^3.972.27", "@aws-sdk/credential-provider-sso": "^3.972.31", "@aws-sdk/credential-provider-web-identity": "^3.972.31", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.31", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/nested-clients": "^3.996.21", "@aws-sdk/token-providers": "3.1032.0", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.31", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/nested-clients": "^3.996.21", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.30", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/core": "^3.23.15", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.23", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-hoQRxjJu4tt3gEOQin21rJKotClJC+x7AmCh9ylRct1DJeaNI/BRlFxMbuhJe54bG6xANPagSs0my8K30QyV9g=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.31", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.7", "@smithy/core": "^3.23.15", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-retry": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.21", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.1", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.31", "@aws-sdk/region-config-resolver": "^3.972.12", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.7", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.17", "@smithy/config-resolver": "^4.4.16", "@smithy/core": "^3.23.15", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.30", "@smithy/middleware-retry": "^4.5.3", "@smithy/middleware-serde": "^4.2.18", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.5.3", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.47", "@smithy/util-defaults-mode-node": "^4.2.52", "@smithy/util-endpoints": "^3.4.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.12", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/config-resolver": "^4.4.16", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.18", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.30", "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-4KT8UXRmvNAP5zKq9UI1MIwbnmSChZncBt89RKu/skMqZSSWGkBZTAJsZ+no+txfmF3kVaUFv31CTBZkQ5BJpQ=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1032.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/nested-clients": "^3.996.21", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.7", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-endpoints": "^3.4.1", "tslib": "^2.6.2" } }, "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.17", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.31", "@aws-sdk/types": "^3.973.8", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.18", "", { "dependencies": { "@smithy/types": "^4.14.1", "fast-xml-parser": "5.5.8", "tslib": "^2.6.2" } }, "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
@@ -697,6 +760,84 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.16", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.4.1", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg=="],
+
+    "@smithy/core": ["@smithy/core@3.23.15", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.23", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.14", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.14", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.30", "", { "dependencies": { "@smithy/core": "^3.23.15", "@smithy/middleware-serde": "^4.2.18", "@smithy/node-config-provider": "^4.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.5.3", "", { "dependencies": { "@smithy/core": "^3.23.15", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/service-error-classification": "^4.2.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.18", "", { "dependencies": { "@smithy/core": "^3.23.15", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.14", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.5.3", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1" } }, "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.9", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.11", "", { "dependencies": { "@smithy/core": "^3.23.15", "@smithy/middleware-endpoint": "^4.4.30", "@smithy/middleware-stack": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.23", "tslib": "^2.6.2" } }, "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg=="],
+
+    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.14", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.47", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.52", "", { "dependencies": { "@smithy/config-resolver": "^4.4.16", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/smithy-client": "^4.12.11", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.4.1", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.3.2", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.23", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.5.3", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@stryker-mutator/api": ["@stryker-mutator/api@9.6.1", "", { "dependencies": { "mutation-testing-metrics": "3.7.3", "mutation-testing-report-schema": "3.7.3", "tslib": "~2.8.0", "typed-inject": "~5.0.0" } }, "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg=="],
@@ -957,6 +1098,8 @@
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1200,6 +1343,10 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -1589,6 +1736,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
@@ -1781,6 +1930,8 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "strnum": ["strnum@2.2.0", "", {}, "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -1964,6 +2115,16 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
+    "@aws-crypto/sha256-browser/@aws-sdk/types": ["@aws-sdk/types@3.973.5", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/sha256-js/@aws-sdk/types": ["@aws-sdk/types@3.973.5", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ=="],
+
+    "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.973.5", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -2173,6 +2334,16 @@
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "@aws-crypto/sha256-browser/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/sha256-js/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
+
+    "@aws-crypto/util/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
     "@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
@@ -2316,5 +2487,9 @@
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
   }
 }

--- a/docker/Dockerfile.agentcore
+++ b/docker/Dockerfile.agentcore
@@ -1,0 +1,103 @@
+# AgentCore Dockerfile
+# Builds the agent-runner for deployment on AWS Bedrock AgentCore runtime.
+#
+# AgentCore requires ARM64 images — the container runs in a dedicated Firecracker
+# microVM, with /invocations exposed on port 8080 via BedrockAgentCoreApp.
+#
+# Usage:
+#   docker build --platform linux/arm64 -f docker/Dockerfile.agentcore -t agentpane-agentcore:latest .
+#
+# The image includes:
+# - Node.js 22 (ARM64)
+# - Claude Agent SDK + bedrock-agentcore runtime
+# - Claude Code CLI (required by the Agent SDK)
+# - ripgrep, fd-find, tree, git for agent file operations
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build
+# ---------------------------------------------------------------------------
+FROM --platform=linux/arm64 node:22-bookworm-slim AS builder
+
+WORKDIR /opt/agent-runner
+
+# Copy package files first for better layer caching
+COPY agent-runner/package.json agent-runner/package-lock.json* ./
+COPY agent-runner/tsconfig.json ./
+
+# Install all dependencies (including devDependencies for TypeScript build)
+RUN npm install --ignore-scripts
+
+# Copy source
+COPY agent-runner/src ./src/
+
+# Build TypeScript to JavaScript
+RUN npm run build
+
+# Prune devDependencies for production
+RUN npm prune --production
+
+# ---------------------------------------------------------------------------
+# Stage 2: Runtime
+# ---------------------------------------------------------------------------
+FROM --platform=linux/arm64 node:22-bookworm-slim
+
+# Install system tools needed by the agent during execution
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ripgrep \
+    fd-find \
+    tree \
+    curl \
+    sudo \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Install Claude Code CLI globally (required by Claude Agent SDK —
+# the SDK spawns the CLI process and communicates with it)
+RUN npm install -g @anthropic-ai/claude-code
+
+# Configure git for mounted / cloned volumes (prevents "dubious ownership" errors)
+RUN git config --system --add safe.directory '*' && \
+    git config --system user.email "agent@agentcore.local" && \
+    git config --system user.name "AgentPane AgentCore"
+
+# Create workspace directory
+RUN mkdir -p /workspace
+
+# Create .claude directories for SDK (plans, credentials, etc.)
+RUN mkdir -p /home/node/.claude/plans && chown -R node:node /home/node/.claude
+
+# Allow node user limited sudo for permission fixes only
+RUN echo "node ALL=(ALL) NOPASSWD: /bin/chown" >> /etc/sudoers.d/node-chown
+
+# Copy built application from builder stage
+COPY --from=builder /opt/agent-runner/dist /opt/agent-runner/dist
+COPY --from=builder /opt/agent-runner/node_modules /opt/agent-runner/node_modules
+COPY --from=builder /opt/agent-runner/package.json /opt/agent-runner/package.json
+
+# Ensure workspace is writable by node user
+RUN chown -R node:node /workspace /opt/agent-runner
+
+WORKDIR /workspace
+
+# Switch to non-root user for security
+USER node
+
+# Ensure .claude dir exists at runtime (may be overwritten by volume mounts)
+RUN mkdir -p /home/node/.claude/plans
+
+# AgentCore runtime listens on port 8080
+EXPOSE 8080
+
+# Health check — BedrockAgentCoreApp responds on /ping
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -sf http://localhost:8080/ping || exit 1
+
+# Entry point: run the AgentCore handler
+CMD ["node", "/opt/agent-runner/dist/agentcore-handler.js"]
+
+# Labels
+LABEL org.opencontainers.image.title="AgentPane AgentCore Runtime"
+LABEL org.opencontainers.image.description="Claude Agent SDK runner for AWS Bedrock AgentCore (ARM64)"
+LABEL org.opencontainers.image.base.name="node:22-bookworm-slim"

--- a/knip.json
+++ b/knip.json
@@ -42,6 +42,7 @@
     "@tanstack/react-start",
     "@radix-ui/react-visually-hidden",
     "agent-browser",
+    "@aws-sdk/client-sts",
     "@radix-ui/react-popover",
     "@biomejs/biome",
     "@stryker-mutator/core"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.113",
     "@anthropic-ai/sdk": "^0.90.0",
+    "@aws-sdk/client-sts": "^3.1032.0",
     "@cdktf/hcl2json": "^0.21.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/app/components/features/sandbox-indicator.tsx
+++ b/src/app/components/features/sandbox-indicator.tsx
@@ -17,7 +17,13 @@ export type ContainerStatus =
   | 'error'
   | 'unavailable';
 
-export type SandboxProviderType = 'docker' | 'devcontainer' | 'kubernetes' | 'nomad' | 'none';
+export type SandboxProviderType =
+  | 'docker'
+  | 'devcontainer'
+  | 'kubernetes'
+  | 'nomad'
+  | 'agentcore'
+  | 'none';
 
 const statusDotVariants = cva('h-2 w-2 rounded-full', {
   variants: {
@@ -58,7 +64,14 @@ function getStatusLabel(status: ContainerStatus): string {
 }
 
 function getStatusDescription(status: ContainerStatus, provider: SandboxProviderType): string {
-  const target = provider === 'kubernetes' ? 'Pod' : provider === 'nomad' ? 'Job' : 'Container';
+  const target =
+    provider === 'kubernetes'
+      ? 'Pod'
+      : provider === 'nomad'
+        ? 'Job'
+        : provider === 'agentcore'
+          ? 'Runtime'
+          : 'Container';
   switch (status) {
     case 'creating':
       return `${target} is starting up...`;
@@ -96,6 +109,8 @@ function getProviderLabel(provider: SandboxProviderType): string {
       return 'Docker';
     case 'devcontainer':
       return 'DevContainer';
+    case 'agentcore':
+      return 'AgentCore';
     default:
       return 'Docker';
   }
@@ -111,6 +126,8 @@ function getProviderDescription(provider: SandboxProviderType): string {
       return 'Agents run in isolated Docker containers for security.';
     case 'devcontainer':
       return 'Agents run in VS Code-compatible DevContainers for reproducible environments.';
+    case 'agentcore':
+      return 'Agents run in AWS Bedrock AgentCore microVMs for managed isolation.';
     default:
       return 'Agents run in isolated containers for security.';
   }
@@ -139,6 +156,13 @@ function getUnavailableDescription(provider: SandboxProviderType): {
       title: 'DevContainer Not Available',
       description:
         'The sandbox requires Docker and a devcontainer.json configuration to run agent tasks in DevContainers. Please check your Docker installation and project configuration.',
+    };
+  }
+  if (provider === 'agentcore') {
+    return {
+      title: 'AgentCore Not Available',
+      description:
+        'The sandbox requires AWS Bedrock AgentCore credentials to run agent tasks in managed microVMs. Please check your AWS configuration in Settings.',
     };
   }
   return {

--- a/src/db/schema/shared/enums.ts
+++ b/src/db/schema/shared/enums.ts
@@ -54,7 +54,13 @@ export type SessionStatus = (typeof SESSION_STATUS)[number];
 // SC-002: 'devcontainer' is a planned future feature for VS Code Dev Container
 // integration. It is included in the enum to reserve the value in the database
 // schema, preventing migration churn when the feature is implemented.
-export const SANDBOX_TYPES = ['docker', 'devcontainer', 'kubernetes', 'nomad'] as const;
+export const SANDBOX_TYPES = [
+  'docker',
+  'devcontainer',
+  'kubernetes',
+  'nomad',
+  'agentcore',
+] as const;
 export type SandboxType = (typeof SANDBOX_TYPES)[number];
 
 export const RBAC_ROLES = ['owner', 'admin', 'agent_operator', 'viewer'] as const;

--- a/src/lib/agents/__tests__/agentcore-bridge.test.ts
+++ b/src/lib/agents/__tests__/agentcore-bridge.test.ts
@@ -1,0 +1,679 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AgentCoreBridge,
+  AgentCoreBridgeOptions,
+  AgentCorePlanReadyData,
+  SSEEvent,
+} from '../agentcore-bridge.js';
+import { createAgentCoreBridge } from '../agentcore-bridge.js';
+import { EVENT_TYPE_MAP } from '../event-type-map.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an AsyncIterable from an array of SSE events.
+ * Optionally inserts a small delay between events for realism.
+ */
+async function* asyncIterableFromArray(events: SSEEvent[]): AsyncIterable<SSEEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/**
+ * Create an AsyncIterable that throws after yielding some events.
+ */
+async function* asyncIterableThatThrows(
+  events: SSEEvent[],
+  errorMessage: string
+): AsyncIterable<SSEEvent> {
+  for (const event of events) {
+    yield event;
+  }
+  throw new Error(errorMessage);
+}
+
+/**
+ * Create an AsyncIterable with a controllable delay that checks for stop.
+ */
+function asyncIterableWithDelay(events: SSEEvent[], delayMs = 50): AsyncIterable<SSEEvent> {
+  let index = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<SSEEvent>> {
+          if (index >= events.length) {
+            return { done: true, value: undefined };
+          }
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          const event = events[index++]!;
+          return { done: false, value: event };
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock DurableStreamsService
+// ---------------------------------------------------------------------------
+
+interface MockStreams {
+  publish: ReturnType<typeof vi.fn>;
+}
+
+function createMockStreams(): MockStreams {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentCoreBridge', () => {
+  let mockStreams: MockStreams;
+  const taskId = 'task-001';
+  const sessionId = 'session-001';
+  const codespaceId = 'proj-001';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStreams = createMockStreams();
+    // Suppress console.log noise from info/debug logs
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createBridge(overrides: Partial<AgentCoreBridgeOptions> = {}): AgentCoreBridge {
+    return createAgentCoreBridge({
+      taskId,
+      sessionId,
+      codespaceId,
+      streams: mockStreams as unknown as AgentCoreBridgeOptions['streams'],
+      ...overrides,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. Basic event processing
+  // -------------------------------------------------------------------------
+
+  it('should map agent events to container-agent events', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: { message: 'Agent starting' } },
+      { type: 'agent:turn', data: { turnCount: 1, content: 'hello' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledTimes(2);
+
+    // First call: agent:started mapped to container-agent:started
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:started',
+      expect.objectContaining({
+        taskId,
+        sessionId,
+        codespaceId,
+        message: 'Agent starting',
+      })
+    );
+
+    // Second call: agent:turn mapped to container-agent:turn
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:turn',
+      expect.objectContaining({
+        taskId,
+        sessionId,
+        codespaceId,
+        turnCount: 1,
+        content: 'hello',
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. All event types mapped correctly
+  // -------------------------------------------------------------------------
+
+  it('should map all event types from EVENT_TYPE_MAP', async () => {
+    const eventTypes = Object.keys(EVENT_TYPE_MAP) as Array<keyof typeof EVENT_TYPE_MAP>;
+    const events: SSEEvent[] = eventTypes.map((type) => ({
+      type,
+      data: {
+        turnCount: 1,
+        status: 'completed',
+        error: 'test',
+        plan: 'plan',
+        sdkSessionId: 'sdk-1',
+      },
+    }));
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledTimes(eventTypes.length);
+
+    for (let i = 0; i < eventTypes.length; i++) {
+      const agentType = eventTypes[i]!;
+      const expectedStreamType = EVENT_TYPE_MAP[agentType];
+      expect(mockStreams.publish).toHaveBeenCalledWith(
+        sessionId,
+        expectedStreamType,
+        expect.objectContaining({ taskId, sessionId, codespaceId })
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Token streaming
+  // -------------------------------------------------------------------------
+
+  it('should publish token events with delta data', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:token', data: { delta: 'Hello' } },
+      { type: 'agent:token', data: { delta: ' world' } },
+      { type: 'agent:token', data: { delta: '!' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledTimes(3);
+
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:token',
+      expect.objectContaining({ delta: 'Hello', taskId, sessionId, codespaceId })
+    );
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:token',
+      expect.objectContaining({ delta: ' world' })
+    );
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:token',
+      expect.objectContaining({ delta: '!' })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Turn tracking (eventCount)
+  // -------------------------------------------------------------------------
+
+  it('should track event count across the stream', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: { message: 'started' } },
+      { type: 'agent:turn', data: { turnCount: 1 } },
+      { type: 'agent:turn', data: { turnCount: 2 } },
+      { type: 'agent:turn', data: { turnCount: 3 } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // All 4 events should be published
+    expect(mockStreams.publish).toHaveBeenCalledTimes(4);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Plan ready callback
+  // -------------------------------------------------------------------------
+
+  it('should call onPlanReady with plan data', async () => {
+    const onPlanReady = vi.fn();
+    const planData: AgentCorePlanReadyData = {
+      plan: 'Step 1: read files\nStep 2: implement feature',
+      turnCount: 5,
+      sdkSessionId: 'sdk-session-123',
+      allowedPrompts: [{ tool: 'Bash', prompt: 'npm test' }],
+    };
+
+    const events: SSEEvent[] = [
+      { type: 'agent:plan_ready', data: planData as unknown as Record<string, unknown> },
+    ];
+
+    const bridge = createBridge({ onPlanReady });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(onPlanReady).toHaveBeenCalledTimes(1);
+    expect(onPlanReady).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: 'Step 1: read files\nStep 2: implement feature',
+        turnCount: 5,
+        sdkSessionId: 'sdk-session-123',
+        allowedPrompts: [{ tool: 'Bash', prompt: 'npm test' }],
+      })
+    );
+  });
+
+  it('should not throw when onPlanReady is not provided', async () => {
+    const events: SSEEvent[] = [
+      {
+        type: 'agent:plan_ready',
+        data: { plan: 'plan text', turnCount: 3, sdkSessionId: 'sdk-1' },
+      },
+    ];
+
+    const bridge = createBridge({ onPlanReady: undefined });
+    await expect(bridge.processStream(asyncIterableFromArray(events))).resolves.toBeUndefined();
+  });
+
+  it('should call onPlanReady with fallback values when plan is missing', async () => {
+    const onPlanReady = vi.fn();
+    const events: SSEEvent[] = [
+      { type: 'agent:plan_ready', data: { turnCount: 3, sdkSessionId: 'sdk-1' } },
+    ];
+
+    const bridge = createBridge({ onPlanReady });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Event is published to DurableStreams
+    expect(mockStreams.publish).toHaveBeenCalledTimes(1);
+    // Callback fires with fallback plan (JSON stringified data) to prevent stuck tasks
+    expect(onPlanReady).toHaveBeenCalledTimes(1);
+    const planData = onPlanReady.mock.calls[0]![0];
+    expect(planData.turnCount).toBe(3);
+    expect(planData.sdkSessionId).toBe('sdk-1');
+    expect(typeof planData.plan).toBe('string');
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Completion callback
+  // -------------------------------------------------------------------------
+
+  it('should call onComplete on agent:complete', async () => {
+    const onComplete = vi.fn();
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: { message: 'started' } },
+      { type: 'agent:turn', data: { turnCount: 1 } },
+      { type: 'agent:complete', data: { status: 'completed', turnCount: 5 } },
+    ];
+
+    const bridge = createBridge({ onComplete });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith('completed', 5);
+  });
+
+  it('should call onComplete with turn_limit status', async () => {
+    const onComplete = vi.fn();
+    const events: SSEEvent[] = [
+      { type: 'agent:complete', data: { status: 'turn_limit', turnCount: 50 } },
+    ];
+
+    const bridge = createBridge({ onComplete });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(onComplete).toHaveBeenCalledWith('turn_limit', 50);
+  });
+
+  it('should call onComplete with cancelled status via agent:cancelled', async () => {
+    const onComplete = vi.fn();
+    const events: SSEEvent[] = [{ type: 'agent:cancelled', data: { turnCount: 3 } }];
+
+    const bridge = createBridge({ onComplete });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(onComplete).toHaveBeenCalledWith('cancelled', 3);
+  });
+
+  it('should call onComplete with fallback turnCount when turnCount is missing', async () => {
+    const onComplete = vi.fn();
+    const events: SSEEvent[] = [{ type: 'agent:complete', data: { status: 'completed' } }];
+
+    const bridge = createBridge({ onComplete });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Callback still fires with fallback turnCount=0 to prevent stuck tasks
+    expect(mockStreams.publish).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith('completed', 0);
+  });
+
+  it('should call onComplete with fallback status when status is invalid', async () => {
+    const onComplete = vi.fn();
+    const events: SSEEvent[] = [
+      { type: 'agent:complete', data: { status: 'unknown_status', turnCount: 5 } },
+    ];
+
+    const bridge = createBridge({ onComplete });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Falls back to 'completed' status to prevent stuck tasks
+    expect(onComplete).toHaveBeenCalledWith('completed', 5);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Error callback
+  // -------------------------------------------------------------------------
+
+  it('should call onError on agent:error', async () => {
+    const onError = vi.fn();
+    const events: SSEEvent[] = [
+      { type: 'agent:error', data: { error: 'Something went wrong', turnCount: 3 } },
+    ];
+
+    const bridge = createBridge({ onError });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith('Something went wrong', 3);
+  });
+
+  it('should call onError with fallback values when error data is malformed', async () => {
+    const onError = vi.fn();
+    const events: SSEEvent[] = [{ type: 'agent:error', data: { error: 123, turnCount: 'bad' } }];
+
+    const bridge = createBridge({ onError });
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Callback fires with coerced values to prevent stuck tasks
+    expect(mockStreams.publish).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith('123', 0);
+  });
+
+  it('should not throw when onError is not provided', async () => {
+    const events: SSEEvent[] = [{ type: 'agent:error', data: { error: 'fail', turnCount: 1 } }];
+
+    const bridge = createBridge({ onError: undefined });
+    await expect(bridge.processStream(asyncIterableFromArray(events))).resolves.toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Stream error handling
+  // -------------------------------------------------------------------------
+
+  it('should handle stream errors gracefully', async () => {
+    const onError = vi.fn();
+    const events: SSEEvent[] = [{ type: 'agent:started', data: { message: 'started' } }];
+
+    const bridge = createBridge({ onError });
+    await bridge.processStream(asyncIterableThatThrows(events, 'Network failure'));
+
+    // The started event should have been published before the error
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:started',
+      expect.objectContaining({ taskId })
+    );
+
+    // Error event should also be published
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:error',
+      expect.objectContaining({
+        error: 'Network failure',
+        turnCount: 0,
+        taskId,
+        sessionId,
+        codespaceId,
+      })
+    );
+
+    // onError callback should be called
+    expect(onError).toHaveBeenCalledWith('Network failure', 0);
+  });
+
+  it('should handle stream error when no events have been processed', async () => {
+    const onError = vi.fn();
+
+    async function* failImmediately(): AsyncIterable<SSEEvent> {
+      throw new Error('Connection refused');
+    }
+
+    const bridge = createBridge({ onError });
+    await bridge.processStream(failImmediately());
+
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:error',
+      expect.objectContaining({ error: 'Connection refused', turnCount: 0 })
+    );
+    expect(onError).toHaveBeenCalledWith('Connection refused', 0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Invalid events skipped
+  // -------------------------------------------------------------------------
+
+  it('should skip events without type or data', async () => {
+    const events: SSEEvent[] = [
+      // Missing type
+      { type: '', data: { message: 'no type' } },
+      // Missing data (null coerced to empty-ish)
+      { type: 'agent:started', data: null as unknown as Record<string, unknown> },
+      // Valid event that should go through
+      { type: 'agent:started', data: { message: 'valid' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Only the valid event should be published
+    expect(mockStreams.publish).toHaveBeenCalledTimes(1);
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:started',
+      expect.objectContaining({ message: 'valid' })
+    );
+  });
+
+  it('should skip events where data is not an object', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: 'string' as unknown as Record<string, unknown> },
+      { type: 'agent:started', data: { message: 'valid' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. Unknown event types skipped
+  // -------------------------------------------------------------------------
+
+  it('should skip unknown event types', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:unknown_event', data: { message: 'unknown' } },
+      { type: 'custom:event', data: { message: 'custom' } },
+      { type: 'agent:started', data: { message: 'valid' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Only the valid agent:started should be published
+    expect(mockStreams.publish).toHaveBeenCalledTimes(1);
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:started',
+      expect.objectContaining({ message: 'valid' })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. Event enrichment
+  // -------------------------------------------------------------------------
+
+  it('should enrich events with taskId, sessionId, and codespaceId', async () => {
+    const events: SSEEvent[] = [{ type: 'agent:token', data: { delta: 'test' } }];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:token',
+      expect.objectContaining({
+        taskId: 'task-001',
+        sessionId: 'session-001',
+        codespaceId: 'proj-001',
+        delta: 'test',
+      })
+    );
+  });
+
+  it('should not allow event data to overwrite bridge context keys', async () => {
+    // Context keys (taskId, sessionId, codespaceId) are placed after the spread
+    // so they always win over event data — prevents event data from misrouting
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: { taskId: 'malicious-task', extra: 'data' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    // Bridge context keys override event data to prevent misrouting
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:started',
+      expect.objectContaining({
+        taskId: 'task-001', // bridge context wins
+        sessionId: 'session-001',
+        codespaceId: 'proj-001',
+        extra: 'data',
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. Stop method
+  // -------------------------------------------------------------------------
+
+  it('should stop processing when stop() is called', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: { message: 'started' } },
+      { type: 'agent:turn', data: { turnCount: 1 } },
+      { type: 'agent:turn', data: { turnCount: 2 } },
+      { type: 'agent:turn', data: { turnCount: 3 } },
+    ];
+
+    const bridge = createBridge();
+
+    // Use delayed stream so we can call stop() between events
+    const stream = asyncIterableWithDelay(events, 20);
+
+    const processPromise = bridge.processStream(stream);
+
+    // Stop after a short delay (should stop before all events are processed)
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    bridge.stop();
+
+    await processPromise;
+
+    // At most first 1-2 events processed (timing dependent, but less than all 4)
+    expect(mockStreams.publish.mock.calls.length).toBeLessThan(4);
+  });
+
+  it('should not process stream when already stopped', async () => {
+    const events: SSEEvent[] = [{ type: 'agent:started', data: { message: 'started' } }];
+
+    const bridge = createBridge();
+    bridge.stop();
+
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  it('should handle publish errors gracefully (not throw)', async () => {
+    mockStreams.publish.mockRejectedValueOnce(new Error('DurableStreams down'));
+
+    const events: SSEEvent[] = [
+      { type: 'agent:started', data: { message: 'started' } },
+      { type: 'agent:turn', data: { turnCount: 1 } },
+    ];
+
+    const bridge = createBridge();
+    // Should not throw even though publish fails for first event
+    await expect(bridge.processStream(asyncIterableFromArray(events))).resolves.toBeUndefined();
+
+    // Both events attempted
+    expect(mockStreams.publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle empty event stream', async () => {
+    async function* emptyStream(): AsyncIterable<SSEEvent> {
+      // yield nothing
+    }
+
+    const bridge = createBridge();
+    await bridge.processStream(emptyStream());
+
+    expect(mockStreams.publish).not.toHaveBeenCalled();
+  });
+
+  it('should process agent:file_changed events', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:file_changed', data: { path: 'src/index.ts', action: 'modified' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:file_changed',
+      expect.objectContaining({
+        path: 'src/index.ts',
+        action: 'modified',
+        taskId,
+      })
+    );
+  });
+
+  it('should process agent:tool:start and agent:tool:result events', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:tool:start', data: { tool: 'Bash', input: 'ls' } },
+      { type: 'agent:tool:result', data: { tool: 'Bash', output: 'file.ts' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledTimes(2);
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:tool:start',
+      expect.objectContaining({ tool: 'Bash', input: 'ls' })
+    );
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:tool:result',
+      expect.objectContaining({ tool: 'Bash', output: 'file.ts' })
+    );
+  });
+
+  it('should process agent:message events', async () => {
+    const events: SSEEvent[] = [
+      { type: 'agent:message', data: { content: 'Analyzing the codebase...' } },
+    ];
+
+    const bridge = createBridge();
+    await bridge.processStream(asyncIterableFromArray(events));
+
+    expect(mockStreams.publish).toHaveBeenCalledWith(
+      sessionId,
+      'container-agent:message',
+      expect.objectContaining({ content: 'Analyzing the codebase...' })
+    );
+  });
+});

--- a/src/lib/agents/agentcore-bridge.ts
+++ b/src/lib/agents/agentcore-bridge.ts
@@ -1,0 +1,324 @@
+/**
+ * AgentCore Bridge - Processes SSE events from AWS AgentCore invoke and bridges them to DurableStreams.
+ *
+ * Unlike ContainerBridge which parses raw JSON lines from Docker stdout,
+ * this bridge receives pre-parsed SSEEvent objects from the AgentCoreSandboxInstance
+ * and publishes them to the same DurableStreams channels.
+ */
+
+import type {
+  DurableStreamsService,
+  StreamEventMap,
+  TypedEventType,
+} from '../../services/durable-streams.service.js';
+import type { SSEEvent } from '../sandbox/providers/agentcore-sandbox-instance.js';
+import { errorMessage } from '../utils/error-message';
+import { type AgentRunnerEventType, EVENT_TYPE_MAP } from './event-type-map.js';
+
+// Re-export for consumers that previously imported from this module
+export type { SSEEvent } from '../sandbox/providers/agentcore-sandbox-instance.js';
+
+// Debug logging helper
+function debugLog(_context: string, _message: string, _data?: Record<string, unknown>): void {
+  // Debug logging intentionally suppressed; enable via DEBUG_AGENTCORE_BRIDGE env var
+}
+
+function warnLog(_context: string, _message: string, _data?: Record<string, unknown>): void {
+  // Warn logging intentionally suppressed
+}
+
+/**
+ * Plan ready data from ExitPlanMode.
+ */
+export interface AgentCorePlanReadyData {
+  plan: string;
+  turnCount: number;
+  sdkSessionId: string;
+  allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
+}
+
+/**
+ * Options for creating an AgentCore bridge.
+ */
+export interface AgentCoreBridgeOptions {
+  taskId: string;
+  sessionId: string;
+  codespaceId: string;
+  streams: DurableStreamsService;
+  onComplete?: (status: 'completed' | 'turn_limit' | 'cancelled', turnCount: number) => void;
+  onError?: (error: string, turnCount: number) => void;
+  onPlanReady?: (data: AgentCorePlanReadyData) => void;
+}
+
+/**
+ * AgentCore bridge instance.
+ */
+export interface AgentCoreBridge {
+  /**
+   * Process an async iterable of SSE events from AgentCore.
+   */
+  processStream(events: AsyncIterable<SSEEvent>): Promise<void>;
+
+  /**
+   * Stop processing and clean up.
+   */
+  stop(): void;
+}
+
+/**
+ * Create an AgentCore bridge for processing SSE events from AWS AgentCore invoke.
+ */
+export function createAgentCoreBridge(options: AgentCoreBridgeOptions): AgentCoreBridge {
+  const { taskId, sessionId, codespaceId, streams, onComplete, onError, onPlanReady } = options;
+  let stopped = false;
+  let eventCount = 0;
+  let consecutivePublishFailures = 0;
+  const MAX_CONSECUTIVE_PUBLISH_FAILURES = 5;
+
+  debugLog('createAgentCoreBridge', 'Creating AgentCore bridge', {
+    taskId,
+    sessionId,
+    codespaceId,
+  });
+
+  /**
+   * Publish an event to DurableStreams.
+   * Tracks consecutive failures and throws after MAX_CONSECUTIVE_PUBLISH_FAILURES
+   * to prevent silent event loss.
+   */
+  async function publishEvent(
+    streamType: TypedEventType,
+    data: Record<string, unknown>
+  ): Promise<void> {
+    // Context keys placed after spread so they cannot be overwritten by event data
+    const eventData = {
+      ...data,
+      taskId,
+      sessionId,
+      codespaceId,
+    };
+
+    debugLog('publishEvent', 'Publishing event to DurableStreams', {
+      type: streamType,
+      sessionId,
+      dataKeys: Object.keys(eventData),
+    });
+
+    try {
+      await streams.publish(sessionId, streamType, eventData as StreamEventMap[typeof streamType]);
+      consecutivePublishFailures = 0;
+      debugLog('publishEvent', 'Event published successfully', { type: streamType });
+    } catch (error) {
+      consecutivePublishFailures++;
+      warnLog(
+        'publishEvent',
+        `Failed to publish event (${consecutivePublishFailures}/${MAX_CONSECUTIVE_PUBLISH_FAILURES})`,
+        {
+          type: streamType,
+          error: errorMessage(error),
+        }
+      );
+      if (consecutivePublishFailures >= MAX_CONSECUTIVE_PUBLISH_FAILURES) {
+        throw new Error(
+          `Stream publishing failed ${consecutivePublishFailures} consecutive times: ${errorMessage(error)}`
+        );
+      }
+    }
+  }
+
+  /**
+   * Handle completion event.
+   * Uses fallback values for malformed data to ensure the callback always fires
+   * for terminal events — silently dropping them would leave tasks stuck forever.
+   */
+  function handleComplete(data: Record<string, unknown>): void {
+    const rawStatus = data.status as string;
+    const turnCount = typeof data.turnCount === 'number' ? data.turnCount : 0;
+
+    const validStatuses = ['completed', 'turn_limit', 'cancelled'] as const;
+    const status = validStatuses.includes(rawStatus as (typeof validStatuses)[number])
+      ? (rawStatus as 'completed' | 'turn_limit' | 'cancelled')
+      : 'completed';
+
+    if (rawStatus !== status || typeof data.turnCount !== 'number') {
+      warnLog('handleComplete', 'Unexpected completion data, using fallback values', {
+        taskId,
+        originalStatus: rawStatus,
+        resolvedStatus: status,
+        originalTurnCount: data.turnCount,
+        resolvedTurnCount: turnCount,
+      });
+    }
+
+    debugLog('handleComplete', 'Agent completed', {
+      taskId,
+      status,
+      turnCount,
+      totalEvents: eventCount,
+    });
+
+    if (onComplete) {
+      onComplete(status, turnCount);
+    }
+  }
+
+  /**
+   * Handle error event.
+   * Uses fallback values for malformed data to ensure the callback always fires.
+   */
+  function handleError(data: Record<string, unknown>): void {
+    const error =
+      typeof data.error === 'string' ? data.error : String(data.error ?? 'Unknown error');
+    const turnCount = typeof data.turnCount === 'number' ? data.turnCount : 0;
+
+    if (typeof data.error !== 'string' || typeof data.turnCount !== 'number') {
+      warnLog('handleError', 'Unexpected error event data, using fallback values', {
+        taskId,
+        data,
+      });
+    }
+
+    debugLog('handleError', 'Agent error received', {
+      taskId,
+      error,
+      turnCount,
+      totalEvents: eventCount,
+    });
+
+    if (onError) {
+      onError(error, turnCount);
+    }
+  }
+
+  /**
+   * Handle cancelled event.
+   * Uses fallback values for malformed data to ensure the callback always fires.
+   */
+  function handleCancelled(data: Record<string, unknown>): void {
+    const turnCount = typeof data.turnCount === 'number' ? data.turnCount : 0;
+
+    if (typeof data.turnCount !== 'number') {
+      warnLog('handleCancelled', 'Unexpected cancelled event data, using fallback values', {
+        taskId,
+        data,
+      });
+    }
+
+    debugLog('handleCancelled', 'Agent cancelled', {
+      taskId,
+      turnCount,
+      totalEvents: eventCount,
+    });
+
+    if (onComplete) {
+      onComplete('cancelled', turnCount);
+    }
+  }
+
+  /**
+   * Handle plan_ready event.
+   * Uses fallback values for malformed data to ensure the callback always fires —
+   * silently dropping a plan_ready event would leave the task stuck in planning forever.
+   */
+  function handlePlanReady(data: Record<string, unknown>): void {
+    const plan = typeof data.plan === 'string' ? data.plan : JSON.stringify(data);
+    const turnCount = typeof data.turnCount === 'number' ? data.turnCount : 0;
+    const sdkSessionId = typeof data.sdkSessionId === 'string' ? data.sdkSessionId : '';
+    const allowedPrompts = Array.isArray(data.allowedPrompts)
+      ? (data.allowedPrompts as Array<{ tool: 'Bash'; prompt: string }>)
+      : undefined;
+
+    if (typeof data.plan !== 'string' || typeof data.turnCount !== 'number') {
+      warnLog('handlePlanReady', 'Unexpected plan_ready event data, using fallback values', {
+        taskId,
+        data,
+      });
+    }
+
+    debugLog('handlePlanReady', 'Plan ready for approval', {
+      taskId,
+      turnCount,
+      sdkSessionId,
+      planLength: plan.length,
+    });
+
+    if (onPlanReady) {
+      onPlanReady({ plan, turnCount, sdkSessionId, allowedPrompts });
+    }
+  }
+
+  return {
+    async processStream(events: AsyncIterable<SSEEvent>): Promise<void> {
+      if (stopped) {
+        debugLog('processStream', 'Bridge already stopped, skipping', { taskId });
+        return;
+      }
+
+      debugLog('processStream', 'Starting to process AgentCore SSE stream', { taskId, sessionId });
+
+      try {
+        for await (const event of events) {
+          if (stopped) {
+            debugLog('processStream', 'Bridge stopped during processing', { taskId, eventCount });
+            break;
+          }
+
+          // Validate event structure
+          if (!event.type || !event.data || typeof event.data !== 'object') {
+            debugLog('processStream', 'Skipping invalid event', {
+              hasType: !!event.type,
+              hasData: !!event.data,
+            });
+            continue;
+          }
+
+          // Map event type
+          const streamType = EVENT_TYPE_MAP[event.type as AgentRunnerEventType];
+          if (!streamType) {
+            debugLog('processStream', 'Unknown event type, skipping', { type: event.type });
+            continue;
+          }
+
+          eventCount++;
+
+          // Publish event to DurableStreams
+          await publishEvent(streamType, event.data);
+
+          // Handle terminal and special events
+          if (event.type === 'agent:complete') {
+            handleComplete(event.data);
+          } else if (event.type === 'agent:error') {
+            handleError(event.data);
+          } else if (event.type === 'agent:cancelled') {
+            handleCancelled(event.data);
+          } else if (event.type === 'agent:plan_ready') {
+            handlePlanReady(event.data);
+          }
+        }
+      } catch (error) {
+        // Stream error -- publish error event and notify
+        const errMsg = errorMessage(error);
+        warnLog('processStream', 'Stream error', { taskId, error: errMsg });
+
+        await publishEvent('container-agent:error', {
+          error: errMsg,
+          turnCount: 0,
+        });
+
+        if (onError) {
+          onError(errMsg, 0);
+        }
+      }
+
+      debugLog('processStream', 'Stream processing complete', {
+        taskId,
+        totalEvents: eventCount,
+      });
+    },
+
+    stop(): void {
+      debugLog('stop', 'Stopping AgentCore bridge', { taskId, eventCount });
+      stopped = true;
+    },
+  };
+}

--- a/src/lib/agents/event-type-map.ts
+++ b/src/lib/agents/event-type-map.ts
@@ -1,12 +1,13 @@
 /**
  * Shared event type mapping from agent-runner events to durable streams events.
  *
- * Used by ContainerBridge (JSON lines from Docker stdout).
+ * Used by both ContainerBridge (JSON lines from Docker stdout) and
+ * AgentCoreBridge (SSE events from AWS AgentCore).
  */
 import type { TypedEventType } from '../../services/durable-streams.service.js';
 
 /**
- * Event types emitted by the agent-runner.
+ * Event types emitted by the agent-runner (container or AgentCore).
  */
 export type AgentRunnerEventType =
   | 'agent:started'
@@ -26,7 +27,7 @@ export type AgentRunnerEventType =
 
 /**
  * Maps agent-runner event types to durable streams event types.
- * Used by ContainerBridge (stdout JSON lines).
+ * Shared between ContainerBridge (stdout JSON lines) and AgentCoreBridge (SSE events).
  */
 export const EVENT_TYPE_MAP: Record<AgentRunnerEventType, TypedEventType> = {
   'agent:started': 'container-agent:started',

--- a/src/lib/background/job.ts
+++ b/src/lib/background/job.ts
@@ -8,9 +8,9 @@
  *
  * Migration status: `EventCleanupService`, `SchedulerService`, and
  * `EventOutboxRelayService` are the first to adopt the interface. Other
- * timer owners (SSE pings, auth session-cleanup, cli-monitor flush)
- * are documented in `specs/arch_review_april/12-cross-cutting.md` as
- * a follow-up.
+ * timer owners (SSE pings, auth session-cleanup, agentcore-bridge
+ * timeouts, cli-monitor flush) are documented in
+ * `specs/arch_review_april/12-cross-cutting.md` as a follow-up.
  *
  * Design goals:
  *   - A failing `stop()` must not prevent other jobs from stopping. The

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -97,16 +97,17 @@ export const MIGRATIONS: Migration[] = [
     ],
   },
 
-  // 14. AgentCore sandbox columns — REMOVED (arch29-W2-D, F04-04 / F04-05).
-  //     The AgentCore feature has been deleted from the codebase. The columns
-  //     were added by Drizzle migration 0010 and dropped by 0011. Existing
-  //     databases that ran the old version-14 step retain the dropped columns;
-  //     fresh installs never receive them. Kept as a tombstone (no-op) to
-  //     preserve sequential version numbering.
+  // 14. AgentCore sandbox columns
   {
     version: 14,
-    name: 'sandbox-agentcore-columns-removed',
-    statements: [],
+    name: 'sandbox-agentcore-columns',
+    statements: [
+      `ALTER TABLE sandbox_configs ADD COLUMN aws_access_key_id TEXT`,
+      `ALTER TABLE sandbox_configs ADD COLUMN aws_secret_access_key TEXT`,
+      `ALTER TABLE sandbox_configs ADD COLUMN aws_region TEXT`,
+      `ALTER TABLE sandbox_configs ADD COLUMN agentcore_runtime_arn TEXT`,
+      `ALTER TABLE sandbox_configs ADD COLUMN ecr_repository_uri TEXT`,
+    ],
   },
 
   // 15. Agents parent_agent_id column

--- a/src/lib/errors/agentcore-errors.ts
+++ b/src/lib/errors/agentcore-errors.ts
@@ -1,0 +1,72 @@
+import { AppErrorClass, createError } from './base.js';
+
+/**
+ * Reserved AgentCore error IDs for monitoring/Sentry grouping.
+ * Format: AGENTCORE-NNN where NNN is a zero-padded category-specific number.
+ * Ranges: 001-099 connection/auth, 600-699 streaming/session, 700-799 API.
+ */
+export const AGENTCORE_ERROR_IDS = {
+  AWS_CREDENTIALS_INVALID: 'AGENTCORE-001',
+  AWS_CREDENTIALS_EXPIRED: 'AGENTCORE-002',
+  AWS_REGION_INVALID: 'AGENTCORE-003',
+  AWS_STS_ERROR: 'AGENTCORE-004',
+
+  STREAMING_ERROR: 'AGENTCORE-600',
+  SESSION_CREATE_FAILED: 'AGENTCORE-601',
+  SESSION_INVOKE_FAILED: 'AGENTCORE-602',
+
+  API_ERROR: 'AGENTCORE-700',
+  INTERNAL_ERROR: 'AGENTCORE-701',
+} as const;
+
+export function isAgentCoreError(error: unknown): boolean {
+  return error instanceof AppErrorClass && error.code.startsWith('AGENTCORE-');
+}
+
+function agentcoreError(
+  key: keyof typeof AGENTCORE_ERROR_IDS,
+  httpStatus: number,
+  message: string,
+  details?: Record<string, unknown>
+) {
+  return createError(AGENTCORE_ERROR_IDS[key], message, httpStatus, {
+    errorName: `AGENTCORE_${key}`,
+    ...details,
+  });
+}
+
+export const AgentCoreErrors = {
+  AWS_CREDENTIALS_INVALID: (reason: string) =>
+    agentcoreError('AWS_CREDENTIALS_INVALID', 401, `AWS credentials invalid: ${reason}`),
+
+  AWS_CREDENTIALS_EXPIRED: () =>
+    agentcoreError('AWS_CREDENTIALS_EXPIRED', 401, 'AWS credentials have expired'),
+
+  AWS_REGION_INVALID: (region: string) =>
+    agentcoreError('AWS_REGION_INVALID', 400, `Invalid AWS region: ${region}`, { region }),
+
+  AWS_STS_ERROR: (reason: string) =>
+    agentcoreError('AWS_STS_ERROR', 503, `AWS STS error: ${reason}`),
+
+  STREAMING_ERROR: (reason: string) =>
+    agentcoreError('STREAMING_ERROR', 502, `AgentCore streaming error: ${reason}`),
+
+  SESSION_CREATE_FAILED: (reason: string) =>
+    agentcoreError('SESSION_CREATE_FAILED', 502, `AgentCore session creation failed: ${reason}`),
+
+  SESSION_INVOKE_FAILED: (reason: string) =>
+    agentcoreError('SESSION_INVOKE_FAILED', 502, `AgentCore invocation failed: ${reason}`),
+
+  API_ERROR: (statusCode: number, reason: string) =>
+    agentcoreError('API_ERROR', statusCode, `AgentCore API error (${statusCode}): ${reason}`),
+
+  INTERNAL_ERROR: (reason: string) => agentcoreError('INTERNAL_ERROR', 500, reason),
+};
+
+// Type-level check: ensure AGENTCORE_ERROR_IDS and AgentCoreErrors have matching keys
+type _AssertKeysMatch = keyof typeof AGENTCORE_ERROR_IDS extends keyof typeof AgentCoreErrors
+  ? keyof typeof AgentCoreErrors extends keyof typeof AGENTCORE_ERROR_IDS
+    ? true
+    : never
+  : never;
+void (true as _AssertKeysMatch);

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,4 +1,5 @@
 export * from './agent-errors.js';
+export * from './agentcore-errors.js';
 export * from './base.js';
 export * from './codespace-errors.js';
 export * from './concurrency-errors.js';

--- a/src/lib/sandbox/providers/__tests__/agentcore-sandbox-instance.test.ts
+++ b/src/lib/sandbox/providers/__tests__/agentcore-sandbox-instance.test.ts
@@ -1,0 +1,644 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type AgentCoreInstanceOptions,
+  AgentCoreSandboxInstance,
+  type SSEEvent,
+} from '../agentcore-sandbox-instance.js';
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../logging/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createSSEChunk(
+  events: Array<{ type: string; data: Record<string, unknown> }>
+): Uint8Array {
+  const lines = events
+    .map((e) => `data: ${JSON.stringify({ type: e.type, data: e.data })}`)
+    .join('\n\n');
+  return new TextEncoder().encode(`${lines}\n\n`);
+}
+
+function createSSEChunkWithEventField(
+  eventType: string,
+  data: Record<string, unknown>
+): Uint8Array {
+  return new TextEncoder().encode(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function createReadableStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let index = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index]!);
+        index++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function createInstance(
+  overrides: Partial<AgentCoreInstanceOptions> = {}
+): AgentCoreSandboxInstance {
+  return new AgentCoreSandboxInstance({
+    runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789:runtime/test-runtime-id',
+    region: 'us-east-1',
+    accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+    secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    codespaceId: 'proj-001',
+    sandboxId: 'sandbox-001',
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentCoreSandboxInstance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Suppress console.log noise from info/debug logs
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Constructor and properties
+  // -------------------------------------------------------------------------
+
+  describe('constructor', () => {
+    it('should set properties from options', () => {
+      const instance = createInstance();
+
+      expect(instance.runtimeArn).toBe(
+        'arn:aws:bedrock-agentcore:us-east-1:123456789:runtime/test-runtime-id'
+      );
+      expect(instance.codespaceId).toBe('proj-001');
+      expect(instance.sandboxId).toBe('sandbox-001');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Status tracking
+  // -------------------------------------------------------------------------
+
+  describe('status', () => {
+    it('should have initial status of running', () => {
+      const instance = createInstance();
+      expect(instance.status).toBe('running');
+    });
+
+    it('should change status to stopped after stop()', async () => {
+      const instance = createInstance();
+      expect(instance.status).toBe('running');
+
+      await instance.stop();
+      expect(instance.status).toBe('stopped');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refreshStatus
+  // -------------------------------------------------------------------------
+
+  describe('refreshStatus', () => {
+    it('should return current status', async () => {
+      const instance = createInstance();
+      const status = await instance.refreshStatus();
+      expect(status).toBe('running');
+    });
+
+    it('should return stopped after stop', async () => {
+      const instance = createInstance();
+      await instance.stop();
+      const status = await instance.refreshStatus();
+      expect(status).toBe('stopped');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SSE Parsing (via invoke)
+  // -------------------------------------------------------------------------
+
+  describe('parseSSEStream (tested via invoke)', () => {
+    // We test SSE parsing indirectly through invoke. We need to mock fetch.
+
+    it('should parse SSE stream into events', async () => {
+      const sseChunk = createSSEChunk([
+        { type: 'agent:started', data: { message: 'hello' } },
+        { type: 'agent:turn', data: { turnCount: 1 } },
+      ]);
+
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        body: createReadableStream([sseChunk]),
+        text: vi.fn(),
+      };
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual({
+        type: 'agent:started',
+        data: { message: 'hello' },
+      });
+      expect(events[1]).toEqual({
+        type: 'agent:turn',
+        data: { turnCount: 1 },
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should handle multiple events in a single chunk', async () => {
+      const chunk = createSSEChunk([
+        { type: 'agent:token', data: { delta: 'a' } },
+        { type: 'agent:token', data: { delta: 'b' } },
+        { type: 'agent:token', data: { delta: 'c' } },
+      ]);
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: createReadableStream([chunk]),
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(3);
+      expect(events.map((e) => (e.data as { delta: string }).delta)).toEqual(['a', 'b', 'c']);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should handle events split across chunks', async () => {
+      // Split a single event across two chunks
+      const fullEvent = `data: ${JSON.stringify({ type: 'agent:started', data: { message: 'split' } })}\n\n`;
+      const midpoint = Math.floor(fullEvent.length / 2);
+      const chunk1 = new TextEncoder().encode(fullEvent.slice(0, midpoint));
+      const chunk2 = new TextEncoder().encode(fullEvent.slice(midpoint));
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: createReadableStream([chunk1, chunk2]),
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'agent:started',
+        data: { message: 'split' },
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should skip malformed SSE data', async () => {
+      // Mix valid and invalid data lines
+      const sseText =
+        'data: not valid json\n\n' +
+        `data: ${JSON.stringify({ type: 'agent:started', data: { ok: true } })}\n\n` +
+        'data: {broken\n\n';
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: createReadableStream([new TextEncoder().encode(sseText)]),
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      // Only the valid event should be parsed
+      expect(events).toHaveLength(1);
+      expect(events[0]!.type).toBe('agent:started');
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should handle SSE comment lines (starting with colon)', async () => {
+      const sseText =
+        ': this is a comment\n' +
+        `data: ${JSON.stringify({ type: 'agent:started', data: { ok: true } })}\n\n`;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: createReadableStream([new TextEncoder().encode(sseText)]),
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.type).toBe('agent:started');
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should support unwrapped format with event field', async () => {
+      const chunk = createSSEChunkWithEventField('agent:turn', { turnCount: 1, content: 'hi' });
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: createReadableStream([chunk]),
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'agent:turn',
+        data: { turnCount: 1, content: 'hi' },
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should skip blocks with no data lines', async () => {
+      const sseText = 'event: agent:turn\n\n'; // event field but no data
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: createReadableStream([new TextEncoder().encode(sseText)]),
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+      const events: SSEEvent[] = [];
+
+      for await (const event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(0);
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Invoke payload and URL construction
+  // -------------------------------------------------------------------------
+
+  describe('invoke', () => {
+    it('should send correct payload to AgentCore', async () => {
+      const payload = { prompt: 'Implement feature X', maxTurns: 50 };
+      let capturedBody: string | undefined;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((_url: string, options: RequestInit) => {
+          capturedBody = options.body as string;
+          return Promise.resolve({
+            ok: true,
+            body: createReadableStream([]),
+            text: vi.fn(),
+          });
+        })
+      );
+
+      const instance = createInstance();
+
+      // Consume the generator
+      for await (const _event of instance.invoke(payload, 'session-1')) {
+        // no-op
+      }
+
+      expect(capturedBody).toBeDefined();
+      expect(JSON.parse(capturedBody!)).toEqual(payload);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should construct correct URL with runtime ID and session ID', async () => {
+      let capturedUrl: string | undefined;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          capturedUrl = url;
+          return Promise.resolve({
+            ok: true,
+            body: createReadableStream([]),
+            text: vi.fn(),
+          });
+        })
+      );
+
+      const instance = createInstance();
+
+      for await (const _event of instance.invoke({ prompt: 'test' }, 'my-session-123')) {
+        // no-op
+      }
+
+      expect(capturedUrl).toBeDefined();
+      expect(capturedUrl).toContain('bedrock-agentcore.us-east-1.amazonaws.com');
+      expect(capturedUrl).toContain('/agentruntimes/test-runtime-id/');
+      expect(capturedUrl).toContain('/sessions/my-session-123/invoke');
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should include proper headers (Content-Type, Accept, Auth)', async () => {
+      let capturedHeaders: Record<string, string> | undefined;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((_url: string, options: RequestInit) => {
+          capturedHeaders = options.headers as Record<string, string>;
+          return Promise.resolve({
+            ok: true,
+            body: createReadableStream([]),
+            text: vi.fn(),
+          });
+        })
+      );
+
+      const instance = createInstance();
+
+      for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        // no-op
+      }
+
+      expect(capturedHeaders).toBeDefined();
+      expect(capturedHeaders!['Content-Type']).toBe('application/json');
+      expect(capturedHeaders!.Accept).toBe('text/event-stream');
+      // SigV4 headers
+      expect(capturedHeaders!.Authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=/);
+      expect(capturedHeaders!['x-amz-date']).toBeDefined();
+      expect(capturedHeaders!['x-amz-content-sha256']).toBeDefined();
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should use POST method', async () => {
+      let capturedMethod: string | undefined;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((_url: string, options: RequestInit) => {
+          capturedMethod = options.method;
+          return Promise.resolve({
+            ok: true,
+            body: createReadableStream([]),
+            text: vi.fn(),
+          });
+        })
+      );
+
+      const instance = createInstance();
+
+      for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        // no-op
+      }
+
+      expect(capturedMethod).toBe('POST');
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('should throw SESSION_INVOKE_FAILED on HTTP error', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 403,
+          text: vi.fn().mockResolvedValue('Access denied'),
+        })
+      );
+
+      const instance = createInstance();
+
+      await expect(async () => {
+        for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+          // no-op
+        }
+      }).rejects.toMatchObject({
+        code: 'AGENTCORE-602',
+        message: expect.stringContaining('HTTP 403'),
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should throw SESSION_INVOKE_FAILED when response body is empty', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          body: null,
+          text: vi.fn(),
+        })
+      );
+
+      const instance = createInstance();
+
+      await expect(async () => {
+        for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+          // no-op
+        }
+      }).rejects.toMatchObject({
+        code: 'AGENTCORE-602',
+        message: expect.stringContaining('empty'),
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should throw SESSION_INVOKE_FAILED on fetch error', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('DNS resolution failed')));
+
+      const instance = createInstance();
+
+      await expect(async () => {
+        for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+          // no-op
+        }
+      }).rejects.toMatchObject({
+        code: 'AGENTCORE-602',
+        message: expect.stringContaining('DNS resolution failed'),
+      });
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should throw SESSION_INVOKE_FAILED when error text cannot be read', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          text: vi.fn().mockRejectedValue(new Error('body stream already read')),
+        })
+      );
+
+      const instance = createInstance();
+
+      await expect(async () => {
+        for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+          // no-op
+        }
+      }).rejects.toMatchObject({
+        code: 'AGENTCORE-602',
+        message: expect.stringContaining('HTTP 500'),
+      });
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // extractRuntimeId
+  // -------------------------------------------------------------------------
+
+  describe('runtime ID extraction', () => {
+    it('should extract runtime ID from full ARN in URL', async () => {
+      let capturedUrl: string | undefined;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          capturedUrl = url;
+          return Promise.resolve({
+            ok: true,
+            body: createReadableStream([]),
+            text: vi.fn(),
+          });
+        })
+      );
+
+      const instance = createInstance({
+        runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789:runtime/my-runtime-abc',
+      });
+
+      for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        // no-op
+      }
+
+      expect(capturedUrl).toContain('/agentruntimes/my-runtime-abc/');
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should use raw string when ARN has no slash', async () => {
+      let capturedUrl: string | undefined;
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          capturedUrl = url;
+          return Promise.resolve({
+            ok: true,
+            body: createReadableStream([]),
+            text: vi.fn(),
+          });
+        })
+      );
+
+      const instance = createInstance({
+        runtimeArn: 'plain-runtime-id',
+      });
+
+      for await (const _event of instance.invoke({ prompt: 'test' }, 'session-1')) {
+        // no-op
+      }
+
+      expect(capturedUrl).toContain('/agentruntimes/plain-runtime-id/');
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // stop
+  // -------------------------------------------------------------------------
+
+  describe('stop', () => {
+    it('should set status to stopped', async () => {
+      const instance = createInstance();
+      expect(instance.status).toBe('running');
+
+      await instance.stop();
+      expect(instance.status).toBe('stopped');
+    });
+  });
+});

--- a/src/lib/sandbox/providers/__tests__/agentcore-sandbox-provider.test.ts
+++ b/src/lib/sandbox/providers/__tests__/agentcore-sandbox-provider.test.ts
@@ -1,0 +1,474 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../logging/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock @aws-sdk/client-sts (used by healthCheck via dynamic import)
+// ---------------------------------------------------------------------------
+
+const { mockStsSend } = vi.hoisted(() => ({
+  mockStsSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-sts', () => {
+  class MockSTSClient {
+    send = mockStsSend;
+  }
+  return {
+    STSClient: MockSTSClient,
+    GetCallerIdentityCommand: class MockGetCallerIdentityCommand {},
+  };
+});
+
+import { AgentCoreSandboxInstance } from '../agentcore-sandbox-instance.js';
+// Import after mocks
+import type { AgentCoreProviderConfig } from '../agentcore-sandbox-provider.js';
+import {
+  AgentCoreSandboxProvider,
+  createAgentCoreProvider,
+} from '../agentcore-sandbox-provider.js';
+
+// ---------------------------------------------------------------------------
+// Test config
+// ---------------------------------------------------------------------------
+
+const testConfig: AgentCoreProviderConfig = {
+  region: 'us-east-1',
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789:runtime/test-runtime',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentCoreSandboxProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Suppress console.log noise from info/debug logs
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createProvider(
+    overrides: Partial<AgentCoreProviderConfig> = {}
+  ): AgentCoreSandboxProvider {
+    return new AgentCoreSandboxProvider({ ...testConfig, ...overrides });
+  }
+
+  // -------------------------------------------------------------------------
+  // Constructor and factory
+  // -------------------------------------------------------------------------
+
+  describe('constructor', () => {
+    it('should have provider name "agentcore"', () => {
+      const provider = createProvider();
+      expect(provider.name).toBe('agentcore');
+    });
+
+    it('should be creatable via factory function', () => {
+      const provider = createAgentCoreProvider(testConfig);
+      expect(provider).toBeInstanceOf(AgentCoreSandboxProvider);
+      expect(provider.name).toBe('agentcore');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Instance creation
+  // -------------------------------------------------------------------------
+
+  describe('create', () => {
+    it('should create instances for projects', () => {
+      const provider = createProvider();
+      const instance = provider.create('proj-001', 'sandbox-001');
+
+      expect(instance).toBeInstanceOf(AgentCoreSandboxInstance);
+      expect(instance.codespaceId).toBe('proj-001');
+      expect(instance.sandboxId).toBe('sandbox-001');
+      expect(instance.runtimeArn).toBe(testConfig.runtimeArn);
+    });
+
+    it('should return existing instance if one already exists for project', () => {
+      const provider = createProvider();
+      const instance1 = provider.create('proj-001', 'sandbox-001');
+      const instance2 = provider.create('proj-001', 'sandbox-002');
+
+      // Same instance returned (not a new one)
+      expect(instance2).toBe(instance1);
+      expect(instance2.sandboxId).toBe('sandbox-001'); // original sandboxId preserved
+    });
+
+    it('should create new instance if existing one is stopped', async () => {
+      const provider = createProvider();
+      const instance1 = provider.create('proj-001', 'sandbox-001');
+      await instance1.stop();
+
+      const instance2 = provider.create('proj-001', 'sandbox-002');
+
+      expect(instance2).not.toBe(instance1);
+      expect(instance2.sandboxId).toBe('sandbox-002');
+    });
+
+    it('should create separate instances for different projects', () => {
+      const provider = createProvider();
+      const instance1 = provider.create('proj-001', 'sandbox-001');
+      const instance2 = provider.create('proj-002', 'sandbox-002');
+
+      expect(instance1).not.toBe(instance2);
+      expect(instance1.codespaceId).toBe('proj-001');
+      expect(instance2.codespaceId).toBe('proj-002');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Instance retrieval
+  // -------------------------------------------------------------------------
+
+  describe('get', () => {
+    it('should retrieve existing instances', () => {
+      const provider = createProvider();
+      const created = provider.create('proj-001', 'sandbox-001');
+      const retrieved = provider.get('proj-001');
+
+      expect(retrieved).toBe(created);
+    });
+
+    it('should return null for nonexistent project', () => {
+      const provider = createProvider();
+      const result = provider.get('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for stopped instances', async () => {
+      const provider = createProvider();
+      const instance = provider.create('proj-001', 'sandbox-001');
+      await instance.stop();
+
+      const result = provider.get('proj-001');
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Session management
+  // -------------------------------------------------------------------------
+
+  describe('getOrCreateSession', () => {
+    it('should create unique session IDs per task', () => {
+      const provider = createProvider();
+      const session1 = provider.getOrCreateSession('proj-001', 'task-001');
+      const session2 = provider.getOrCreateSession('proj-001', 'task-002');
+
+      expect(session1).not.toBe(session2);
+      expect(session1).toContain('proj-001');
+      expect(session1).toContain('task-001');
+      expect(session2).toContain('task-002');
+    });
+
+    it('should reuse existing session for same task', () => {
+      const provider = createProvider();
+      const session1 = provider.getOrCreateSession('proj-001', 'task-001');
+      const session2 = provider.getOrCreateSession('proj-001', 'task-001');
+
+      expect(session2).toBe(session1);
+    });
+
+    it('should format session ID as codespaceId:taskId:timestamp', () => {
+      const provider = createProvider();
+      const session = provider.getOrCreateSession('proj-001', 'task-001');
+
+      // Format: {codespaceId}:{taskId}:{timestamp}
+      const parts = session.split(':');
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toBe('proj-001');
+      expect(parts[1]).toBe('task-001');
+      expect(Number(parts[2])).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getSession', () => {
+    it('should return session for existing task', () => {
+      const provider = createProvider();
+      const created = provider.getOrCreateSession('proj-001', 'task-001');
+      const retrieved = provider.getSession('task-001');
+
+      expect(retrieved).toBe(created);
+    });
+
+    it('should return null for nonexistent task', () => {
+      const provider = createProvider();
+      expect(provider.getSession('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('removeSession', () => {
+    it('should remove existing session and return true', () => {
+      const provider = createProvider();
+      provider.getOrCreateSession('proj-001', 'task-001');
+
+      const result = provider.removeSession('task-001');
+      expect(result).toBe(true);
+      expect(provider.getSession('task-001')).toBeNull();
+    });
+
+    it('should return false for nonexistent session', () => {
+      const provider = createProvider();
+      const result = provider.removeSession('nonexistent');
+      expect(result).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Health check
+  // -------------------------------------------------------------------------
+
+  describe('healthCheck', () => {
+    it('should return healthy when STS succeeds', async () => {
+      mockStsSend.mockResolvedValue({
+        Account: '123456789012',
+        Arn: 'arn:aws:iam::123456789012:user/testuser',
+      });
+
+      const provider = createProvider();
+      const health = await provider.healthCheck();
+
+      expect(health.healthy).toBe(true);
+      expect(health.details?.provider).toBe('agentcore');
+      expect(health.details?.region).toBe('us-east-1');
+      expect(health.details?.runtimeArn).toBe(testConfig.runtimeArn);
+      expect(health.details?.awsAccount).toBe('123456789012');
+    });
+
+    it('should return unhealthy on STS failure', async () => {
+      mockStsSend.mockRejectedValue(new Error('STS service unavailable'));
+
+      const provider = createProvider();
+      const health = await provider.healthCheck();
+
+      expect(health.healthy).toBe(false);
+      expect(health.message).toContain('STS');
+    });
+
+    it('should detect expired credentials', async () => {
+      const expiredError = new Error('Token has expired');
+      Object.defineProperty(expiredError, 'name', {
+        value: 'ExpiredTokenException',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+
+      mockStsSend.mockRejectedValue(expiredError);
+
+      const provider = createProvider();
+      const health = await provider.healthCheck();
+
+      expect(health.healthy).toBe(false);
+      expect(health.message).toContain('expired');
+      expect(health.details?.errorType).toBe('expired_credentials');
+    });
+
+    it('should detect invalid credentials', async () => {
+      const invalidError = new Error('The security token is not valid');
+      Object.defineProperty(invalidError, 'name', {
+        value: 'InvalidClientTokenId',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+
+      mockStsSend.mockRejectedValue(invalidError);
+
+      const provider = createProvider();
+      const health = await provider.healthCheck();
+
+      expect(health.healthy).toBe(false);
+      expect(health.message).toContain('invalid');
+      expect(health.details?.errorType).toBe('invalid_credentials');
+    });
+
+    it('should include active instance and session counts in details', async () => {
+      mockStsSend.mockResolvedValue({ Account: '111', Arn: 'arn:test' });
+
+      const provider = createProvider();
+      provider.create('proj-001', 'sandbox-001');
+      provider.getOrCreateSession('proj-001', 'task-001');
+
+      const health = await provider.healthCheck();
+
+      expect(health.healthy).toBe(true);
+      expect(health.details?.activeInstances).toBe(1);
+      expect(health.details?.activeSessions).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  describe('cleanup', () => {
+    it('should clean up all instances', async () => {
+      const provider = createProvider();
+      provider.create('proj-001', 'sandbox-001');
+      provider.create('proj-002', 'sandbox-002');
+      provider.getOrCreateSession('proj-001', 'task-001');
+
+      const cleaned = await provider.cleanup();
+
+      expect(cleaned).toBe(2);
+      expect(provider.get('proj-001')).toBeNull();
+      expect(provider.get('proj-002')).toBeNull();
+      expect(provider.getSession('task-001')).toBeNull();
+    });
+
+    it('should return 0 when nothing to clean', async () => {
+      const provider = createProvider();
+      const cleaned = await provider.cleanup();
+      expect(cleaned).toBe(0);
+    });
+
+    it('should stop each instance during cleanup', async () => {
+      const provider = createProvider();
+      const instance = provider.create('proj-001', 'sandbox-001');
+
+      await provider.cleanup();
+
+      expect(instance.status).toBe('stopped');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // List instances
+  // -------------------------------------------------------------------------
+
+  describe('list', () => {
+    it('should return empty list when no instances', () => {
+      const provider = createProvider();
+      const list = provider.list();
+      expect(list).toEqual([]);
+    });
+
+    it('should list all managed instances', () => {
+      const provider = createProvider();
+      provider.create('proj-001', 'sandbox-001');
+      provider.create('proj-002', 'sandbox-002');
+
+      const list = provider.list();
+
+      expect(list).toHaveLength(2);
+      expect(list.map((i) => i.codespaceId).sort()).toEqual(['proj-001', 'proj-002']);
+    });
+
+    it('should include correct info for each instance', () => {
+      const provider = createProvider();
+      provider.create('proj-001', 'sandbox-001');
+
+      const list = provider.list();
+
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({
+        sandboxId: 'sandbox-001',
+        codespaceId: 'proj-001',
+        runtimeArn: testConfig.runtimeArn,
+        status: 'running',
+      });
+      expect(list[0]!.createdAt).toBeDefined();
+      expect(typeof list[0]!.activeSessions).toBe('number');
+    });
+
+    it('should count active sessions for each instance', () => {
+      const provider = createProvider();
+      provider.create('proj-001', 'sandbox-001');
+      provider.getOrCreateSession('proj-001', 'task-001');
+      provider.getOrCreateSession('proj-001', 'task-002');
+
+      const list = provider.list();
+
+      expect(list).toHaveLength(1);
+      expect(list[0]!.activeSessions).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // invokeForTask
+  // -------------------------------------------------------------------------
+
+  describe('invokeForTask', () => {
+    it('should create instance and session if they do not exist', async () => {
+      // Mock fetch for the invoke call
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          text: vi.fn(),
+        })
+      );
+
+      const provider = createProvider();
+
+      // Consume the generator
+      const events = [];
+      for await (const event of provider.invokeForTask('proj-001', 'task-001', 'sandbox-001', {
+        prompt: 'test',
+      })) {
+        events.push(event);
+      }
+
+      // Should have created instance and session
+      expect(provider.get('proj-001')).not.toBeNull();
+      expect(provider.getSession('task-001')).not.toBeNull();
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should reuse existing instance for same project', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: new ReadableStream({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          text: vi.fn(),
+        })
+      );
+
+      const provider = createProvider();
+      const existingInstance = provider.create('proj-001', 'sandbox-001');
+
+      for await (const _event of provider.invokeForTask('proj-001', 'task-001', 'sandbox-new', {
+        prompt: 'test',
+      })) {
+        // no-op
+      }
+
+      // Should have reused the existing instance
+      const retrieved = provider.get('proj-001');
+      expect(retrieved).toBe(existingInstance);
+
+      vi.unstubAllGlobals();
+    });
+  });
+});

--- a/src/lib/sandbox/providers/agentcore-sandbox-instance.ts
+++ b/src/lib/sandbox/providers/agentcore-sandbox-instance.ts
@@ -1,0 +1,402 @@
+/**
+ * AgentCore Sandbox Instance
+ *
+ * Represents a connection to an AWS Bedrock AgentCore runtime.
+ * Unlike Docker/K8s/Nomad sandbox instances, AgentCore is NOT a container
+ * you exec into. Instead, you invoke the runtime handler with a payload
+ * and receive Server-Sent Events (SSE) back.
+ *
+ * This class does NOT implement the Sandbox interface (sandbox-provider.ts)
+ * because AgentCore has no shell, exec, or tmux capabilities.
+ */
+
+import { AgentCoreErrors, isAgentCoreError } from '../../errors/agentcore-errors.js';
+import { createLogger } from '../../logging/logger.js';
+import { errorMessage } from '../../utils/error-message';
+import type { SandboxStatus } from '../types.js';
+
+const log = createLogger('AgentCoreSandboxInstance');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SSEEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+export interface AgentCoreInstanceOptions {
+  /** ARN of the AgentCore runtime to invoke */
+  runtimeArn: string;
+  /** AWS region (e.g. us-east-1) */
+  region: string;
+  /** AWS access key ID */
+  accessKeyId: string;
+  /** AWS secret access key */
+  secretAccessKey: string;
+  /** Codespace this instance belongs to */
+  codespaceId: string;
+  /** Unique sandbox identifier */
+  sandboxId: string;
+}
+
+// ---------------------------------------------------------------------------
+// AWS SigV4 Signing (minimal implementation for AgentCore invoke)
+// ---------------------------------------------------------------------------
+
+/**
+ * SC-038: Minimal hand-rolled AWS Signature Version 4 signer for AgentCore invoke requests.
+ *
+ * DEFERRED: Replace with `@aws-sdk/signature-v4` or `@aws-sdk/client-bedrock-agentcore`
+ * InvokeAgentRuntimeCommand once the package is added to dependencies. The SDK provides
+ * automatic signing, retries, and proper error parsing. This manual approach is a stopgap
+ * and should be replaced in a future iteration to reduce maintenance burden and improve
+ * compliance with AWS signing edge cases (e.g. double-encoded URIs, session tokens).
+ */
+async function hmacSha256(key: ArrayBuffer | Uint8Array, data: string): Promise<ArrayBuffer> {
+  const rawKey = key instanceof ArrayBuffer ? new Uint8Array(key) : key;
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    rawKey as BufferSource,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  return crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(data));
+}
+
+async function sha256Hex(data: string): Promise<string> {
+  const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(data));
+  return [...new Uint8Array(hash)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function getSignatureKey(
+  secretKey: string,
+  dateStamp: string,
+  region: string,
+  service: string
+): Promise<ArrayBuffer> {
+  let key = await hmacSha256(new TextEncoder().encode(`AWS4${secretKey}`), dateStamp);
+  key = await hmacSha256(key, region);
+  key = await hmacSha256(key, service);
+  key = await hmacSha256(key, 'aws4_request');
+  return key;
+}
+
+interface SignedHeaders {
+  Authorization: string;
+  'x-amz-date': string;
+  'x-amz-content-sha256': string;
+}
+
+async function signRequest(opts: {
+  method: string;
+  url: URL;
+  body: string;
+  region: string;
+  service: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}): Promise<SignedHeaders> {
+  if (!globalThis.crypto?.subtle) {
+    throw AgentCoreErrors.INTERNAL_ERROR(
+      'Web Crypto API (crypto.subtle) is not available. AgentCore signing requires Node.js 18+ or a compatible runtime.'
+    );
+  }
+
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  const dateStamp = amzDate.slice(0, 8);
+
+  const payloadHash = await sha256Hex(opts.body);
+
+  const canonicalHeaders =
+    `host:${opts.url.host}\n` + `x-amz-content-sha256:${payloadHash}\n` + `x-amz-date:${amzDate}\n`;
+  const signedHeadersList = 'host;x-amz-content-sha256;x-amz-date';
+
+  const canonicalPath = opts.url.pathname || '/';
+  const canonicalQueryString = opts.url.search ? opts.url.search.slice(1) : '';
+
+  const canonicalRequest = [
+    opts.method,
+    canonicalPath,
+    canonicalQueryString,
+    canonicalHeaders,
+    signedHeadersList,
+    payloadHash,
+  ].join('\n');
+
+  const credentialScope = `${dateStamp}/${opts.region}/${opts.service}/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    await sha256Hex(canonicalRequest),
+  ].join('\n');
+
+  const signingKey = await getSignatureKey(
+    opts.secretAccessKey,
+    dateStamp,
+    opts.region,
+    opts.service
+  );
+  const signatureBytes = await hmacSha256(signingKey, stringToSign);
+  const signature = [...new Uint8Array(signatureBytes)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  return {
+    Authorization:
+      `AWS4-HMAC-SHA256 Credential=${opts.accessKeyId}/${credentialScope}, ` +
+      `SignedHeaders=${signedHeadersList}, Signature=${signature}`,
+    'x-amz-date': amzDate,
+    'x-amz-content-sha256': payloadHash,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AgentCoreSandboxInstance
+// ---------------------------------------------------------------------------
+
+export class AgentCoreSandboxInstance {
+  readonly runtimeArn: string;
+  readonly codespaceId: string;
+  readonly sandboxId: string;
+  readonly createdAt: string;
+
+  private readonly region: string;
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
+  private _status: SandboxStatus = 'running';
+
+  constructor(options: AgentCoreInstanceOptions) {
+    this.runtimeArn = options.runtimeArn;
+    this.codespaceId = options.codespaceId;
+    this.sandboxId = options.sandboxId;
+    this.createdAt = new Date().toISOString();
+    this.region = options.region;
+    this.accessKeyId = options.accessKeyId;
+    this.secretAccessKey = options.secretAccessKey;
+  }
+
+  get status(): SandboxStatus {
+    return this._status;
+  }
+
+  /**
+   * Invoke the AgentCore runtime handler and stream SSE events.
+   *
+   * Each invocation targets a specific `runtimeSessionId` which maps to
+   * an isolated microVM on the AgentCore side. This provides per-task
+   * isolation without managing containers ourselves.
+   *
+   * The response body is a text/event-stream formatted as:
+   *   data: {"type":"...", "data": {...}}\n\n
+   *
+   * TODO: Replace manual fetch + SigV4 signing with
+   * `@aws-sdk/client-bedrock-agentcore` InvokeAgentRuntimeCommand once the
+   * package is available. The SDK handles signing, retries, and streaming
+   * natively.
+   */
+  async *invoke(
+    payload: Record<string, unknown>,
+    runtimeSessionId: string
+  ): AsyncGenerator<SSEEvent> {
+    if (this._status === 'stopped') {
+      throw AgentCoreErrors.SESSION_INVOKE_FAILED('Instance is stopped');
+    }
+
+    const body = JSON.stringify(payload);
+
+    // Build the AgentCore invoke URL.
+    // Endpoint format: https://bedrock-agentcore.{region}.amazonaws.com
+    // Path: /agentruntimes/{runtimeArn}/sessions/{sessionId}/invoke
+    const runtimeId = this.extractRuntimeId(this.runtimeArn);
+    const url = new URL(
+      `/agentruntimes/${encodeURIComponent(runtimeId)}/sessions/${encodeURIComponent(runtimeSessionId)}/invoke`,
+      `https://bedrock-agentcore.${this.region}.amazonaws.com`
+    );
+
+    try {
+      const signed = await signRequest({
+        method: 'POST',
+        url,
+        body,
+        region: this.region,
+        service: 'bedrock-agentcore',
+        accessKeyId: this.accessKeyId,
+        secretAccessKey: this.secretAccessKey,
+      });
+
+      log.info('Invoking AgentCore runtime', {
+        data: {
+          runtimeArn: this.runtimeArn,
+          runtimeSessionId,
+          region: this.region,
+        },
+      });
+
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+          ...signed,
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => 'unknown error');
+        throw AgentCoreErrors.SESSION_INVOKE_FAILED(`HTTP ${response.status}: ${errorBody}`);
+      }
+
+      if (!response.body) {
+        throw AgentCoreErrors.SESSION_INVOKE_FAILED('Response body is empty');
+      }
+
+      // Parse SSE stream from response body
+      yield* this.parseSSEStream(response.body);
+    } catch (error) {
+      if (isAgentCoreError(error)) throw error;
+      throw AgentCoreErrors.SESSION_INVOKE_FAILED(errorMessage(error));
+    }
+  }
+
+  /**
+   * Parse an SSE stream (text/event-stream) into typed events.
+   *
+   * Expected format per the SSE spec:
+   *   data: {"type":"agent:turn", "data": {"content":"..."}}\n\n
+   *
+   * Handles:
+   * - Multi-line data fields (joined with newline)
+   * - Event type fields (event: ...)
+   * - Comment lines (: ...)
+   * - Chunked delivery where event boundaries span multiple chunks
+   */
+  private async *parseSSEStream(body: ReadableStream<Uint8Array>): AsyncGenerator<SSEEvent> {
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    for await (const chunk of this.readableStreamToAsyncIterable(body)) {
+      buffer += decoder.decode(chunk, { stream: true });
+
+      // Split on double newlines (SSE event boundary)
+      const parts = buffer.split('\n\n');
+      // Keep the last incomplete part in the buffer
+      buffer = parts.pop() || '';
+
+      for (const part of parts) {
+        const event = this.parseSSEBlock(part);
+        if (event) {
+          yield event;
+        }
+      }
+    }
+
+    // Flush any remaining data in buffer after stream ends
+    buffer += decoder.decode();
+    if (buffer.trim()) {
+      const event = this.parseSSEBlock(buffer);
+      if (event) {
+        yield event;
+      }
+    }
+  }
+
+  /**
+   * Parse a single SSE block (text between double-newline boundaries) into
+   * an SSEEvent. Returns null if the block doesn't contain valid event data.
+   */
+  private parseSSEBlock(block: string): SSEEvent | null {
+    const lines = block.split('\n');
+    const dataLines: string[] = [];
+    let eventType: string | undefined;
+
+    for (const line of lines) {
+      if (line.startsWith(':')) continue;
+
+      if (line.startsWith('data: ')) {
+        dataLines.push(line.slice(6));
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5));
+      } else if (line.startsWith('event: ')) {
+        eventType = line.slice(7).trim();
+      } else if (line.startsWith('event:')) {
+        eventType = line.slice(6).trim();
+      }
+    }
+
+    if (dataLines.length === 0) return null;
+
+    const dataStr = dataLines.join('\n');
+    try {
+      const parsed = JSON.parse(dataStr);
+
+      // Support two formats:
+      // 1. Wrapped: data: {"type":"...", "data": {...}}
+      // 2. Unwrapped with event field: event: agent:turn\ndata: {...}
+      if (typeof parsed === 'object' && parsed !== null) {
+        if (parsed.type && parsed.data) {
+          return parsed as SSEEvent;
+        }
+        if (eventType) {
+          return { type: eventType, data: parsed };
+        }
+      }
+    } catch (parseErr) {
+      log.warn('Failed to parse SSE block as JSON', {
+        data: {
+          block: dataStr.slice(0, 200),
+          error: parseErr instanceof Error ? parseErr.message : 'parse error',
+        },
+      });
+    }
+
+    return null;
+  }
+
+  /**
+   * Convert a ReadableStream into an AsyncIterable.
+   * Required because not all environments support `for await` on ReadableStream.
+   */
+  private async *readableStreamToAsyncIterable(
+    stream: ReadableStream<Uint8Array>
+  ): AsyncGenerator<Uint8Array> {
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) yield value;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Extract the runtime ID from the full ARN.
+   * ARN format: arn:aws:bedrock-agentcore:{region}:{account}:runtime/{id}
+   * Returns the {id} portion, or the full string if it doesn't match.
+   */
+  private extractRuntimeId(arn: string): string {
+    const parts = arn.split('/');
+    return parts.length > 1 ? (parts[parts.length - 1] ?? arn) : arn;
+  }
+
+  async stop(): Promise<void> {
+    this._status = 'stopped';
+    log.info('AgentCore instance stopped', {
+      data: { sandboxId: this.sandboxId, codespaceId: this.codespaceId },
+    });
+  }
+
+  async refreshStatus(): Promise<SandboxStatus> {
+    // AgentCore runtimes are managed by AWS. There's no local container
+    // to probe. The status is tracked locally based on invoke lifecycle.
+    return this._status;
+  }
+}

--- a/src/lib/sandbox/providers/agentcore-sandbox-provider.ts
+++ b/src/lib/sandbox/providers/agentcore-sandbox-provider.ts
@@ -1,0 +1,379 @@
+/**
+ * AgentCore Sandbox Provider
+ *
+ * Manages AWS Bedrock AgentCore runtime lifecycle:
+ * - Creates/tracks AgentCoreSandboxInstance per project
+ * - Assigns isolated runtimeSessionIds per task for microVM isolation
+ * - Verifies AWS credentials via STS health check
+ *
+ * This provider does NOT implement the full SandboxProvider interface
+ * (sandbox-provider.ts) because AgentCore has no exec/shell/tmux capabilities.
+ * Instead, it provides a focused API for invoke-and-stream workflows.
+ */
+
+import { AgentCoreErrors, isAgentCoreError } from '../../errors/agentcore-errors.js';
+import { createLogger } from '../../logging/logger.js';
+import { errorMessage } from '../../utils/error-message';
+import type { SandboxHealthCheck, SandboxStatus } from '../types.js';
+import {
+  type AgentCoreInstanceOptions,
+  AgentCoreSandboxInstance,
+  type SSEEvent,
+} from './agentcore-sandbox-instance.js';
+
+const log = createLogger('AgentCoreSandboxProvider');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentCoreProviderConfig {
+  /** AWS region for the AgentCore runtime */
+  region: string;
+  /** AWS access key ID */
+  accessKeyId: string;
+  /** AWS secret access key */
+  secretAccessKey: string;
+  /** ARN of the AgentCore runtime */
+  runtimeArn: string;
+}
+
+export interface AgentCoreRuntimeInfo {
+  sandboxId: string;
+  codespaceId: string;
+  runtimeArn: string;
+  status: SandboxStatus;
+  createdAt: string;
+  activeSessions: number;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export class AgentCoreSandboxProvider {
+  readonly name = 'agentcore';
+
+  private readonly config: AgentCoreProviderConfig;
+
+  /** Instances keyed by codespaceId */
+  private instances = new Map<string, AgentCoreSandboxInstance>();
+
+  /**
+   * Runtime session IDs keyed by taskId.
+   * Each task gets a unique runtimeSessionId to ensure microVM isolation
+   * on the AgentCore side.
+   */
+  private taskSessions = new Map<string, string>();
+
+  constructor(config: AgentCoreProviderConfig) {
+    this.config = config;
+  }
+
+  // -------------------------------------------------------------------------
+  // Instance lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Create a new AgentCoreSandboxInstance for a project.
+   *
+   * Unlike Docker/K8s providers, this doesn't actually create a container.
+   * It creates a local handle that can invoke the AgentCore runtime.
+   * The actual microVM is provisioned on-demand by AWS when invoke() is called.
+   */
+  create(codespaceId: string, sandboxId: string): AgentCoreSandboxInstance {
+    // Check for existing instance
+    const existing = this.instances.get(codespaceId);
+    if (existing && existing.status !== 'stopped') {
+      log.info('Returning existing AgentCore instance for codespace', {
+        data: { codespaceId, sandboxId: existing.sandboxId },
+      });
+      return existing;
+    }
+
+    const options: AgentCoreInstanceOptions = {
+      runtimeArn: this.config.runtimeArn,
+      region: this.config.region,
+      accessKeyId: this.config.accessKeyId,
+      secretAccessKey: this.config.secretAccessKey,
+      codespaceId,
+      sandboxId,
+    };
+
+    const instance = new AgentCoreSandboxInstance(options);
+    this.instances.set(codespaceId, instance);
+
+    log.info('Created AgentCore instance', {
+      data: { codespaceId, sandboxId, runtimeArn: this.config.runtimeArn },
+    });
+
+    return instance;
+  }
+
+  /**
+   * Get an existing instance for a project.
+   */
+  get(codespaceId: string): AgentCoreSandboxInstance | null {
+    const instance = this.instances.get(codespaceId);
+    if (!instance || instance.status === 'stopped') {
+      return null;
+    }
+    return instance;
+  }
+
+  /**
+   * List all managed instances (including stopped ones).
+   */
+  list(): AgentCoreRuntimeInfo[] {
+    const result: AgentCoreRuntimeInfo[] = [];
+
+    for (const instance of this.instances.values()) {
+      const activeSessions = this.getSessionsByCodespace(instance.codespaceId).length;
+
+      result.push({
+        sandboxId: instance.sandboxId,
+        codespaceId: instance.codespaceId,
+        runtimeArn: instance.runtimeArn,
+        status: instance.status,
+        createdAt: instance.createdAt,
+        activeSessions,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Clean up all instances and sessions.
+   */
+  async cleanup(): Promise<number> {
+    let cleaned = 0;
+    const codespaceIds = [...this.instances.keys()];
+
+    for (const codespaceId of codespaceIds) {
+      const instance = this.instances.get(codespaceId);
+      if (instance) {
+        try {
+          await instance.stop();
+          cleaned++;
+        } catch (stopErr) {
+          log.warn('Failed to stop AgentCore instance during cleanup', {
+            data: {
+              codespaceId,
+              error: stopErr instanceof Error ? stopErr.message : String(stopErr),
+            },
+          });
+        }
+      }
+    }
+
+    this.instances.clear();
+    this.taskSessions.clear();
+
+    log.info('Cleaned up all AgentCore instances', { data: { cleaned } });
+    return cleaned;
+  }
+
+  // -------------------------------------------------------------------------
+  // Session management (per-task microVM isolation)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get or create a runtimeSessionId for a task.
+   *
+   * Each task gets a unique session ID so that AgentCore provisions an
+   * isolated microVM for its execution. Session IDs are formatted as
+   * `{codespaceId}:{taskId}:{timestamp}` for traceability in AWS logs.
+   */
+  getOrCreateSession(codespaceId: string, taskId: string): string {
+    const existing = this.taskSessions.get(taskId);
+    if (existing) {
+      return existing;
+    }
+
+    const sessionId = `${codespaceId}:${taskId}:${Date.now()}`;
+    this.taskSessions.set(taskId, sessionId);
+
+    log.info('Created AgentCore runtime session', {
+      data: { codespaceId, taskId, runtimeSessionId: sessionId },
+    });
+
+    return sessionId;
+  }
+
+  /**
+   * Get the runtimeSessionId for a task (if it exists).
+   */
+  getSession(taskId: string): string | null {
+    return this.taskSessions.get(taskId) ?? null;
+  }
+
+  /**
+   * Remove the session for a task (after completion or cancellation).
+   */
+  removeSession(taskId: string): boolean {
+    const existed = this.taskSessions.has(taskId);
+    this.taskSessions.delete(taskId);
+    if (existed) {
+      log.info('Removed AgentCore runtime session', { data: { taskId } });
+    }
+    return existed;
+  }
+
+  /**
+   * Get all sessions that belong to a specific project.
+   * Returns [taskId, runtimeSessionId] pairs.
+   */
+  private getSessionsByCodespace(codespaceId: string): [string, string][] {
+    const result: [string, string][] = [];
+    for (const [taskId, sessionId] of this.taskSessions) {
+      if (sessionId.startsWith(`${codespaceId}:`)) {
+        result.push([taskId, sessionId]);
+      }
+    }
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Health check
+  // -------------------------------------------------------------------------
+
+  /**
+   * Verify AWS credentials are valid using STS GetCallerIdentity.
+   *
+   * Uses the @aws-sdk/client-sts package which is already in the project
+   * dependencies (package.json).
+   */
+  async healthCheck(): Promise<SandboxHealthCheck> {
+    try {
+      // Dynamic import to avoid loading AWS SDK at module level.
+      // Use string variable to prevent TypeScript from resolving the module statically.
+      const stsModuleName = '@aws-sdk/client-sts';
+      const stsModule = (await import(/* webpackIgnore: true */ stsModuleName)) as {
+        STSClient: new (config: {
+          region: string;
+          credentials: { accessKeyId: string; secretAccessKey: string };
+        }) => { send(cmd: unknown): Promise<{ Account?: string; Arn?: string }> };
+        GetCallerIdentityCommand: new (input: Record<string, never>) => unknown;
+      };
+      const { STSClient, GetCallerIdentityCommand } = stsModule;
+
+      const sts = new STSClient({
+        region: this.config.region,
+        credentials: {
+          accessKeyId: this.config.accessKeyId,
+          secretAccessKey: this.config.secretAccessKey,
+        },
+      });
+
+      const identity = await sts.send(new GetCallerIdentityCommand({}));
+
+      return {
+        healthy: true,
+        message: undefined,
+        details: {
+          provider: 'agentcore',
+          region: this.config.region,
+          runtimeArn: this.config.runtimeArn,
+          awsAccount: identity.Account,
+          awsArn: identity.Arn,
+          activeInstances: this.instances.size,
+          activeSessions: this.taskSessions.size,
+        },
+      };
+    } catch (error) {
+      // Let programming errors propagate — don't mask bugs as credential issues
+      if (
+        error instanceof TypeError ||
+        error instanceof ReferenceError ||
+        error instanceof SyntaxError
+      ) {
+        throw error;
+      }
+
+      const message = errorMessage(error);
+
+      // Check for specific AWS error types
+      const errorName = (error as { name?: string })?.name;
+      if (errorName === 'ExpiredTokenException' || errorName === 'ExpiredToken') {
+        return {
+          healthy: false,
+          message: 'AWS credentials have expired',
+          details: {
+            provider: 'agentcore',
+            region: this.config.region,
+            errorType: 'expired_credentials',
+          },
+        };
+      }
+
+      if (
+        errorName === 'InvalidClientTokenId' ||
+        errorName === 'SignatureDoesNotMatch' ||
+        errorName === 'UnrecognizedClientException'
+      ) {
+        return {
+          healthy: false,
+          message: `AWS credentials invalid: ${message}`,
+          details: {
+            provider: 'agentcore',
+            region: this.config.region,
+            errorType: 'invalid_credentials',
+          },
+        };
+      }
+
+      return {
+        healthy: false,
+        message: `AWS STS health check failed: ${message}`,
+        details: {
+          provider: 'agentcore',
+          region: this.config.region,
+          runtimeArn: this.config.runtimeArn,
+          errorType: 'sts_error',
+        },
+      };
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Convenience: invoke + stream in one call
+  // -------------------------------------------------------------------------
+
+  /**
+   * High-level helper that gets/creates an instance and session, then invokes
+   * the runtime and returns the SSE event stream.
+   *
+   * This is the primary entry point for callers who want to execute a task
+   * on AgentCore without managing instance/session lifecycle manually.
+   */
+  async *invokeForTask(
+    codespaceId: string,
+    taskId: string,
+    sandboxId: string,
+    payload: Record<string, unknown>
+  ): AsyncGenerator<SSEEvent> {
+    const instance = this.get(codespaceId) ?? this.create(codespaceId, sandboxId);
+    const runtimeSessionId = this.getOrCreateSession(codespaceId, taskId);
+
+    try {
+      yield* instance.invoke(payload, runtimeSessionId);
+    } catch (error) {
+      // Re-wrap with context if it's not already an AgentCore error
+      if (isAgentCoreError(error)) throw error;
+      throw AgentCoreErrors.STREAMING_ERROR(errorMessage(error));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Factory function for creating an AgentCoreSandboxProvider.
+ * Mirrors the createAgentSandboxProvider / createDockerProvider patterns.
+ */
+export function createAgentCoreProvider(config: AgentCoreProviderConfig): AgentCoreSandboxProvider {
+  return new AgentCoreSandboxProvider(config);
+}

--- a/src/lib/sandbox/providers/sandbox-provider.ts
+++ b/src/lib/sandbox/providers/sandbox-provider.ts
@@ -185,7 +185,9 @@ export interface SandboxProvider {
    *
    * theme-04 P1-03: crash-safe startup — scan the runtime for agentpane
    * sandboxes, re-register running ones into the in-memory cache, tear down
-   * stale/stopped ones. Implemented by Docker, K8s and Nomad providers.
+   * stale/stopped ones. Implemented by Docker, K8s and Nomad providers. The
+   * default implementation is a no-op for providers that do not persist state
+   * across restarts (e.g. AgentCore).
    */
   recover(): Promise<RecoverResult>;
 

--- a/src/server/routes/__tests__/sandbox.test.ts
+++ b/src/server/routes/__tests__/sandbox.test.ts
@@ -153,6 +153,7 @@ describe('Sandbox Config API Routes', () => {
               id: 'cfg-1',
               name: 'Nomad',
               nomadToken: 'secret-token',
+              awsSecretAccessKey: 'aws-secret',
             },
           ],
           totalCount: 1,
@@ -164,6 +165,7 @@ describe('Sandbox Config API Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.items[0].nomadToken).toBeUndefined();
+      expect(json.data.items[0].awsSecretAccessKey).toBeUndefined();
       expect(json.data.items[0].name).toBe('Nomad');
     });
 
@@ -325,6 +327,7 @@ describe('Sandbox Config API Routes', () => {
           id: 'cfg-1',
           name: 'Config',
           nomadToken: 'encrypted-secret',
+          awsSecretAccessKey: 'encrypted-aws',
         },
       });
 
@@ -335,6 +338,7 @@ describe('Sandbox Config API Routes', () => {
       expect(res.status).toBe(201);
       const json = await res.json();
       expect(json.data.nomadToken).toBeUndefined();
+      expect(json.data.awsSecretAccessKey).toBeUndefined();
     });
 
     it('returns 400 for memoryMb too high', async () => {
@@ -432,6 +436,21 @@ describe('Sandbox Config API Routes', () => {
 
       expect(res.status).toBe(201);
     });
+
+    it('accepts valid agentcore type', async () => {
+      const { app, sandboxConfigService } = createTestApp();
+      sandboxConfigService.create.mockResolvedValue({
+        ok: true,
+        value: { id: 'cfg-ac', name: 'AgentCore Config', type: 'agentcore' },
+      });
+
+      const res = await request(app, 'POST', '/api/sandbox-configs', {
+        name: 'AgentCore Config',
+        type: 'agentcore',
+      });
+
+      expect(res.status).toBe(201);
+    });
   });
 
   // ── GET /api/sandbox-configs/:id ──
@@ -496,6 +515,7 @@ describe('Sandbox Config API Routes', () => {
           id: 'cfg-1',
           name: 'Config',
           nomadToken: 'secret',
+          awsSecretAccessKey: 'aws-secret',
         },
       });
 
@@ -504,6 +524,7 @@ describe('Sandbox Config API Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.nomadToken).toBeUndefined();
+      expect(json.data.awsSecretAccessKey).toBeUndefined();
     });
   });
 
@@ -619,6 +640,7 @@ describe('Sandbox Config API Routes', () => {
           id: 'cfg-1',
           name: 'Config',
           nomadToken: 'secret',
+          awsSecretAccessKey: 'aws-secret',
         },
       });
 
@@ -629,6 +651,7 @@ describe('Sandbox Config API Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.nomadToken).toBeUndefined();
+      expect(json.data.awsSecretAccessKey).toBeUndefined();
     });
 
     it('allows updating isDefault', async () => {

--- a/src/server/routes/sandbox-configs.ts
+++ b/src/server/routes/sandbox-configs.ts
@@ -34,6 +34,11 @@ const sandboxConfigBodySchema = z.object({
   nomadNamespace: z.string().max(200).optional(),
   nomadDatacenter: z.string().max(200).optional(),
   nomadRegion: z.string().max(200).optional(),
+  awsAccessKeyId: z.string().max(128).optional(),
+  awsSecretAccessKey: z.string().max(256).optional(),
+  awsRegion: z.string().max(64).optional(),
+  agentcoreRuntimeArn: z.string().max(2048).optional(),
+  ecrRepositoryUri: z.string().max(2048).optional(),
 });
 
 const sandboxConfigCreateSchema = sandboxConfigBodySchema.extend({
@@ -41,13 +46,15 @@ const sandboxConfigCreateSchema = sandboxConfigBodySchema.extend({
 });
 
 /** Strip sensitive credential fields from a config before returning it to the client. */
-function redactConfig<T extends Record<string, unknown>>(config: T): Omit<T, 'nomadToken'> {
-  const { nomadToken: _token, ...safe } = config;
+function redactConfig<T extends Record<string, unknown>>(
+  config: T
+): Omit<T, 'nomadToken' | 'awsSecretAccessKey'> {
+  const { nomadToken: _token, awsSecretAccessKey: _awsSecret, ...safe } = config;
   return safe;
 }
 
 /** Sensitive fields in sandbox configs that must be encrypted before storage. */
-const SANDBOX_CONFIG_SENSITIVE_FIELDS = ['nomadToken'] as const;
+const SANDBOX_CONFIG_SENSITIVE_FIELDS = ['nomadToken', 'awsSecretAccessKey'] as const;
 
 /** Encrypt sensitive credential fields in a sandbox config body before database storage. */
 async function encryptSensitiveFields<T extends Record<string, unknown>>(body: T): Promise<T> {

--- a/src/server/routes/sandbox.ts
+++ b/src/server/routes/sandbox.ts
@@ -39,6 +39,11 @@ const sandboxConfigBodySchema = z.object({
   nomadNamespace: z.string().max(200).optional(),
   nomadDatacenter: z.string().max(200).optional(),
   nomadRegion: z.string().max(200).optional(),
+  awsAccessKeyId: z.string().max(128).optional(),
+  awsSecretAccessKey: z.string().max(256).optional(),
+  awsRegion: z.string().max(64).optional(),
+  agentcoreRuntimeArn: z.string().max(2048).optional(),
+  ecrRepositoryUri: z.string().max(2048).optional(),
 });
 
 const sandboxConfigCreateSchema = sandboxConfigBodySchema.extend({
@@ -48,13 +53,15 @@ const sandboxConfigCreateSchema = sandboxConfigBodySchema.extend({
 const log = createLogger('SandboxRoutes');
 
 /** Strip sensitive credential fields from a config before returning it to the client. */
-function redactConfig<T extends Record<string, unknown>>(config: T): Omit<T, 'nomadToken'> {
-  const { nomadToken: _token, ...safe } = config;
+function redactConfig<T extends Record<string, unknown>>(
+  config: T
+): Omit<T, 'nomadToken' | 'awsSecretAccessKey'> {
+  const { nomadToken: _token, awsSecretAccessKey: _awsSecret, ...safe } = config;
   return safe;
 }
 
 /** Sensitive fields in sandbox configs that must be encrypted before storage. */
-const SANDBOX_CONFIG_SENSITIVE_FIELDS = ['nomadToken'] as const;
+const SANDBOX_CONFIG_SENSITIVE_FIELDS = ['nomadToken', 'awsSecretAccessKey'] as const;
 
 /** Encrypt sensitive credential fields in a sandbox config body before database storage. */
 async function encryptSensitiveFields<T extends Record<string, unknown>>(body: T): Promise<T> {

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -22,6 +22,7 @@ const ALLOWED_SETTINGS_KEYS = new Set([
   'sandbox.provider',
   'sandbox.kubernetes',
   'sandbox.nomad',
+  'sandbox.agentcore',
   'anthropic.apiKey',
   'anthropic.model',
   'github.token',
@@ -48,6 +49,7 @@ const ALLOWED_SETTINGS_KEYS = new Set([
 
 const SENSITIVE_FIELDS: Record<string, { secretKey: string; flagKey: string }> = {
   'sandbox.nomad': { secretKey: 'token', flagKey: 'hasToken' },
+  'sandbox.agentcore': { secretKey: 'secretAccessKey', flagKey: 'hasSecretAccessKey' },
 };
 
 interface SettingsDeps {

--- a/src/services/__tests__/container-agent.service.test.ts
+++ b/src/services/__tests__/container-agent.service.test.ts
@@ -1,7 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// theme-04 P1-02: AgentCore provider is gated behind AGENTCORE_ENABLED.
+// Enable it for this test suite so setAgentCoreProvider actually wires up.
+const ORIGINAL_AGENTCORE_ENABLED = process.env.AGENTCORE_ENABLED;
+beforeAll(() => {
+  process.env.AGENTCORE_ENABLED = 'true';
+});
+afterAll(() => {
+  if (ORIGINAL_AGENTCORE_ENABLED === undefined) {
+    delete process.env.AGENTCORE_ENABLED;
+  } else {
+    process.env.AGENTCORE_ENABLED = ORIGINAL_AGENTCORE_ENABLED;
+  }
+});
 
 import { SandboxErrors } from '../../lib/errors/sandbox-errors.js';
 import { err } from '../../lib/utils/result.js';
+import type { AgentCoreBridgeService } from '../container-agent/agentcore-bridge.service.js';
 import { ContainerAgentService } from '../container-agent/container-agent.service.js';
 import type { ContainerExecService } from '../container-agent/container-exec.service.js';
 import type { PlanApprovalService } from '../container-agent/plan-approval.service.js';
@@ -25,9 +40,11 @@ vi.mock('../container-agent/sandbox-state.js', () => {
   SandboxStateManager.prototype.isStarting = vi.fn().mockReturnValue(false);
   SandboxStateManager.prototype.markStarting = vi.fn();
   SandboxStateManager.prototype.clearStarting = vi.fn();
+  SandboxStateManager.prototype.getRunningAgentCoreAgent = vi.fn().mockReturnValue(undefined);
   SandboxStateManager.prototype.getRunningAgent = vi.fn().mockReturnValue(undefined);
   SandboxStateManager.prototype.getAnyRunningAgent = vi.fn().mockReturnValue(null);
   SandboxStateManager.prototype.getAllRunningAgents = vi.fn().mockReturnValue([]);
+  SandboxStateManager.prototype.getAllRunningAgentCoreAgents = vi.fn().mockReturnValue([]);
   SandboxStateManager.prototype.getPendingPlan = vi.fn().mockReturnValue(undefined);
   SandboxStateManager.prototype.setPendingPlan = vi.fn();
   SandboxStateManager.prototype.deletePendingPlan = vi.fn();
@@ -51,6 +68,17 @@ vi.mock('../container-agent/container-exec.service.js', () => {
   return { ContainerExecService };
 });
 
+vi.mock('../container-agent/agentcore-bridge.service.js', () => {
+  const AgentCoreBridgeService = vi.fn();
+  AgentCoreBridgeService.prototype.startAgentCoreAgent = vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: undefined });
+  AgentCoreBridgeService.prototype.stopAgentCoreAgent = vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: undefined });
+  return { AgentCoreBridgeService };
+});
+
 vi.mock('../container-agent/plan-approval.service.js', () => {
   const PlanApprovalService = vi.fn();
   PlanApprovalService.prototype.approvePlan = vi
@@ -63,6 +91,13 @@ vi.mock('../container-agent/plan-approval.service.js', () => {
   PlanApprovalService.prototype.handlePlanReady = vi.fn().mockResolvedValue(undefined);
   return { PlanApprovalService };
 });
+
+vi.mock('../../lib/sandbox/providers/agentcore-sandbox-provider.js', () => ({
+  createAgentCoreProvider: vi.fn(() => ({
+    name: 'agentcore',
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
 
 vi.mock('../../lib/logging/logger.js', () => ({
   createLogger: () => ({
@@ -83,15 +118,7 @@ function createMockDb() {
       codespaces: {
         findFirst: vi.fn().mockResolvedValue({ id: 'proj-1', name: 'Test', path: '/tmp' }),
       },
-      tasks: {
-        findMany: vi.fn().mockResolvedValue([]),
-      },
     },
-    update: vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      }),
-    }),
   } as any;
 }
 
@@ -126,9 +153,11 @@ describe('ContainerAgentService', () => {
     const { SandboxStateManager: SM } = await import('../container-agent/sandbox-state.js');
     (SM as any).prototype.hasAnyRunningAgent.mockReturnValue(false);
     (SM as any).prototype.isStarting.mockReturnValue(false);
+    (SM as any).prototype.getRunningAgentCoreAgent.mockReturnValue(undefined);
     (SM as any).prototype.getRunningAgent.mockReturnValue(undefined);
     (SM as any).prototype.getAnyRunningAgent.mockReturnValue(null);
     (SM as any).prototype.getAllRunningAgents.mockReturnValue([]);
+    (SM as any).prototype.getAllRunningAgentCoreAgents.mockReturnValue([]);
     (SM as any).prototype.getPendingPlan.mockReturnValue(undefined);
 
     const { ContainerExecService: CES } = await import(
@@ -136,6 +165,12 @@ describe('ContainerAgentService', () => {
     );
     (CES as any).prototype.startAgent.mockResolvedValue({ ok: true, value: undefined });
     (CES as any).prototype.stopAgent.mockResolvedValue({ ok: true, value: undefined });
+
+    const { AgentCoreBridgeService: ACBS } = await import(
+      '../container-agent/agentcore-bridge.service.js'
+    );
+    (ACBS as any).prototype.startAgentCoreAgent.mockResolvedValue({ ok: true, value: undefined });
+    (ACBS as any).prototype.stopAgentCoreAgent.mockResolvedValue({ ok: true, value: undefined });
 
     const { PlanApprovalService: PAS } = await import(
       '../container-agent/plan-approval.service.js'
@@ -164,7 +199,7 @@ describe('ContainerAgentService', () => {
       prompt: 'Build feature X',
     };
 
-    it('delegates to ContainerExecService', async () => {
+    it('delegates to ContainerExecService when no AgentCore provider is set', async () => {
       const result = await service.startAgent(baseInput);
 
       expect(result.ok).toBe(true);
@@ -172,6 +207,27 @@ describe('ContainerAgentService', () => {
       // ContainerExecService.startAgent should have been called
       const containerExec = (service as any).containerExec as ContainerExecService;
       expect(containerExec.startAgent).toHaveBeenCalledWith(baseInput);
+    });
+
+    it('delegates to AgentCoreBridgeService when AgentCore provider is set', async () => {
+      // Set up AgentCore provider
+      await service.setAgentCoreProvider({
+        region: 'us-east-1',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        runtimeArn: 'arn:aws:agentcore:test',
+      });
+
+      const result = await service.startAgent(baseInput);
+
+      expect(result.ok).toBe(true);
+
+      // AgentCoreBridgeService.startAgentCoreAgent should have been called
+      const agentCoreBridge = (service as any).agentCoreBridge as AgentCoreBridgeService;
+      expect(agentCoreBridge.startAgentCoreAgent).toHaveBeenCalledWith(
+        baseInput,
+        expect.objectContaining({ id: 'proj-1' })
+      );
     });
 
     it('returns AGENT_ALREADY_RUNNING when agent is already running for task', async () => {
@@ -219,6 +275,24 @@ describe('ContainerAgentService', () => {
       expect(stateManager.clearStarting).toHaveBeenCalledWith('task-1');
     });
 
+    it('returns PROJECT_NOT_FOUND for AgentCore path when project missing', async () => {
+      await service.setAgentCoreProvider({
+        region: 'us-east-1',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        runtimeArn: 'arn:aws:agentcore:test',
+      });
+
+      db.query.codespaces.findFirst.mockResolvedValue(null);
+
+      const result = await service.startAgent(baseInput);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('SANDBOX_PROJECT_NOT_FOUND');
+      }
+    });
+
     it('defaults phase to plan when not specified', async () => {
       await service.startAgent(baseInput);
 
@@ -234,13 +308,34 @@ describe('ContainerAgentService', () => {
   // =========================================================================
 
   describe('stopAgent() delegation', () => {
-    it('delegates to ContainerExecService', async () => {
+    it('delegates to ContainerExecService when no AgentCore agent is running', async () => {
       const result = await service.stopAgent('task-1');
 
       expect(result.ok).toBe(true);
 
       const containerExec = (service as any).containerExec as ContainerExecService;
       expect(containerExec.stopAgent).toHaveBeenCalledWith('task-1');
+    });
+
+    it('delegates to AgentCoreBridgeService when AgentCore agent is running', async () => {
+      const agentCoreAgent = {
+        taskId: 'task-1',
+        sessionId: 'sess-1',
+        codespaceId: 'proj-1',
+        sandboxId: 'sb-1',
+        startedAt: new Date(),
+      };
+      const stateManager = (service as any).state as SandboxStateManager;
+      (stateManager.getRunningAgentCoreAgent as ReturnType<typeof vi.fn>).mockReturnValue(
+        agentCoreAgent
+      );
+
+      const result = await service.stopAgent('task-1');
+
+      expect(result.ok).toBe(true);
+
+      const agentCoreBridge = (service as any).agentCoreBridge as AgentCoreBridgeService;
+      expect(agentCoreBridge.stopAgentCoreAgent).toHaveBeenCalledWith(agentCoreAgent);
     });
 
     it('propagates error from ContainerExecService.stopAgent', async () => {
@@ -361,7 +456,7 @@ describe('ContainerAgentService', () => {
       expect(stateManager.getAnyRunningAgent).toHaveBeenCalledWith('task-1');
     });
 
-    it('getRunningAgents returns running agents array', () => {
+    it('getRunningAgents combines container and AgentCore agents', () => {
       const stateManager = (service as any).state as SandboxStateManager;
       const containerAgent = {
         taskId: 'task-1',
@@ -369,23 +464,56 @@ describe('ContainerAgentService', () => {
         sessionId: 'sess-1',
         startedAt: new Date(),
       };
+      const agentCoreAgent = {
+        taskId: 'task-2',
+        codespaceId: 'proj-1',
+        sessionId: 'sess-2',
+        startedAt: new Date(),
+      };
       (stateManager.getAllRunningAgents as ReturnType<typeof vi.fn>).mockReturnValue([
         containerAgent,
+      ]);
+      (stateManager.getAllRunningAgentCoreAgents as ReturnType<typeof vi.fn>).mockReturnValue([
+        agentCoreAgent,
       ]);
 
       const running = service.getRunningAgents();
 
-      expect(running).toHaveLength(1);
+      expect(running).toHaveLength(2);
       expect(running[0]?.taskId).toBe('task-1');
+      expect(running[1]?.taskId).toBe('task-2');
     });
   });
 
   // =========================================================================
-  // Provider name
+  // AgentCore provider management
   // =========================================================================
 
-  describe('providerName', () => {
-    it('returns the underlying provider name', () => {
+  describe('AgentCore provider management', () => {
+    it('providerName returns "docker" by default', () => {
+      expect(service.providerName).toBe('docker');
+    });
+
+    it('providerName returns "agentcore" after setAgentCoreProvider', async () => {
+      await service.setAgentCoreProvider({
+        region: 'us-east-1',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        runtimeArn: 'arn:aws:agentcore:test',
+      });
+      expect(service.providerName).toBe('agentcore');
+    });
+
+    it('clearAgentCoreProvider reverts to container provider name', async () => {
+      await service.setAgentCoreProvider({
+        region: 'us-east-1',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        runtimeArn: 'arn:aws:agentcore:test',
+      });
+      expect(service.providerName).toBe('agentcore');
+
+      service.clearAgentCoreProvider();
       expect(service.providerName).toBe('docker');
     });
   });
@@ -400,6 +528,20 @@ describe('ContainerAgentService', () => {
 
       const stateManager = (service as any).state as SandboxStateManager;
       expect(stateManager.dispose).toHaveBeenCalled();
+    });
+
+    it('cleans up AgentCore provider when set', async () => {
+      await service.setAgentCoreProvider({
+        region: 'us-east-1',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        runtimeArn: 'arn:aws:agentcore:test',
+      });
+
+      const agentCoreProvider = (service as any).agentCoreProvider;
+      service.dispose();
+
+      expect(agentCoreProvider.cleanup).toHaveBeenCalled();
     });
   });
 

--- a/src/services/container-agent.service.ts
+++ b/src/services/container-agent.service.ts
@@ -10,6 +10,7 @@
  * @see ./container-agent/sandbox-state.ts            (state management)
  * @see ./container-agent/worktree-init.service.ts    (worktree operations)
  * @see ./container-agent/container-exec.service.ts   (container lifecycle)
+ * @see ./container-agent/agentcore-bridge.service.ts (AgentCore SSE bridge)
  * @see ./container-agent/plan-approval.service.ts    (plan approve/reject)
  */
 

--- a/src/services/container-agent/agentcore-bridge.service.ts
+++ b/src/services/container-agent/agentcore-bridge.service.ts
@@ -1,0 +1,567 @@
+/**
+ * AgentCoreBridgeService - AgentCore-specific start/stop and SSE bridge.
+ *
+ * Responsibilities:
+ * - Start agents via AgentCore invoke + SSE (no container exec)
+ * - Stop AgentCore agents
+ * - Process SSE output from AgentCore invocations
+ * - Handle AgentCore-specific completion and error callbacks
+ * - Clean up AgentCore runtime state
+ */
+
+import { eq } from 'drizzle-orm';
+
+import { agents, sessions, tasks } from '../../db/schema';
+import { createAgentCoreBridge } from '../../lib/agents/agentcore-bridge.js';
+import { DEFAULT_AGENT_MODEL, getFullModelId } from '../../lib/constants/models.js';
+import type { SandboxError } from '../../lib/errors/sandbox-errors.js';
+import { SandboxErrors } from '../../lib/errors/sandbox-errors.js';
+import { createLogger } from '../../lib/logging/logger.js';
+import type { SSEEvent } from '../../lib/sandbox/providers/agentcore-sandbox-instance.js';
+import type { AgentCoreSandboxProvider } from '../../lib/sandbox/providers/agentcore-sandbox-provider.js';
+import type { Result } from '../../lib/utils/result.js';
+import { err, ok } from '../../lib/utils/result.js';
+import { getAgentMaxRuntimeMs, getGlobalDefaultModel } from '../settings.service.js';
+import type { ContainerExecService } from './container-exec.service.js';
+import type { SandboxStateManager } from './sandbox-state.js';
+import {
+  resolveOAuthExpiresAtMs,
+  resolveOAuthToken,
+  updateAgentStatus,
+  updateTaskOnAgentComplete,
+  updateTaskOnAgentError,
+} from './shared-helpers.js';
+import type {
+  AgentConfig,
+  ContainerAgentDeps,
+  RunningAgentCoreAgent,
+  StartAgentInput,
+} from './types.js';
+
+const log = createLogger('AgentCoreBridgeService');
+
+export class AgentCoreBridgeService {
+  constructor(
+    private deps: ContainerAgentDeps,
+    private state: SandboxStateManager,
+    private containerExec: ContainerExecService,
+    private getAgentCoreProvider: () => AgentCoreSandboxProvider | undefined,
+    private onPlanReady: (
+      taskId: string,
+      sessionId: string,
+      codespaceId: string,
+      planData: {
+        plan: string;
+        turnCount: number;
+        sdkSessionId: string;
+        allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
+      }
+    ) => Promise<void>,
+    private onAgentCompleteCallback?: () =>
+      | ((codespaceId: string, taskId: string) => Promise<void>)
+      | undefined
+  ) {}
+
+  /**
+   * Start an agent via AgentCore invoke + SSE (no container exec).
+   */
+  async startAgentCoreAgent(
+    input: StartAgentInput,
+    codespace: {
+      id: string;
+      name: string;
+      path: string | null;
+      config?: Record<string, unknown> | null;
+    }
+  ): Promise<Result<void, SandboxError>> {
+    const {
+      codespaceId,
+      taskId,
+      sessionId,
+      prompt,
+      model,
+      maxTurns,
+      phase = 'plan',
+      sdkSessionId,
+    } = input;
+
+    const provider = this.getAgentCoreProvider();
+    if (!provider) {
+      log.info('AgentCore provider was cleared during startup', { data: { taskId } });
+      return err(
+        SandboxErrors.AGENT_START_FAILED(
+          'AgentCore provider was removed while agent was starting. Please retry.'
+        )
+      );
+    }
+
+    const { db, streams, apiKeyService } = this.deps;
+
+    log.info('Starting agent via AgentCore', {
+      data: { taskId, codespaceId, sessionId, phase },
+    });
+
+    // Fetch task
+    const task = await db.query.tasks.findFirst({ where: eq(tasks.id, taskId) });
+    if (!task) {
+      log.info('Task not found', { data: { taskId } });
+      return err(SandboxErrors.TASK_NOT_FOUND(taskId));
+    }
+
+    // Create or reuse agent record
+    const agentId = `agent-${taskId}`;
+    try {
+      await db
+        .insert(agents)
+        .values({
+          id: agentId,
+          codespaceId,
+          name: 'AgentCore Agent',
+          type: 'task',
+          status: 'starting',
+          currentTaskId: taskId,
+          currentSessionId: sessionId,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
+        .onConflictDoUpdate({
+          target: agents.id,
+          set: {
+            status: 'starting',
+            currentTaskId: taskId,
+            currentSessionId: sessionId,
+          },
+        });
+    } catch (dbErr) {
+      const errorMessage = dbErr instanceof Error ? dbErr.message : String(dbErr);
+      log.error('Failed to create agent record', { data: { agentId, error: errorMessage } });
+      return err(SandboxErrors.AGENT_RECORD_FAILED(errorMessage, dbErr));
+    }
+
+    // Create session record
+    const sandboxId = `agentcore-${codespaceId}`;
+    try {
+      await db
+        .insert(sessions)
+        .values({
+          id: sessionId,
+          codespaceId,
+          taskId,
+          agentId,
+          title: task.title ?? `AgentCore Agent - ${taskId}`,
+          url: `/codespaces/${codespaceId}/sessions/${sessionId}`,
+          status: 'active',
+          sandboxProvider: 'agentcore',
+          sandboxContainerId: null,
+          createdAt: new Date().toISOString(),
+        })
+        .onConflictDoUpdate({
+          target: sessions.id,
+          set: {
+            sandboxProvider: 'agentcore',
+            sandboxContainerId: null,
+            agentId,
+          },
+        });
+    } catch (dbErr) {
+      const errorMessage = dbErr instanceof Error ? dbErr.message : String(dbErr);
+      log.error('Failed to create session record', { data: { sessionId, error: errorMessage } });
+      return err(SandboxErrors.SESSION_CREATE_FAILED(errorMessage, dbErr));
+    }
+
+    // Link agent and session to task
+    try {
+      await db.update(tasks).set({ agentId, sessionId }).where(eq(tasks.id, taskId));
+    } catch (dbErr) {
+      const errorMessage = dbErr instanceof Error ? dbErr.message : String(dbErr);
+      log.info('Failed to link task (non-critical)', { data: { taskId, error: errorMessage } });
+    }
+
+    // Create durable stream
+    try {
+      await streams.createStream(sessionId, { type: 'container-agent', codespaceId, taskId });
+    } catch (streamErr) {
+      const errorMessage = streamErr instanceof Error ? streamErr.message : String(streamErr);
+      if (!errorMessage.includes('already exists') && !errorMessage.includes('duplicate')) {
+        log.error('Failed to create durable stream', { data: { sessionId, error: errorMessage } });
+        return err(SandboxErrors.STREAM_CREATE_FAILED(errorMessage, streamErr));
+      }
+    }
+
+    // Publish initial status
+    try {
+      await streams.publish(sessionId, 'container-agent:status', {
+        taskId,
+        sessionId,
+        stage: 'initializing',
+        message: 'Starting via AgentCore...',
+      });
+    } catch (publishErr) {
+      const errorMessage = publishErr instanceof Error ? publishErr.message : String(publishErr);
+      log.error('Failed to publish initial status', { data: { sessionId, error: errorMessage } });
+      return err(SandboxErrors.STREAM_PUBLISH_FAILED(errorMessage, publishErr));
+    }
+
+    // Resolve agent configuration
+    const codespaceModel = codespace.config?.model as string | undefined;
+    const resolvedModel =
+      (model ? getFullModelId(model) : undefined) ??
+      (codespaceModel ? getFullModelId(codespaceModel) : undefined) ??
+      (await getGlobalDefaultModel(db));
+    const agentConfig: AgentConfig = {
+      model: resolvedModel ?? getFullModelId(DEFAULT_AGENT_MODEL),
+      maxTurns: maxTurns ?? (codespace.config?.maxTurns as number | undefined) ?? 50,
+    };
+
+    await streams.publish(sessionId, 'container-agent:status', {
+      taskId,
+      sessionId,
+      stage: 'validating',
+      message: 'Configuration validated',
+    });
+
+    // Get OAuth token (using shared helper)
+    const oauthToken = await resolveOAuthToken(apiKeyService);
+    if (!oauthToken) {
+      log.info('No OAuth token available');
+      await streams.publish(sessionId, 'container-agent:message', {
+        taskId,
+        sessionId,
+        role: 'system',
+        content: 'No OAuth token configured. Please add your Anthropic API key in Settings.',
+      });
+      return err(SandboxErrors.API_KEY_NOT_CONFIGURED);
+    }
+
+    // theme-03 F11: resolve real OAuth expiry alongside the token so AgentCore
+    // does not write a fabricated 24h lifetime into the credentials file.
+    const oauthExpiresAtMs = await resolveOAuthExpiresAtMs(db);
+    // F03-09 (arch29-W2-C): forward the refresh token so the AgentCore handler
+    // can write it into the credentials file. AgentCore reads
+    // `oauthRefreshToken` from the payload; absence falls through to the
+    // env-var fallback (`CLAUDE_OAUTH_REFRESH_TOKEN`) and finally to null.
+    const oauthRefreshToken = await apiKeyService.getDecryptedRefreshToken('anthropic');
+
+    // Build invocation payload
+    const payload: Record<string, unknown> = {
+      prompt,
+      taskId,
+      sessionId,
+      model: agentConfig.model,
+      maxTurns: agentConfig.maxTurns,
+      phase,
+      oauthToken,
+      ...(oauthExpiresAtMs ? { oauthExpiresAt: oauthExpiresAtMs } : {}),
+      ...(oauthRefreshToken ? { oauthRefreshToken } : {}),
+      cwd: '/workspace',
+      ...(sdkSessionId ? { sdkSessionId } : {}),
+    };
+
+    // Get or create AgentCore instance and runtime session
+    const instance = provider.get(codespaceId) ?? provider.create(codespaceId, sandboxId);
+    const runtimeSessionId = provider.getOrCreateSession(codespaceId, taskId);
+
+    await streams.publish(sessionId, 'container-agent:status', {
+      taskId,
+      sessionId,
+      stage: 'executing',
+      message: phase === 'plan' ? 'Planning via AgentCore...' : 'Executing via AgentCore...',
+    });
+
+    try {
+      const events = instance.invoke(payload, runtimeSessionId);
+
+      const bridge = createAgentCoreBridge({
+        taskId,
+        sessionId,
+        codespaceId,
+        streams,
+        onComplete: (status, turnCount) => {
+          log.info('AgentCore agent completed', { data: { taskId, status, turnCount } });
+          void this.handleAgentCoreComplete(taskId, status, turnCount);
+        },
+        onError: (error, turnCount) => {
+          log.info('AgentCore agent error', { data: { taskId, error, turnCount } });
+          void this.handleAgentCoreError(taskId, error, turnCount);
+        },
+        onPlanReady: (planData) => {
+          log.info('AgentCore plan ready', {
+            data: { taskId, planLength: planData.plan.length, sdkSessionId: planData.sdkSessionId },
+          });
+          void this.onPlanReady(taskId, sessionId, codespaceId, planData);
+        },
+      });
+
+      const runningAgent: RunningAgentCoreAgent = {
+        taskId,
+        sessionId,
+        codespaceId,
+        sandboxId,
+        bridge,
+        instance,
+        runtimeSessionId,
+        startedAt: new Date(),
+        stopRequested: false,
+        phase,
+      };
+
+      this.state.setRunningAgentCoreAgent(taskId, runningAgent);
+
+      // Set max runtime timeout (env var > DB setting > default 4hr)
+      const maxRuntimeMs = await getAgentMaxRuntimeMs(db);
+      runningAgent.timeoutHandle = setTimeout(() => {
+        log.info('Agent exceeded max runtime, stopping', { data: { taskId, maxRuntimeMs } });
+        void this.stopAgentCoreAgent(runningAgent);
+      }, maxRuntimeMs);
+      runningAgent.timeoutHandle.unref();
+
+      // Update agent status
+      try {
+        await db
+          .update(agents)
+          .set({
+            status: phase === 'plan' ? 'planning' : 'running',
+          })
+          .where(eq(agents.id, agentId));
+      } catch (dbErr) {
+        const errorMessage = dbErr instanceof Error ? dbErr.message : String(dbErr);
+        log.info('Failed to update agent status (non-critical)', {
+          data: { agentId, error: errorMessage },
+        });
+      }
+
+      // Process the SSE stream asynchronously
+      this.processAgentCoreOutput(runningAgent, events).catch(async (streamErr) => {
+        const message = streamErr instanceof Error ? streamErr.message : String(streamErr);
+        log.warn('AgentCore output stream failed', {
+          data: { taskId, sessionId, error: message },
+        });
+        if (this.state.hasRunningAgentCoreAgent(taskId)) {
+          try {
+            await streams.publish(sessionId, 'container-agent:error', {
+              taskId,
+              sessionId,
+              error: 'Agent output stream failed unexpectedly.',
+              turnCount: 0,
+            });
+            await this.handleAgentCoreError(taskId, message, 0);
+          } catch (notifyErr) {
+            log.warn('Failed to notify user of stream failure (best-effort)', {
+              data: { taskId },
+              error: notifyErr,
+            });
+          }
+        }
+      });
+
+      // Publish running status
+      await streams.publish(sessionId, 'container-agent:status', {
+        taskId,
+        sessionId,
+        stage: 'running',
+        message: 'Running',
+      });
+      await streams.publish(sessionId, 'container-agent:started', {
+        taskId,
+        sessionId,
+        model: agentConfig.model,
+        maxTurns: agentConfig.maxTurns,
+        sandboxProvider: 'agentcore',
+      });
+
+      log.info('Agent started via AgentCore', { data: { taskId, sessionId } });
+      return ok(undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error('Failed to start agent', { data: { taskId, error: message } });
+      provider.removeSession(taskId);
+      return err(SandboxErrors.AGENT_START_FAILED(message, error));
+    }
+  }
+
+  /**
+   * Process SSE output from an AgentCore invocation.
+   */
+  private async processAgentCoreOutput(
+    agent: RunningAgentCoreAgent,
+    events: AsyncIterable<SSEEvent>
+  ): Promise<void> {
+    log.debug('Starting to process AgentCore SSE stream', {
+      data: { taskId: agent.taskId, sessionId: agent.sessionId },
+    });
+
+    try {
+      await agent.bridge.processStream(events);
+      log.debug('Bridge finished processing stream', { data: { taskId: agent.taskId } });
+
+      if (this.state.hasRunningAgentCoreAgent(agent.taskId)) {
+        if (agent.stopRequested) {
+          log.info('Agent stopped via cancellation request', { data: { taskId: agent.taskId } });
+          await this.handleAgentCoreComplete(agent.taskId, 'cancelled', 0);
+          return;
+        }
+
+        const errorMessage = 'Agent stream ended without emitting a completion event';
+        log.info('Stream ended without completion', { data: { taskId: agent.taskId } });
+
+        await this.deps.streams.publish(agent.sessionId, 'container-agent:error', {
+          taskId: agent.taskId,
+          sessionId: agent.sessionId,
+          error: errorMessage,
+          turnCount: 0,
+        });
+
+        await this.handleAgentCoreError(agent.taskId, errorMessage, 0);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.info('Error processing AgentCore stream', {
+        data: { taskId: agent.taskId, error: message },
+      });
+
+      if (this.state.hasRunningAgentCoreAgent(agent.taskId)) {
+        if (agent.stopRequested) {
+          await this.handleAgentCoreComplete(agent.taskId, 'cancelled', 0);
+          return;
+        }
+
+        await this.deps.streams.publish(agent.sessionId, 'container-agent:error', {
+          taskId: agent.taskId,
+          sessionId: agent.sessionId,
+          error: message,
+          turnCount: 0,
+        });
+
+        await this.handleAgentCoreError(agent.taskId, message, 0);
+      }
+    } finally {
+      log.debug('Stream processing finished', {
+        data: {
+          taskId: agent.taskId,
+          stillRunning: this.state.hasRunningAgentCoreAgent(agent.taskId),
+        },
+      });
+    }
+  }
+
+  /**
+   * Stop an AgentCore agent by stopping the bridge and instance.
+   */
+  async stopAgentCoreAgent(agent: RunningAgentCoreAgent): Promise<Result<void, SandboxError>> {
+    const { taskId, sessionId } = agent;
+    log.info('Stopping AgentCore agent', {
+      data: { taskId, runtimeSessionId: agent.runtimeSessionId },
+    });
+
+    try {
+      agent.stopRequested = true;
+      agent.bridge.stop();
+      await agent.instance.stop();
+
+      const provider = this.getAgentCoreProvider();
+      if (provider) {
+        provider.removeSession(taskId);
+      }
+
+      await this.deps.streams.publish(sessionId, 'container-agent:cancelled', {
+        taskId,
+        sessionId,
+        turnCount: 0,
+      });
+
+      return ok(undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error('Failed to stop agent', { data: { taskId, error: message } });
+      return err(SandboxErrors.AGENT_STOP_FAILED(message, error));
+    } finally {
+      // Explicit cleanup in case stream handler doesn't fire
+      if (agent.timeoutHandle) clearTimeout(agent.timeoutHandle);
+      this.state.deleteRunningAgentCoreAgent(taskId);
+    }
+  }
+
+  /**
+   * Shared cleanup for AgentCore agents.
+   */
+  private async cleanupAgentCoreRunState(
+    taskId: string,
+    agent: RunningAgentCoreAgent,
+    agentDbStatus: 'completed' | 'error',
+    context: string
+  ): Promise<void> {
+    await updateAgentStatus(this.deps.db, taskId, agentDbStatus);
+
+    const provider = this.getAgentCoreProvider();
+    if (provider) {
+      provider.removeSession(taskId);
+    }
+
+    clearTimeout(agent.timeoutHandle);
+    this.state.deleteRunningAgentCoreAgent(taskId);
+    log.info(`[${context}] AgentCore agent cleanup finished`, {
+      data: { taskId, remainingAgents: this.state.totalRunningAgentCount },
+    });
+  }
+
+  /**
+   * Handle AgentCore agent completion.
+   */
+  async handleAgentCoreComplete(
+    taskId: string,
+    status: 'completed' | 'turn_limit' | 'cancelled' | 'error',
+    turnCount: number
+  ): Promise<void> {
+    log.info('AgentCore agent completion', { data: { taskId, status, turnCount } });
+
+    const agent = this.state.getRunningAgentCoreAgent(taskId);
+    if (!agent) {
+      log.debug('Agent not found in AgentCore agents map', { data: { taskId } });
+      return this.containerExec.handleAgentComplete(taskId, status, turnCount);
+    }
+
+    const { db, streams } = this.deps;
+
+    // Update task status (using shared helper)
+    await updateTaskOnAgentComplete(
+      db,
+      taskId,
+      status,
+      streams,
+      agent.sessionId,
+      this.deps.skillTrackingService
+    );
+
+    await this.cleanupAgentCoreRunState(taskId, agent, 'completed', 'handleAgentCoreComplete');
+
+    // Auto-dequeue
+    const callback = this.onAgentCompleteCallback?.();
+    if (status === 'completed' && callback) {
+      callback(agent.codespaceId, taskId).catch((dequeueErr) => {
+        log.warn('Failed to auto-dequeue next task', {
+          data: { taskId },
+          error: dequeueErr,
+        });
+      });
+    }
+  }
+
+  /**
+   * Handle AgentCore agent error.
+   */
+  async handleAgentCoreError(taskId: string, error: string, turnCount: number): Promise<void> {
+    log.info('AgentCore agent error', { data: { taskId, error, turnCount } });
+
+    const agent = this.state.getRunningAgentCoreAgent(taskId);
+    if (!agent) {
+      return this.containerExec.handleAgentError(taskId, error, turnCount);
+    }
+
+    const { db, streams } = this.deps;
+
+    // Update task -- clear agent refs on error (using shared helper)
+    await updateTaskOnAgentError(db, taskId, streams, agent.sessionId);
+
+    await this.cleanupAgentCoreRunState(taskId, agent, 'error', 'handleAgentCoreError');
+  }
+}

--- a/src/services/container-agent/container-agent.service.ts
+++ b/src/services/container-agent/container-agent.service.ts
@@ -6,18 +6,28 @@
  * in src/services/container-agent.service.ts.
  *
  * Sub-services:
- * - SandboxStateManager:    owns 2 Maps + 1 Set for state tracking
+ * - SandboxStateManager:    owns 3 Maps + 1 Set for state tracking
  * - WorktreeInitService:    worktree creation, path translation
  * - ContainerExecService:   container lifecycle management (Docker/K8s/Nomad)
+ * - AgentCoreBridgeService: AgentCore start/stop, SSE bridge
  * - PlanApprovalService:    plan ready/approve/reject handlers
  */
 
 import { eq } from 'drizzle-orm';
 
-import { tasks } from '../../db/schema';
+import { codespaces, tasks } from '../../db/schema';
 import type { SandboxError } from '../../lib/errors/sandbox-errors.js';
 import { SandboxErrors } from '../../lib/errors/sandbox-errors.js';
 import { createLogger } from '../../lib/logging/logger.js';
+// theme-04 P1-02: AgentCore provider types are imported with `import type` so
+// the concrete module (which pulls in the AWS SDK) is NOT added to the module
+// graph when AgentCore is disabled. The factory (`createAgentCoreProvider`) is
+// loaded via dynamic import inside `setAgentCoreProvider` only when
+// `AGENTCORE_ENABLED=true`.
+import type {
+  AgentCoreProviderConfig,
+  AgentCoreSandboxProvider,
+} from '../../lib/sandbox/providers/agentcore-sandbox-provider.js';
 import type { SandboxProvider } from '../../lib/sandbox/providers/sandbox-provider.js';
 import type { Result } from '../../lib/utils/result.js';
 import { err } from '../../lib/utils/result.js';
@@ -29,6 +39,7 @@ import type { SkillTrackingService } from '../memory/skill-tracking.service.js';
 import type { WorktreeService } from '../worktree.service.js';
 
 import { AgentReviewService } from './agent-review.service.js';
+import { AgentCoreBridgeService } from './agentcore-bridge.service.js';
 import { ContainerExecService } from './container-exec.service.js';
 import { PlanApprovalService } from './plan-approval.service.js';
 import { SandboxStateManager } from './sandbox-state.js';
@@ -37,18 +48,34 @@ import { WorktreeInitService } from './worktree-init.service.js';
 
 const log = createLogger('ContainerAgentService');
 
+/**
+ * theme-04 P1-02: Feature flag for AgentCore.
+ *
+ * When this returns false (the default), the agentcore-sandbox-provider module
+ * is never imported, so the AWS SDK does not land in the module graph. Set
+ * `AGENTCORE_ENABLED=true` to opt in.
+ */
+function isAgentCoreEnabled(): boolean {
+  return process.env.AGENTCORE_ENABLED === 'true';
+}
+
 export class ContainerAgentService {
   private state: SandboxStateManager;
   private worktreeInit: WorktreeInitService;
   private containerExec: ContainerExecService;
+  private agentCoreBridge: AgentCoreBridgeService;
   private planApproval: PlanApprovalService;
   private deps: ContainerAgentDeps;
+
+  /** AgentCore sandbox provider (lazily initialized when AgentCore config is set) */
+  private agentCoreProvider?: AgentCoreSandboxProvider;
 
   /** Optional callback invoked when an agent completes a task, for queue auto-dequeue */
   private onAgentCompleteCallback?: (codespaceId: string, taskId: string) => Promise<void>;
 
   /** Expose provider name so callers (e.g. TaskService) can tag sessions at creation */
   get providerName(): string {
+    if (this.agentCoreProvider) return 'agentcore';
     return this.deps.provider.name;
   }
 
@@ -79,7 +106,7 @@ export class ContainerAgentService {
     this.state = new SandboxStateManager();
     this.worktreeInit = new WorktreeInitService(this.deps);
 
-    // handlePlanReady callback shared by exec path
+    // handlePlanReady callback shared by both exec paths
     const handlePlanReady = (
       taskId: string,
       sessionId: string,
@@ -102,6 +129,15 @@ export class ContainerAgentService {
       getOnAgentCompleteCallback
     );
 
+    this.agentCoreBridge = new AgentCoreBridgeService(
+      this.deps,
+      this.state,
+      this.containerExec,
+      () => this.agentCoreProvider,
+      handlePlanReady,
+      getOnAgentCompleteCallback
+    );
+
     const agentReview = new AgentReviewService(this.deps);
 
     this.planApproval = new PlanApprovalService(
@@ -109,6 +145,7 @@ export class ContainerAgentService {
       this.state,
       this.worktreeInit,
       (input) => this.startAgent(input),
+      () => this.isAgentCoreProvider(),
       agentReview
     );
 
@@ -121,6 +158,46 @@ export class ContainerAgentService {
    */
   setOnAgentComplete(callback: (codespaceId: string, taskId: string) => Promise<void>): void {
     this.onAgentCompleteCallback = callback;
+  }
+
+  /**
+   * Check whether the active sandbox provider is AgentCore.
+   */
+  private isAgentCoreProvider(): boolean {
+    return this.agentCoreProvider !== undefined;
+  }
+
+  /**
+   * Configure the AgentCore sandbox provider.
+   *
+   * theme-04 P1-02: This is a no-op unless `AGENTCORE_ENABLED=true` is set in
+   * the environment. The agentcore-sandbox-provider module (which pulls in
+   * the AWS SDK via dynamic import) is loaded lazily — with the feature flag
+   * off, the module never reaches the module graph.
+   */
+  async setAgentCoreProvider(config: AgentCoreProviderConfig): Promise<void> {
+    if (!isAgentCoreEnabled()) {
+      log.warn(
+        'setAgentCoreProvider called but AGENTCORE_ENABLED is not set — AgentCore is disabled',
+        { data: { region: config.region } }
+      );
+      return;
+    }
+    const { createAgentCoreProvider } = await import(
+      '../../lib/sandbox/providers/agentcore-sandbox-provider.js'
+    );
+    this.agentCoreProvider = createAgentCoreProvider(config);
+    log.info('AgentCore provider configured', {
+      data: { region: config.region, runtimeArn: config.runtimeArn },
+    });
+  }
+
+  /**
+   * Remove the AgentCore provider (switch back to container-based execution).
+   */
+  clearAgentCoreProvider(): void {
+    this.agentCoreProvider = undefined;
+    log.info('AgentCore provider cleared, using container exec path');
   }
 
   /**
@@ -153,10 +230,15 @@ export class ContainerAgentService {
   }
 
   /**
-   * Stop the plan cleanup interval.
+   * Stop the plan cleanup interval and clean up AgentCore resources.
    */
   dispose(): void {
     this.state.dispose();
+    if (this.agentCoreProvider) {
+      this.agentCoreProvider.cleanup().catch((cleanupErr) => {
+        log.warn('AgentCore cleanup failed', { error: cleanupErr });
+      });
+    }
   }
 
   /** Start an agent for a task. */
@@ -171,6 +253,13 @@ export class ContainerAgentService {
     this.state.markStarting(taskId);
 
     try {
+      if (this.isAgentCoreProvider()) {
+        const codespace = await this.deps.db.query.codespaces.findFirst({
+          where: eq(codespaces.id, input.codespaceId),
+        });
+        if (!codespace) return err(SandboxErrors.PROJECT_NOT_FOUND);
+        return this.agentCoreBridge.startAgentCoreAgent(input, codespace);
+      }
       return this.containerExec.startAgent(input);
     } finally {
       this.state.clearStarting(taskId);
@@ -188,6 +277,13 @@ export class ContainerAgentService {
     // Clear starting guard
     this.state.clearStarting(taskId);
 
+    // AgentCore branch
+    const acAgent = this.state.getRunningAgentCoreAgent(taskId);
+    if (acAgent) {
+      return this.agentCoreBridge.stopAgentCoreAgent(acAgent);
+    }
+
+    // Container exec branch
     return this.containerExec.stopAgent(taskId);
   }
 
@@ -216,12 +312,19 @@ export class ContainerAgentService {
     sessionId: string;
     startedAt: Date;
   }> {
-    return this.state.getAllRunningAgents().map((agent) => ({
+    const containerAgents = this.state.getAllRunningAgents().map((agent) => ({
       taskId: agent.taskId,
       codespaceId: agent.codespaceId,
       sessionId: agent.sessionId,
       startedAt: agent.startedAt,
     }));
+    const agentCoreAgents = this.state.getAllRunningAgentCoreAgents().map((agent) => ({
+      taskId: agent.taskId,
+      codespaceId: agent.codespaceId,
+      sessionId: agent.sessionId,
+      startedAt: agent.startedAt,
+    }));
+    return [...containerAgents, ...agentCoreAgents];
   }
 
   /**

--- a/src/services/container-agent/plan-approval.service.ts
+++ b/src/services/container-agent/plan-approval.service.ts
@@ -30,6 +30,7 @@ export class PlanApprovalService {
     private state: SandboxStateManager,
     private worktreeInit: WorktreeInitService,
     private startAgentFn: (input: StartAgentInput) => Promise<Result<void, SandboxError>>,
+    private isAgentCoreProvider: () => boolean,
     private agentReview?: AgentReviewService
   ) {}
 
@@ -55,8 +56,9 @@ export class PlanApprovalService {
       log.warn('Duplicate plan_ready event — plan already pending, ignoring', {
         data: { taskId },
       });
-      // Still clean up running agent map (planning phase is done)
+      // Still clean up running agent maps (planning phase is done)
       this.state.deleteRunningAgent(taskId);
+      this.state.deleteRunningAgentCoreAgent(taskId);
       return;
     }
 
@@ -122,6 +124,7 @@ export class PlanApprovalService {
         );
         this.state.deletePendingPlan(taskId);
         this.state.deleteRunningAgent(taskId);
+        this.state.deleteRunningAgentCoreAgent(taskId);
         return;
       }
     } catch (dbErr) {
@@ -157,13 +160,15 @@ export class PlanApprovalService {
         });
       }
 
-      // Clean up running agent
+      // Clean up running agent (both maps)
       this.state.deleteRunningAgent(taskId);
+      this.state.deleteRunningAgentCoreAgent(taskId);
       return;
     }
 
-    // Clean up running agent (planning phase completed)
+    // Clean up running agent (planning phase completed -- both maps)
     this.state.deleteRunningAgent(taskId);
+    this.state.deleteRunningAgentCoreAgent(taskId);
 
     log.info('Plan persisted and stored, waiting for approval', {
       data: {
@@ -318,6 +323,69 @@ export class PlanApprovalService {
       lastAgentStatus: 'planning',
       ...(executionSkillId ? { skillId: originalSkillId, skillName: originalSkillName } : {}),
     };
+
+    // AgentCore branch
+    if (this.isAgentCoreProvider()) {
+      log.info('Approving plan via AgentCore path', {
+        data: { taskId, sdkSessionId: planData.sdkSessionId },
+      });
+
+      try {
+        // Atomic: move to in_progress + swap skill in one CAS update
+        const [updated] = await db
+          .update(tasks)
+          .set(transitionSet)
+          .where(and(eq(tasks.id, taskId), eq(tasks.column, 'waiting_approval')))
+          .returning();
+
+        if (!updated) {
+          this.state.deletePendingPlan(taskId);
+          log.warn('Plan approval failed — task already moved from waiting_approval', {
+            data: { taskId },
+          });
+          return err(SandboxErrors.PLAN_NOT_FOUND(taskId));
+        }
+      } catch (dbErr) {
+        const errorMessage = dbErr instanceof Error ? dbErr.message : String(dbErr);
+        log.error('Failed to move task to in_progress for execution (AgentCore)', {
+          data: { taskId, error: errorMessage },
+        });
+        return err(SandboxErrors.AGENT_START_FAILED(`DB update failed: ${errorMessage}`));
+      }
+
+      const startResult = await this.startAgentFn({
+        codespaceId: planData.codespaceId,
+        taskId: planData.taskId,
+        sessionId: planData.sessionId,
+        prompt: executionPrompt,
+        phase: 'execute',
+        sdkSessionId: planData.sdkSessionId || undefined,
+      });
+
+      if (!startResult.ok) {
+        // Restore task state + original skill so user can retry approval
+        try {
+          const [restored] = await db
+            .update(tasks)
+            .set(rollbackSet)
+            .where(and(eq(tasks.id, taskId), eq(tasks.column, 'in_progress')))
+            .returning({ id: tasks.id });
+          softInvariant(!!restored, 'task restore expected column in_progress', { taskId });
+        } catch (restoreErr) {
+          log.error('Failed to restore task state after agent start failure', {
+            data: {
+              taskId,
+              error: restoreErr instanceof Error ? restoreErr.message : String(restoreErr),
+            },
+          });
+        }
+        return startResult;
+      }
+
+      // Only delete plan from memory AFTER successful start
+      this.state.deletePendingPlan(taskId);
+      return ok(undefined);
+    }
 
     // Container exec branch: detect sandbox changes, start execution
     let effectiveSdkSessionId: string | undefined = planData.sdkSessionId || undefined;

--- a/src/services/container-agent/sandbox-state.ts
+++ b/src/services/container-agent/sandbox-state.ts
@@ -3,12 +3,13 @@
  *
  * Centralizes:
  * - runningAgents map (Docker/K8s/Nomad container exec path)
+ * - runningAgentCoreAgents map (AgentCore invoke + SSE path)
  * - pendingPlans map (plans awaiting user approval)
  * - startingAgents set (prevents concurrent startAgent races)
  */
 
 import { createLogger } from '../../lib/logging/logger.js';
-import type { PlanData, RunningAgent } from './types.js';
+import type { PlanData, RunningAgent, RunningAgentCoreAgent } from './types.js';
 import { PENDING_PLAN_TTL_MS, PLAN_CLEANUP_INTERVAL_MS } from './types.js';
 
 const log = createLogger('SandboxStateManager');
@@ -16,6 +17,9 @@ const log = createLogger('SandboxStateManager');
 export class SandboxStateManager {
   /** Map of taskId -> running agent (Docker/K8s/Nomad) */
   private runningAgents = new Map<string, RunningAgent>();
+
+  /** Map of taskId -> running AgentCore agent */
+  private runningAgentCoreAgents = new Map<string, RunningAgentCoreAgent>();
 
   /** Map of taskId -> pending plan data (awaiting approval) */
   private pendingPlans = new Map<string, PlanData>();
@@ -68,19 +72,50 @@ export class SandboxStateManager {
   }
 
   // ---------------------------------------------------------------------------
-  // Combined helpers
+  // Running agents (AgentCore path)
   // ---------------------------------------------------------------------------
 
-  /** Check if a task has any running agent */
-  hasAnyRunningAgent(taskId: string): boolean {
-    return this.runningAgents.has(taskId);
+  getRunningAgentCoreAgent(taskId: string): RunningAgentCoreAgent | undefined {
+    return this.runningAgentCoreAgents.get(taskId);
   }
 
-  /** Get running agent info */
+  setRunningAgentCoreAgent(taskId: string, agent: RunningAgentCoreAgent): void {
+    if (this.runningAgentCoreAgents.has(taskId)) {
+      log.warn('Overwriting existing running AgentCore agent entry', { data: { taskId } });
+    }
+    this.runningAgentCoreAgents.set(taskId, agent);
+  }
+
+  deleteRunningAgentCoreAgent(taskId: string): boolean {
+    return this.runningAgentCoreAgents.delete(taskId);
+  }
+
+  hasRunningAgentCoreAgent(taskId: string): boolean {
+    return this.runningAgentCoreAgents.has(taskId);
+  }
+
+  get runningAgentCoreAgentCount(): number {
+    return this.runningAgentCoreAgents.size;
+  }
+
+  getAllRunningAgentCoreAgents(): RunningAgentCoreAgent[] {
+    return Array.from(this.runningAgentCoreAgents.values());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Combined helpers (both maps)
+  // ---------------------------------------------------------------------------
+
+  /** Check if a task has any running agent (container or AgentCore) */
+  hasAnyRunningAgent(taskId: string): boolean {
+    return this.runningAgents.has(taskId) || this.runningAgentCoreAgents.has(taskId);
+  }
+
+  /** Get running agent info from either map */
   getAnyRunningAgent(
     taskId: string
   ): { codespaceId: string; sessionId: string; startedAt: Date } | null {
-    const agent = this.runningAgents.get(taskId);
+    const agent = this.runningAgents.get(taskId) ?? this.runningAgentCoreAgents.get(taskId);
     if (!agent) return null;
     return {
       codespaceId: agent.codespaceId,
@@ -89,9 +124,9 @@ export class SandboxStateManager {
     };
   }
 
-  /** Total count of running agents */
+  /** Total count of all running agents across both maps */
   get totalRunningAgentCount(): number {
-    return this.runningAgents.size;
+    return this.runningAgents.size + this.runningAgentCoreAgents.size;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/services/container-agent/shared-helpers.ts
+++ b/src/services/container-agent/shared-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Shared helper functions for the container-agent sub-services.
  *
- * Deduplicates common patterns used across container-exec service:
+ * Deduplicates common patterns used across container-exec and agentcore-bridge services:
  * - Task status updates on agent completion
  * - Task status updates on agent error
  * - OAuth token resolution

--- a/src/services/container-agent/types.ts
+++ b/src/services/container-agent/types.ts
@@ -3,7 +3,9 @@
  */
 
 import type { StoredPlanOptions } from '../../db/schema';
+import type { AgentCoreBridge } from '../../lib/agents/agentcore-bridge.js';
 import type { ContainerBridge } from '../../lib/agents/container-bridge.js';
+import type { AgentCoreSandboxInstance } from '../../lib/sandbox/providers/agentcore-sandbox-instance.js';
 import type { ExecStreamResult } from '../../lib/sandbox/providers/sandbox-provider.js';
 
 /**
@@ -55,6 +57,23 @@ export interface RunningAgent {
   /** Guard flag: set to true once handleAgentComplete/handleAgentError begins processing.
    *  Prevents the processAgentOutput exit-code path from racing against the bridge callback. */
   completionHandled?: boolean;
+}
+
+/**
+ * Running agent instance for AgentCore (invoke + SSE path -- no container exec).
+ */
+export interface RunningAgentCoreAgent {
+  taskId: string;
+  sessionId: string;
+  codespaceId: string;
+  sandboxId: string;
+  bridge: AgentCoreBridge;
+  instance: AgentCoreSandboxInstance;
+  runtimeSessionId: string;
+  startedAt: Date;
+  stopRequested: boolean;
+  phase: AgentPhase;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
 }
 
 /**

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -505,8 +505,8 @@ describe('Enum Constants', () => {
     expect(SANDBOX_TYPES).toContain('docker');
     expect(SANDBOX_TYPES).toContain('kubernetes');
     expect(SANDBOX_TYPES).toContain('nomad');
-    expect(SANDBOX_TYPES).toContain('devcontainer');
-    expect(SANDBOX_TYPES).toHaveLength(4);
+    expect(SANDBOX_TYPES).toContain('agentcore');
+    expect(SANDBOX_TYPES).toHaveLength(5);
   });
 
   it('RBAC_ROLES contains expected roles', () => {

--- a/tests/functional/prove-plan-approval-bugs.test.ts
+++ b/tests/functional/prove-plan-approval-bugs.test.ts
@@ -48,6 +48,7 @@ function createPlanApprovalService(
   stateManager: SandboxStateManager,
   overrides: {
     startAgentFn?: ReturnType<typeof vi.fn>;
+    isAgentCoreProvider?: () => boolean;
     mockWorktreeInit?: ReturnType<typeof createMockWorktreeInit>;
     mockProvider?: { get: ReturnType<typeof vi.fn> };
   } = {}
@@ -61,7 +62,8 @@ function createPlanApprovalService(
     { db, streams, provider: mockProvider as any } as any,
     stateManager,
     mockWorktreeInit as any,
-    mockStartAgentFn
+    mockStartAgentFn,
+    overrides.isAgentCoreProvider ?? (() => false)
   );
 
   return { planService, mockStartAgentFn, mockWorktreeInit, mockProvider };
@@ -603,6 +605,41 @@ describe('Prove/Disprove Plan Approval Bugs', () => {
       // 2. lastAgentStatus is restored to 'planning'
       // 3. The pending plan is NOT deleted from memory (only deleted on success)
       // This allows the user to retry the approval.
+    });
+
+    it('approvePlan via AgentCore path also restores on failure', async () => {
+      const codespace = await createTestProject({ name: 'AgentCore Restore Test' });
+      const task = await createTestTask(codespace.id, {
+        column: 'in_progress',
+        title: 'Task for AgentCore restore test',
+      });
+
+      const mockStartAgentFn = vi.fn().mockResolvedValue({
+        ok: false,
+        error: { code: 'SANDBOX_AGENT_START_FAILED', message: 'AgentCore invoke failed' },
+      });
+
+      const { planService } = createPlanApprovalService(db, streams, stateManager, {
+        startAgentFn: mockStartAgentFn,
+        isAgentCoreProvider: () => true,
+      });
+
+      // Store plan
+      await planService.handlePlanReady(
+        task.id,
+        'session-ac',
+        codespace.id,
+        makePlanData({ plan: 'AgentCore plan' })
+      );
+
+      // Approve via AgentCore path
+      const approveResult = await planService.approvePlan(task.id);
+      expect(approveResult.ok).toBe(false);
+
+      // Task should be restored
+      const taskAfter = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+      expect(taskAfter!.column).toBe('waiting_approval');
+      expect(taskAfter!.lastAgentStatus).toBe('planning');
     });
 
     it('plan remains available for retry after startAgentFn failure', async () => {

--- a/tests/functional/state-guard-vulnerabilities.test.ts
+++ b/tests/functional/state-guard-vulnerabilities.test.ts
@@ -124,7 +124,8 @@ function createPlanApprovalService(
     { db, streams, provider: { get: vi.fn() } as any },
     stateManager,
     mockWorktreeInit as any,
-    mockStartAgentFn
+    mockStartAgentFn,
+    () => false
   );
 
   return { planService, mockStartAgentFn, mockWorktreeInit };
@@ -1035,7 +1036,8 @@ describe('State Machine Guard Vulnerabilities', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      failingStartAgentFn
+      failingStartAgentFn,
+      () => false
     );
 
     // Store plan via real handlePlanReady

--- a/tests/functional/task-lifecycle-advanced.test.ts
+++ b/tests/functional/task-lifecycle-advanced.test.ts
@@ -127,7 +127,8 @@ describe('Advanced Task Lifecycle Scenarios', () => {
       { db, streams, provider: mockProvider as any },
       stateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn
+      mockStartAgentFn,
+      () => false // not AgentCore -- use the container exec branch
     );
 
     // Store plan via real handlePlanReady (captures sandbox-original-123 from running agent)
@@ -196,7 +197,8 @@ describe('Advanced Task Lifecycle Scenarios', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn
+      mockStartAgentFn,
+      () => false
     );
 
     // Store plan via real handlePlanReady (persists to DB + in-memory)
@@ -227,7 +229,8 @@ describe('Advanced Task Lifecycle Scenarios', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       freshStateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn2
+      mockStartAgentFn2,
+      () => false
     );
 
     // Call approvePlan -- should recover plan from DB
@@ -274,7 +277,8 @@ describe('Advanced Task Lifecycle Scenarios', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn
+      mockStartAgentFn,
+      () => false
     );
 
     // Store plan via real handlePlanReady
@@ -344,7 +348,8 @@ describe('Advanced Task Lifecycle Scenarios', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn
+      mockStartAgentFn,
+      () => false
     );
 
     // Store plan via real handlePlanReady

--- a/tests/functional/task-lifecycle-e2e.test.ts
+++ b/tests/functional/task-lifecycle-e2e.test.ts
@@ -192,7 +192,8 @@ describe('Functional E2E: Real Service Transitions', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn
+      mockStartAgentFn,
+      () => false // not AgentCore
     );
 
     // Process the plan_ready event through the real container bridge.
@@ -366,7 +367,8 @@ describe('Functional E2E: Real Service Transitions', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      vi.fn().mockResolvedValue({ ok: true })
+      vi.fn().mockResolvedValue({ ok: true }),
+      () => false
     );
 
     // Store plan via real handlePlanReady
@@ -445,7 +447,8 @@ describe('Functional E2E: Real Service Transitions', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      mockStartAgentFn
+      mockStartAgentFn,
+      () => false
     );
 
     // ── Round 1: Move → Plan → Reject ──
@@ -573,7 +576,8 @@ describe('Functional E2E: Real Service Transitions', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      vi.fn().mockResolvedValue({ ok: true })
+      vi.fn().mockResolvedValue({ ok: true }),
+      () => false
     );
 
     await planService.handlePlanReady(taskId, 'session-bug', codespace.id, {
@@ -623,7 +627,8 @@ describe('Functional E2E: Real Service Transitions', () => {
       { db, streams, provider: { get: vi.fn() } as any },
       stateManager,
       mockWorktreeInit as any,
-      vi.fn().mockResolvedValue({ ok: true })
+      vi.fn().mockResolvedValue({ ok: true }),
+      () => false
     );
 
     await planService.handlePlanReady(taskId, 'session-bug2', codespace.id, {

--- a/tests/integration/agentcore-bridge-service.test.ts
+++ b/tests/integration/agentcore-bridge-service.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Integration tests for AgentCoreBridgeService — the AgentCore-specific execution pathway.
+ *
+ * Tests verify agent start via AgentCore invoke + SSE, stop, completion handling,
+ * error handling, and fallback to ContainerExecService.
+ * Uses real SQLite DB for state verification.
+ */
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agents, sessions, tasks } from '../../src/db/schema';
+import { createTestProject } from '../factories/project.factory';
+import { createTestTask } from '../factories/task.factory';
+import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Mock the agentcore-bridge module
+vi.mock('../../src/lib/agents/agentcore-bridge.js', () => ({
+  createAgentCoreBridge: vi.fn(() => ({
+    processStream: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+  })),
+}));
+
+// Mock settings service
+vi.mock('../../src/services/settings.service.js', () => ({
+  getGlobalDefaultModel: vi.fn().mockResolvedValue('claude-sonnet-4-6'),
+  getAgentMaxRuntimeMs: vi.fn().mockResolvedValue(4 * 60 * 60 * 1000),
+}));
+
+// Mock shared helpers
+vi.mock('../../src/services/container-agent/shared-helpers.js', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../../src/services/container-agent/shared-helpers.js')>();
+  return {
+    ...original,
+    resolveOAuthToken: vi.fn().mockResolvedValue('mock-oauth-token'),
+    updateAgentStatus: vi.fn().mockResolvedValue(undefined),
+    updateTaskOnAgentComplete: vi.fn().mockResolvedValue(true),
+    updateTaskOnAgentError: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Suppress logger output
+vi.mock('../../src/lib/logging/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock constants
+vi.mock('../../src/lib/constants/models.js', () => ({
+  DEFAULT_AGENT_MODEL: 'claude-sonnet-4-6',
+  getFullModelId: (id: string) => id,
+}));
+
+// Import after mocks
+import { AgentCoreBridgeService } from '../../src/services/container-agent/agentcore-bridge.service';
+import { SandboxStateManager } from '../../src/services/container-agent/sandbox-state';
+import {
+  resolveOAuthToken,
+  updateAgentStatus,
+  updateTaskOnAgentComplete,
+  updateTaskOnAgentError,
+} from '../../src/services/container-agent/shared-helpers.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createMockStreams() {
+  return {
+    createStream: vi.fn().mockResolvedValue(undefined),
+    publish: vi.fn().mockResolvedValue(undefined),
+    deleteStream: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockProvider() {
+  const mockInstance = {
+    invoke: vi.fn().mockReturnValue(
+      (async function* () {
+        yield { type: 'status', data: { stage: 'running' } };
+      })()
+    ),
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    provider: {
+      get: vi.fn().mockReturnValue(mockInstance),
+      create: vi.fn().mockReturnValue(mockInstance),
+      getOrCreateSession: vi.fn().mockReturnValue('runtime-session-1'),
+      removeSession: vi.fn(),
+    },
+    instance: mockInstance,
+  };
+}
+
+function createMockContainerExec() {
+  return {
+    handleAgentComplete: vi.fn().mockResolvedValue(undefined),
+    handleAgentError: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockApiKeyService() {
+  return {
+    getApiKey: vi.fn().mockResolvedValue('test-api-key'),
+    getDecryptedKey: vi.fn().mockResolvedValue('sk-ant-oat01-test-token'),
+    // F03-09 (arch29-W2-C): default to null (no refresh token stored).
+    getDecryptedRefreshToken: vi.fn().mockResolvedValue(null),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AgentCoreBridgeService (IT-1650 to IT-1651)', () => {
+  let db: ReturnType<typeof getTestDb>;
+  let state: SandboxStateManager;
+  let mockStreams: ReturnType<typeof createMockStreams>;
+  let mockProviderSetup: ReturnType<typeof createMockProvider>;
+  let mockContainerExec: ReturnType<typeof createMockContainerExec>;
+  let service: AgentCoreBridgeService;
+
+  beforeEach(async () => {
+    await setupTestDatabase();
+    db = getTestDb();
+    state = new SandboxStateManager();
+    mockStreams = createMockStreams();
+    mockProviderSetup = createMockProvider();
+    mockContainerExec = createMockContainerExec();
+
+    const deps = {
+      db,
+      provider: {} as never, // Not used by AgentCoreBridgeService directly
+      streams: mockStreams as never,
+      apiKeyService: createMockApiKeyService() as never,
+    };
+
+    service = new AgentCoreBridgeService(
+      deps,
+      state,
+      mockContainerExec as never,
+      () => mockProviderSetup.provider as never,
+      vi.fn().mockResolvedValue(undefined),
+      () => undefined
+    );
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+    vi.clearAllMocks();
+    // Cleanup state manager interval
+    state.dispose();
+  });
+
+  describe('startAgentCoreAgent', () => {
+    it('IT-1650: happy path — creates agent, session, publishes status events, returns ok', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, {
+        column: 'in_progress',
+        title: 'Test task',
+      });
+
+      const result = await service.startAgentCoreAgent(
+        {
+          codespaceId: codespace.id,
+          taskId: task.id,
+          sessionId: 'session-ac-1',
+          prompt: 'Implement feature',
+          phase: 'plan',
+        },
+        {
+          id: codespace.id,
+          name: codespace.name,
+          path: codespace.path,
+          config: null,
+        }
+      );
+
+      expect(result.ok).toBe(true);
+
+      // Verify agent record created in DB
+      const agent = await db.query.agents.findFirst({
+        where: eq(agents.id, `agent-${task.id}`),
+      });
+      expect(agent).toBeDefined();
+      expect(agent!.codespaceId).toBe(codespace.id);
+
+      // Verify session record created in DB
+      const session = await db.query.sessions.findFirst({
+        where: eq(sessions.id, 'session-ac-1'),
+      });
+      expect(session).toBeDefined();
+      expect(session!.sandboxProvider).toBe('agentcore');
+
+      // Verify task linked to agent and session
+      const updatedTask = await db.query.tasks.findFirst({
+        where: eq(tasks.id, task.id),
+      });
+      expect(updatedTask!.agentId).toBe(`agent-${task.id}`);
+      expect(updatedTask!.sessionId).toBe('session-ac-1');
+
+      // Verify status events published
+      const statusCalls = mockStreams.publish.mock.calls.filter(
+        (call: unknown[]) => (call[1] as string) === 'container-agent:status'
+      );
+      expect(statusCalls.length).toBeGreaterThanOrEqual(3); // initializing, validating, executing
+
+      // Verify started event published (proves agent was set in state and execution began)
+      const startedCalls = mockStreams.publish.mock.calls.filter(
+        (call: unknown[]) => (call[1] as string) === 'container-agent:started'
+      );
+      expect(startedCalls.length).toBe(1);
+
+      // Note: hasRunningAgentCoreAgent may be false by now because
+      // processAgentCoreOutput runs asynchronously and the bridge mock
+      // resolves immediately, triggering cleanup. The "started" event
+      // above confirms the agent was properly tracked.
+    });
+
+    it('IT-1652: returns error when provider is undefined', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, { column: 'in_progress' });
+
+      // Create service with null provider
+      const deps = {
+        db,
+        provider: {} as never,
+        streams: mockStreams as never,
+        apiKeyService: createMockApiKeyService() as never,
+      };
+      const serviceNoProvider = new AgentCoreBridgeService(
+        deps,
+        state,
+        mockContainerExec as never,
+        () => undefined, // No provider
+        vi.fn().mockResolvedValue(undefined),
+        () => undefined
+      );
+
+      const result = await serviceNoProvider.startAgentCoreAgent(
+        {
+          codespaceId: codespace.id,
+          taskId: task.id,
+          sessionId: 'session-no-provider',
+          prompt: 'Test',
+        },
+        { id: codespace.id, name: codespace.name, path: codespace.path }
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('removed');
+      }
+    });
+
+    it('IT-1653: returns error when task not found', async () => {
+      const codespace = await createTestProject();
+
+      const result = await service.startAgentCoreAgent(
+        {
+          codespaceId: codespace.id,
+          taskId: 'nonexistent-task',
+          sessionId: 'session-no-task',
+          prompt: 'Test',
+        },
+        { id: codespace.id, name: codespace.name, path: codespace.path }
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('not found');
+      }
+    });
+
+    it('IT-1654: returns error when no OAuth token available', async () => {
+      const codespace = await createTestProject();
+      const task = await createTestTask(codespace.id, { column: 'in_progress' });
+
+      // Override resolveOAuthToken to return null
+      vi.mocked(resolveOAuthToken).mockResolvedValueOnce(null);
+
+      const result = await service.startAgentCoreAgent(
+        {
+          codespaceId: codespace.id,
+          taskId: task.id,
+          sessionId: 'session-no-oauth',
+          prompt: 'Test',
+        },
+        { id: codespace.id, name: codespace.name, path: codespace.path }
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toContain('API_KEY');
+      }
+    });
+  });
+
+  describe('stopAgentCoreAgent', () => {
+    it('IT-1655: stops bridge, instance, removes session, publishes cancelled', async () => {
+      const mockBridge = { processStream: vi.fn(), stop: vi.fn() };
+      const mockInstance = { invoke: vi.fn(), stop: vi.fn().mockResolvedValue(undefined) };
+
+      const agent = {
+        taskId: 'task-stop-1',
+        sessionId: 'session-stop-1',
+        codespaceId: 'cs-1',
+        sandboxId: 'sb-1',
+        bridge: mockBridge,
+        instance: mockInstance,
+        runtimeSessionId: 'runtime-1',
+        startedAt: new Date(),
+        stopRequested: false,
+        phase: 'plan' as const,
+      };
+
+      state.setRunningAgentCoreAgent('task-stop-1', agent as never);
+
+      const result = await service.stopAgentCoreAgent(agent as never);
+
+      expect(result.ok).toBe(true);
+      expect(agent.stopRequested).toBe(true);
+      expect(mockBridge.stop).toHaveBeenCalled();
+      expect(mockInstance.stop).toHaveBeenCalled();
+      expect(mockProviderSetup.provider.removeSession).toHaveBeenCalledWith('task-stop-1');
+
+      // Verify cancelled event published
+      const cancelledCalls = mockStreams.publish.mock.calls.filter(
+        (call: unknown[]) => (call[1] as string) === 'container-agent:cancelled'
+      );
+      expect(cancelledCalls.length).toBe(1);
+
+      // Verify state cleaned up
+      expect(state.hasRunningAgentCoreAgent('task-stop-1')).toBe(false);
+    });
+  });
+
+  describe('handleAgentCoreComplete', () => {
+    it('IT-1656: updates task via shared helper, cleans up state, triggers auto-dequeue', async () => {
+      const mockBridge = { processStream: vi.fn(), stop: vi.fn() };
+      const mockInstance = { invoke: vi.fn(), stop: vi.fn() };
+
+      const onCompleteCallback = vi.fn().mockResolvedValue(undefined);
+      const deps = {
+        db,
+        provider: {} as never,
+        streams: mockStreams as never,
+        apiKeyService: createMockApiKeyService() as never,
+      };
+      const serviceWithCallback = new AgentCoreBridgeService(
+        deps,
+        state,
+        mockContainerExec as never,
+        () => mockProviderSetup.provider as never,
+        vi.fn().mockResolvedValue(undefined),
+        () => onCompleteCallback
+      );
+
+      const agent = {
+        taskId: 'task-complete-1',
+        sessionId: 'session-complete-1',
+        codespaceId: 'cs-complete-1',
+        sandboxId: 'sb-complete-1',
+        bridge: mockBridge,
+        instance: mockInstance,
+        runtimeSessionId: 'runtime-complete-1',
+        startedAt: new Date(),
+        stopRequested: false,
+        phase: 'execute' as const,
+      };
+      state.setRunningAgentCoreAgent('task-complete-1', agent as never);
+
+      await serviceWithCallback.handleAgentCoreComplete('task-complete-1', 'completed', 5);
+
+      // Verify shared helper called
+      expect(updateTaskOnAgentComplete).toHaveBeenCalledWith(
+        db,
+        'task-complete-1',
+        'completed',
+        expect.anything(),
+        'session-complete-1',
+        undefined
+      );
+
+      // Verify agent status updated
+      expect(updateAgentStatus).toHaveBeenCalledWith(db, 'task-complete-1', 'completed');
+
+      // Verify state cleaned up
+      expect(state.hasRunningAgentCoreAgent('task-complete-1')).toBe(false);
+
+      // Verify auto-dequeue callback invoked
+      expect(onCompleteCallback).toHaveBeenCalledWith('cs-complete-1', 'task-complete-1');
+    });
+
+    it('IT-1657: falls back to containerExec when agent not in AgentCore map', async () => {
+      // Don't add any running agent to state
+      await service.handleAgentCoreComplete('task-fallback-1', 'completed', 3);
+
+      expect(mockContainerExec.handleAgentComplete).toHaveBeenCalledWith(
+        'task-fallback-1',
+        'completed',
+        3
+      );
+    });
+
+    it('IT-1658: cancelled status does NOT trigger auto-dequeue', async () => {
+      const onCompleteCallback = vi.fn().mockResolvedValue(undefined);
+      const deps = {
+        db,
+        provider: {} as never,
+        streams: mockStreams as never,
+        apiKeyService: createMockApiKeyService() as never,
+      };
+      const serviceWithCallback = new AgentCoreBridgeService(
+        deps,
+        state,
+        mockContainerExec as never,
+        () => mockProviderSetup.provider as never,
+        vi.fn().mockResolvedValue(undefined),
+        () => onCompleteCallback
+      );
+
+      const agent = {
+        taskId: 'task-cancel-1',
+        sessionId: 'session-cancel-1',
+        codespaceId: 'cs-cancel-1',
+        sandboxId: 'sb-cancel-1',
+        bridge: { processStream: vi.fn(), stop: vi.fn() },
+        instance: { invoke: vi.fn(), stop: vi.fn() },
+        runtimeSessionId: 'rt-cancel-1',
+        startedAt: new Date(),
+        stopRequested: false,
+        phase: 'execute' as const,
+      };
+      state.setRunningAgentCoreAgent('task-cancel-1', agent as never);
+
+      await serviceWithCallback.handleAgentCoreComplete('task-cancel-1', 'cancelled', 0);
+
+      // Auto-dequeue should NOT be called for cancelled
+      expect(onCompleteCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleAgentCoreError', () => {
+    it('IT-1659: cleans up state and updates task on error', async () => {
+      const mockBridge = { processStream: vi.fn(), stop: vi.fn() };
+      const mockInstance = { invoke: vi.fn(), stop: vi.fn() };
+
+      const agent = {
+        taskId: 'task-error-1',
+        sessionId: 'session-error-1',
+        codespaceId: 'cs-error-1',
+        sandboxId: 'sb-error-1',
+        bridge: mockBridge,
+        instance: mockInstance,
+        runtimeSessionId: 'rt-error-1',
+        startedAt: new Date(),
+        stopRequested: false,
+        phase: 'plan' as const,
+      };
+      state.setRunningAgentCoreAgent('task-error-1', agent as never);
+
+      await service.handleAgentCoreError('task-error-1', 'Stream failed', 2);
+
+      // Verify shared helper called
+      expect(updateTaskOnAgentError).toHaveBeenCalledWith(
+        db,
+        'task-error-1',
+        expect.anything(),
+        'session-error-1'
+      );
+
+      // Verify agent status updated
+      expect(updateAgentStatus).toHaveBeenCalledWith(db, 'task-error-1', 'error');
+
+      // Verify state cleaned up
+      expect(state.hasRunningAgentCoreAgent('task-error-1')).toBe(false);
+    });
+
+    it('IT-1651: falls back to containerExec when agent not in AgentCore map', async () => {
+      await service.handleAgentCoreError('task-fallback-err', 'Unknown error', 0);
+
+      expect(mockContainerExec.handleAgentError).toHaveBeenCalledWith(
+        'task-fallback-err',
+        'Unknown error',
+        0
+      );
+    });
+  });
+});

--- a/tests/integration/container-agent-service.test.ts
+++ b/tests/integration/container-agent-service.test.ts
@@ -77,14 +77,14 @@ describe('ContainerAgentService — DB-level integration tests', () => {
       .where(eq(sessions.id, session1.id));
     await db
       .update(sessions)
-      .set({ sandboxProvider: 'kubernetes' })
+      .set({ sandboxProvider: 'agentcore' })
       .where(eq(sessions.id, session2.id));
 
     const dbSession1 = await db.query.sessions.findFirst({ where: eq(sessions.id, session1.id) });
     const dbSession2 = await db.query.sessions.findFirst({ where: eq(sessions.id, session2.id) });
 
     expect(dbSession1?.sandboxProvider).toBe('docker');
-    expect(dbSession2?.sandboxProvider).toBe('kubernetes');
+    expect(dbSession2?.sandboxProvider).toBe('agentcore');
   });
 
   it('IT-104: simulates agent stop — clears currentTaskId and sets status to idle', async () => {

--- a/tests/integration/container-agent-services.test.ts
+++ b/tests/integration/container-agent-services.test.ts
@@ -3,7 +3,8 @@ import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { agents, sessions, tasks } from '../../src/db/schema';
 import { CONTAINER_WORKSPACE_PATH } from '../../src/lib/constants/sandbox';
-// Explicit imports for coverage gap detection (container-exec.service)
+// Explicit imports for coverage gap detection (agentcore-bridge.service, container-exec.service)
+import type {} from '../../src/services/container-agent/agentcore-bridge.service';
 import type {} from '../../src/services/container-agent/container-exec.service';
 import { SandboxStateManager } from '../../src/services/container-agent/sandbox-state';
 import {
@@ -13,7 +14,11 @@ import {
   updateTaskOnAgentComplete,
   updateTaskOnAgentError,
 } from '../../src/services/container-agent/shared-helpers';
-import type { PlanData, RunningAgent } from '../../src/services/container-agent/types';
+import type {
+  PlanData,
+  RunningAgent,
+  RunningAgentCoreAgent,
+} from '../../src/services/container-agent/types';
 import { PENDING_PLAN_TTL_MS } from '../../src/services/container-agent/types';
 import { WorktreeInitService } from '../../src/services/container-agent/worktree-init.service';
 import { createTestAgent } from '../factories/agent.factory';
@@ -472,9 +477,84 @@ describe('SandboxStateManager (IT-305)', () => {
     expect(all).toContain(agent2);
   });
 
+  // -- Running AgentCore agents --
+
+  it('IT-305e: stores and retrieves AgentCore agents by taskId', () => {
+    const acAgent: RunningAgentCoreAgent = {
+      taskId: 'ac-task-1',
+      sessionId: 'ac-session-1',
+      codespaceId: 'ac-cs-1',
+      sandboxId: 'agentcore-ac-cs-1',
+      bridge: {} as any,
+      instance: {} as any,
+      runtimeSessionId: 'runtime-1',
+      startedAt: new Date(),
+      stopRequested: false,
+      phase: 'plan',
+    };
+
+    state.setRunningAgentCoreAgent('ac-task-1', acAgent);
+
+    expect(state.hasRunningAgentCoreAgent('ac-task-1')).toBe(true);
+    expect(state.getRunningAgentCoreAgent('ac-task-1')).toBe(acAgent);
+    expect(state.runningAgentCoreAgentCount).toBe(1);
+  });
+
+  it('IT-305f: deletes AgentCore agent', () => {
+    const acAgent: RunningAgentCoreAgent = {
+      taskId: 'ac-task-2',
+      sessionId: 'ac-session-2',
+      codespaceId: 'ac-cs-2',
+      sandboxId: 'agentcore-ac-cs-2',
+      bridge: {} as any,
+      instance: {} as any,
+      runtimeSessionId: 'runtime-2',
+      startedAt: new Date(),
+      stopRequested: false,
+      phase: 'execute',
+    };
+
+    state.setRunningAgentCoreAgent('ac-task-2', acAgent);
+    expect(state.deleteRunningAgentCoreAgent('ac-task-2')).toBe(true);
+    expect(state.hasRunningAgentCoreAgent('ac-task-2')).toBe(false);
+    expect(state.runningAgentCoreAgentCount).toBe(0);
+  });
+
+  it('IT-305g: getAllRunningAgentCoreAgents returns all AgentCore entries', () => {
+    const a1: RunningAgentCoreAgent = {
+      taskId: 'act-1',
+      sessionId: 's1',
+      codespaceId: 'c1',
+      sandboxId: 'sb1',
+      bridge: {} as any,
+      instance: {} as any,
+      runtimeSessionId: 'r1',
+      startedAt: new Date(),
+      stopRequested: false,
+      phase: 'plan',
+    };
+    const a2: RunningAgentCoreAgent = {
+      taskId: 'act-2',
+      sessionId: 's2',
+      codespaceId: 'c2',
+      sandboxId: 'sb2',
+      bridge: {} as any,
+      instance: {} as any,
+      runtimeSessionId: 'r2',
+      startedAt: new Date(),
+      stopRequested: false,
+      phase: 'execute',
+    };
+
+    state.setRunningAgentCoreAgent('act-1', a1);
+    state.setRunningAgentCoreAgent('act-2', a2);
+
+    expect(state.getAllRunningAgentCoreAgents()).toHaveLength(2);
+  });
+
   // -- Combined helpers --
 
-  it('IT-305h: hasAnyRunningAgent checks the running-agents map', () => {
+  it('IT-305h: hasAnyRunningAgent checks both maps', () => {
     expect(state.hasAnyRunningAgent('x')).toBe(false);
 
     state.setRunningAgent('x', {
@@ -490,6 +570,20 @@ describe('SandboxStateManager (IT-305)', () => {
       phase: 'plan',
     });
     expect(state.hasAnyRunningAgent('x')).toBe(true);
+
+    state.setRunningAgentCoreAgent('y', {
+      taskId: 'y',
+      sessionId: 'sy',
+      codespaceId: 'cy',
+      sandboxId: 'sby',
+      bridge: {} as any,
+      instance: {} as any,
+      runtimeSessionId: 'ry',
+      startedAt: new Date(),
+      stopRequested: false,
+      phase: 'plan',
+    });
+    expect(state.hasAnyRunningAgent('y')).toBe(true);
   });
 
   it('IT-305i: getAnyRunningAgent returns info from either map', () => {
@@ -517,7 +611,7 @@ describe('SandboxStateManager (IT-305)', () => {
     });
   });
 
-  it('IT-305j: totalRunningAgentCount counts running agents', () => {
+  it('IT-305j: totalRunningAgentCount sums both maps', () => {
     expect(state.totalRunningAgentCount).toBe(0);
 
     state.setRunningAgent('a', {
@@ -532,14 +626,14 @@ describe('SandboxStateManager (IT-305)', () => {
       stopRequested: false,
       phase: 'plan',
     });
-    state.setRunningAgent('b', {
+    state.setRunningAgentCoreAgent('b', {
       taskId: 'b',
       sessionId: 'sb',
       codespaceId: 'cb',
       sandboxId: 'sbb',
       bridge: {} as any,
-      execResult: {} as any,
-      stopFilePath: '/tmp/stop-b',
+      instance: {} as any,
+      runtimeSessionId: 'rb',
       startedAt: new Date(),
       stopRequested: false,
       phase: 'plan',
@@ -1095,6 +1189,197 @@ describe('WorktreeInitService (IT-306)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// AgentCoreBridgeService — DB-level integration
+// ---------------------------------------------------------------------------
+
+describe('AgentCoreBridgeService — DB-level state (IT-307)', () => {
+  beforeEach(async () => {
+    await setupTestDatabase();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+  });
+
+  it('IT-307a: creates agent and session records with correct fields for agentcore', async () => {
+    const db = getTestDb();
+    const codespace = await createTestProject();
+    const task = await createTestTask(codespace.id, {
+      column: 'in_progress',
+      title: 'AgentCore Task',
+    });
+
+    const agentId = `agent-${task.id}`;
+    const sessionId = createId();
+
+    // Simulate what AgentCoreBridgeService.startAgentCoreAgent does at the DB level
+    await db
+      .insert(agents)
+      .values({
+        id: agentId,
+        codespaceId: codespace.id,
+        name: 'AgentCore Agent',
+        type: 'task',
+        status: 'starting',
+        currentTaskId: task.id,
+        currentSessionId: sessionId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      .onConflictDoUpdate({
+        target: agents.id,
+        set: {
+          status: 'starting',
+          currentTaskId: task.id,
+          currentSessionId: sessionId,
+        },
+      });
+
+    await db.insert(sessions).values({
+      id: sessionId,
+      codespaceId: codespace.id,
+      taskId: task.id,
+      agentId,
+      title: task.title ?? `AgentCore Agent - ${task.id}`,
+      url: `/codespaces/${codespace.id}/sessions/${sessionId}`,
+      status: 'active',
+      sandboxProvider: 'agentcore',
+      sandboxContainerId: null,
+      createdAt: new Date().toISOString(),
+    });
+
+    await db.update(tasks).set({ agentId, sessionId }).where(eq(tasks.id, task.id));
+
+    // Verify all records
+    const dbAgent = await db.query.agents.findFirst({ where: eq(agents.id, agentId) });
+    expect(dbAgent?.name).toBe('AgentCore Agent');
+    expect(dbAgent?.type).toBe('task');
+    expect(dbAgent?.status).toBe('starting');
+    expect(dbAgent?.currentTaskId).toBe(task.id);
+
+    const dbSession = await db.query.sessions.findFirst({ where: eq(sessions.id, sessionId) });
+    expect(dbSession?.sandboxProvider).toBe('agentcore');
+    expect(dbSession?.sandboxContainerId).toBeNull();
+    expect(dbSession?.agentId).toBe(agentId);
+    expect(dbSession?.taskId).toBe(task.id);
+
+    const dbTask = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+    expect(dbTask?.agentId).toBe(agentId);
+    expect(dbTask?.sessionId).toBe(sessionId);
+  });
+
+  it('IT-307b: agent record upsert works (onConflictDoUpdate)', async () => {
+    const db = getTestDb();
+    const codespace = await createTestProject();
+    const task1 = await createTestTask(codespace.id, { column: 'in_progress' });
+    const task2 = await createTestTask(codespace.id, { column: 'in_progress' });
+
+    const agentId = `agent-${task1.id}`;
+
+    // First insert
+    await db.insert(agents).values({
+      id: agentId,
+      codespaceId: codespace.id,
+      name: 'AgentCore Agent',
+      type: 'task',
+      status: 'starting',
+      currentTaskId: task1.id,
+      currentSessionId: 'session-1',
+    });
+
+    // Upsert with different task
+    await db
+      .insert(agents)
+      .values({
+        id: agentId,
+        codespaceId: codespace.id,
+        name: 'AgentCore Agent',
+        type: 'task',
+        status: 'starting',
+        currentTaskId: task2.id,
+        currentSessionId: 'session-2',
+      })
+      .onConflictDoUpdate({
+        target: agents.id,
+        set: {
+          status: 'starting',
+          currentTaskId: task2.id,
+          currentSessionId: 'session-2',
+        },
+      });
+
+    const dbAgent = await db.query.agents.findFirst({ where: eq(agents.id, agentId) });
+    expect(dbAgent?.currentTaskId).toBe(task2.id);
+    expect(dbAgent?.currentSessionId).toBe('session-2');
+  });
+
+  it('IT-307c: handleAgentCoreComplete flow — task moves to waiting_approval via shared helper', async () => {
+    const db = getTestDb();
+    const codespace = await createTestProject();
+    const task = await createTestTask(codespace.id, {
+      column: 'in_progress',
+      title: 'Completed task',
+    });
+
+    // Create agent record with the expected ID pattern
+    await createTestAgent(codespace.id, {
+      id: `agent-${task.id}`,
+      status: 'running',
+      currentTaskId: task.id,
+    });
+
+    // Simulate handleAgentCoreComplete calling updateTaskOnAgentComplete + updateAgentStatus
+    const taskResult = await updateTaskOnAgentComplete(db, task.id, 'completed');
+    expect(taskResult).toBe(true);
+
+    await updateAgentStatus(db, task.id, 'completed');
+
+    const dbTask = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+    expect(dbTask?.column).toBe('waiting_approval');
+    expect(dbTask?.lastAgentStatus).toBe('completed');
+    expect(dbTask?.agentId).toBeNull();
+
+    const dbAgent = await db.query.agents.findFirst({
+      where: eq(agents.id, `agent-${task.id}`),
+    });
+    expect(dbAgent?.status).toBe('completed');
+    expect(dbAgent?.currentTaskId).toBeNull();
+  });
+
+  it('IT-307d: handleAgentCoreError flow — task error state + agent cleanup', async () => {
+    const db = getTestDb();
+    const codespace = await createTestProject();
+    const task = await createTestTask(codespace.id, {
+      column: 'in_progress',
+      title: 'Error task',
+    });
+
+    await createTestAgent(codespace.id, {
+      id: `agent-${task.id}`,
+      status: 'running',
+      currentTaskId: task.id,
+    });
+
+    // Simulate handleAgentCoreError calling updateTaskOnAgentError + updateAgentStatus
+    const taskResult = await updateTaskOnAgentError(db, task.id);
+    expect(taskResult).toBe(true);
+
+    await updateAgentStatus(db, task.id, 'error');
+
+    const dbTask = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+    expect(dbTask?.lastAgentStatus).toBe('error');
+    expect(dbTask?.agentId).toBeNull();
+    expect(dbTask?.column).toBe('in_progress'); // stays in_progress
+
+    const dbAgent = await db.query.agents.findFirst({
+      where: eq(agents.id, `agent-${task.id}`),
+    });
+    expect(dbAgent?.status).toBe('error');
+    expect(dbAgent?.currentTaskId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ContainerExecService — DB-level integration
 // ---------------------------------------------------------------------------
 
@@ -1372,14 +1657,14 @@ describe('Cross-service: State Manager + DB consistency (IT-309)', () => {
       phase: 'plan',
     });
 
-    state.setRunningAgent(task2.id, {
+    state.setRunningAgentCoreAgent(task2.id, {
       taskId: task2.id,
       sessionId: 'sess-2',
       codespaceId: cs2.id,
-      sandboxId: 'sb-2',
+      sandboxId: 'agentcore-cs2',
       bridge: {} as any,
-      execResult: {} as any,
-      stopFilePath: '/tmp/stop-2',
+      instance: {} as any,
+      runtimeSessionId: 'rt-2',
       startedAt: new Date(),
       stopRequested: false,
       phase: 'execute',

--- a/tests/integration/plan-approval-flow.test.ts
+++ b/tests/integration/plan-approval-flow.test.ts
@@ -38,7 +38,13 @@ describe('PlanApprovalService — full service integration (IT-220)', () => {
       apiKeyService: {} as any,
     };
 
-    service = new PlanApprovalService(deps, state, mockWorktreeInit as any, mockStartAgentFn);
+    service = new PlanApprovalService(
+      deps,
+      state,
+      mockWorktreeInit as any,
+      mockStartAgentFn,
+      () => false // isAgentCoreProvider
+    );
   });
 
   afterEach(async () => {
@@ -443,6 +449,92 @@ describe('PlanApprovalService — full service integration (IT-220)', () => {
           sdkSessionId: 'sdk-same',
         })
       );
+    });
+  });
+
+  describe('approvePlan — AgentCore path (IT-224)', () => {
+    let agentCoreService: PlanApprovalService;
+
+    beforeEach(() => {
+      const deps: ContainerAgentDeps = {
+        db: db as any,
+        provider: mockProvider as any,
+        streams: mockStreams as any,
+        apiKeyService: {} as any,
+      };
+
+      agentCoreService = new PlanApprovalService(
+        deps,
+        state,
+        mockWorktreeInit as any,
+        mockStartAgentFn,
+        () => true // isAgentCoreProvider returns true
+      );
+    });
+
+    it('IT-224a: approves plan via AgentCore path without sandbox check', async () => {
+      const project = await createTestProject();
+      const session = await createTestSession(project.id);
+      const task = await createTestTask(project.id, { column: 'waiting_approval' });
+
+      state.setPendingPlan(task.id, {
+        taskId: task.id,
+        sessionId: session.id,
+        codespaceId: project.id,
+        plan: 'AgentCore plan',
+        turnCount: 4,
+        sdkSessionId: 'sdk-agentcore',
+        createdAt: new Date(),
+      });
+
+      const result = await agentCoreService.approvePlan(task.id);
+
+      expect(result.ok).toBe(true);
+
+      // Provider.get should NOT have been called (no sandbox check)
+      expect(mockProvider.get).not.toHaveBeenCalled();
+
+      // startAgentFn should be called with sdkSessionId
+      expect(mockStartAgentFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: 'execute',
+          sdkSessionId: 'sdk-agentcore',
+          prompt: 'AgentCore plan',
+        })
+      );
+
+      const dbTask = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+      expect(dbTask?.column).toBe('in_progress');
+    });
+
+    it('IT-224b: restores task state on AgentCore start failure', async () => {
+      const project = await createTestProject();
+      const session = await createTestSession(project.id);
+      const task = await createTestTask(project.id, { column: 'waiting_approval' });
+
+      state.setPendingPlan(task.id, {
+        taskId: task.id,
+        sessionId: session.id,
+        codespaceId: project.id,
+        plan: 'Failing AgentCore plan',
+        turnCount: 4,
+        sdkSessionId: 'sdk-fail',
+        createdAt: new Date(),
+      });
+
+      mockStartAgentFn.mockResolvedValue({
+        ok: false,
+        error: { code: 'SANDBOX_AGENT_START_FAILED', message: 'API key expired' },
+      });
+
+      const result = await agentCoreService.approvePlan(task.id);
+
+      expect(result.ok).toBe(false);
+
+      // Task should be restored to waiting_approval
+      const dbTask = await db.query.tasks.findFirst({ where: eq(tasks.id, task.id) });
+      expect(dbTask?.column).toBe('waiting_approval');
+      expect(dbTask?.lastAgentStatus).toBe('planning');
     });
   });
 

--- a/tests/integration/route-sandbox.test.ts
+++ b/tests/integration/route-sandbox.test.ts
@@ -47,6 +47,11 @@ function createMockSandboxConfigService(
     nomadNamespace: null,
     nomadDatacenter: null,
     nomadRegion: null,
+    awsAccessKeyId: null,
+    awsSecretAccessKey: 'test-placeholder-key',
+    awsRegion: null,
+    agentcoreRuntimeArn: null,
+    ecrRepositoryUri: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
@@ -245,7 +250,7 @@ describe('Sandbox Routes (IT-1000)', () => {
   // =========================================================================
 
   describe('Credential redaction', () => {
-    it('IT-1020: GET list redacts nomadToken', async () => {
+    it('IT-1020: GET list redacts nomadToken and awsSecretAccessKey', async () => {
       const response = await app.request('http://localhost/api/sandbox-configs');
 
       expect(response.status).toBe(200);
@@ -254,6 +259,7 @@ describe('Sandbox Routes (IT-1000)', () => {
 
       const item = body.data.items[0];
       expect(item.nomadToken).toBeUndefined();
+      expect(item.awsSecretAccessKey).toBeUndefined();
       // Other fields should be present
       expect(item.name).toBe('Test Config');
       expect(item.type).toBe('docker');
@@ -266,6 +272,7 @@ describe('Sandbox Routes (IT-1000)', () => {
       const body = await response.json();
       expect(body.ok).toBe(true);
       expect(body.data.nomadToken).toBeUndefined();
+      expect(body.data.awsSecretAccessKey).toBeUndefined();
     });
 
     it('IT-1022: POST create redacts sensitive fields in response', async () => {
@@ -280,6 +287,7 @@ describe('Sandbox Routes (IT-1000)', () => {
       const body = await response.json();
       expect(body.ok).toBe(true);
       expect(body.data.nomadToken).toBeUndefined();
+      expect(body.data.awsSecretAccessKey).toBeUndefined();
     });
 
     it('IT-1023: PATCH update redacts sensitive fields in response', async () => {
@@ -295,6 +303,7 @@ describe('Sandbox Routes (IT-1000)', () => {
       const body = await response.json();
       expect(body.ok).toBe(true);
       expect(body.data.nomadToken).toBeUndefined();
+      expect(body.data.awsSecretAccessKey).toBeUndefined();
     });
   });
 

--- a/tests/lib/errors/errors.test.ts
+++ b/tests/lib/errors/errors.test.ts
@@ -3,6 +3,11 @@
  */
 import { describe, expect, it } from 'vitest';
 import { AgentErrors } from '@/lib/errors/agent-errors';
+import {
+  AGENTCORE_ERROR_IDS,
+  AgentCoreErrors,
+  isAgentCoreError,
+} from '@/lib/errors/agentcore-errors';
 import { AppErrorClass, createError } from '@/lib/errors/base';
 import { CodespaceErrors } from '@/lib/errors/codespace-errors';
 import { ConcurrencyErrors } from '@/lib/errors/concurrency-errors';
@@ -919,5 +924,66 @@ describe('SandboxConfigErrors', () => {
   it('DEFAULT_EXISTS has status 409', () => {
     expect(SandboxConfigErrors.DEFAULT_EXISTS.code).toBe('SANDBOX_CONFIG_DEFAULT_EXISTS');
     expect(SandboxConfigErrors.DEFAULT_EXISTS.status).toBe(409);
+  });
+});
+
+// =============================================================================
+// AgentCore Errors Tests
+// =============================================================================
+
+describe('AgentCoreErrors', () => {
+  it('AWS_CREDENTIALS_INVALID returns 401 with AGENTCORE error id', () => {
+    const error = AgentCoreErrors.AWS_CREDENTIALS_INVALID('bad key');
+
+    expect(error.code).toBe(AGENTCORE_ERROR_IDS.AWS_CREDENTIALS_INVALID);
+    expect(error.status).toBe(401);
+    expect(error.message).toContain('bad key');
+    expect(error.details?.errorName).toBe('AGENTCORE_AWS_CREDENTIALS_INVALID');
+  });
+
+  it('AWS_CREDENTIALS_EXPIRED returns 401', () => {
+    const error = AgentCoreErrors.AWS_CREDENTIALS_EXPIRED();
+
+    expect(error.code).toBe(AGENTCORE_ERROR_IDS.AWS_CREDENTIALS_EXPIRED);
+    expect(error.status).toBe(401);
+  });
+
+  it('STREAMING_ERROR returns 502', () => {
+    const error = AgentCoreErrors.STREAMING_ERROR('disconnected');
+
+    expect(error.code).toBe(AGENTCORE_ERROR_IDS.STREAMING_ERROR);
+    expect(error.status).toBe(502);
+  });
+
+  it('SESSION_CREATE_FAILED returns 502', () => {
+    const error = AgentCoreErrors.SESSION_CREATE_FAILED('timeout');
+
+    expect(error.code).toBe(AGENTCORE_ERROR_IDS.SESSION_CREATE_FAILED);
+    expect(error.status).toBe(502);
+  });
+
+  it('API_ERROR uses the provided statusCode', () => {
+    const error = AgentCoreErrors.API_ERROR(503, 'service unavailable');
+
+    expect(error.status).toBe(503);
+    expect(error.code).toBe(AGENTCORE_ERROR_IDS.API_ERROR);
+  });
+
+  it('isAgentCoreError returns true for AgentCore errors', () => {
+    const error = AgentCoreErrors.INTERNAL_ERROR('test');
+
+    expect(isAgentCoreError(error)).toBe(true);
+  });
+
+  it('isAgentCoreError returns false for non-AppErrorClass errors', () => {
+    expect(isAgentCoreError(new Error('test'))).toBe(false);
+    expect(isAgentCoreError(null)).toBe(false);
+    expect(isAgentCoreError('string')).toBe(false);
+  });
+
+  it('isAgentCoreError returns false for non-AGENTCORE codes', () => {
+    const error = new AppErrorClass('OTHER_CODE', 'msg', 500);
+
+    expect(isAgentCoreError(error)).toBe(false);
   });
 });

--- a/tests/lib/sandbox/sandbox-theme-04.test.ts
+++ b/tests/lib/sandbox/sandbox-theme-04.test.ts
@@ -5,6 +5,7 @@
  * Groups:
  *   P0-01 image validation
  *   P1-01 provider conformance
+ *   P1-02 AgentCore gating
  *   P1-03 K8s / Nomad recover()
  *   P1-05 credential injection via writeFile
  *   P1-06 network-mode default opt-in
@@ -121,6 +122,48 @@ describe('P1-01 SandboxProvider conformance', () => {
       expect(typeof provider.on).toBe('function');
       expect(typeof provider.off).toBe('function');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P1-02 — AgentCore gating
+// ---------------------------------------------------------------------------
+
+describe('P1-02 AgentCore gating', () => {
+  const ORIGINAL = process.env.AGENTCORE_ENABLED;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.AGENTCORE_ENABLED;
+    else process.env.AGENTCORE_ENABLED = ORIGINAL;
+  });
+
+  it('setAgentCoreProvider is a no-op when AGENTCORE_ENABLED is unset', async () => {
+    delete process.env.AGENTCORE_ENABLED;
+
+    // Spy on the dynamic import target — if the gate is violated, this fails.
+    // We import the service fresh with resetModules so the guard runs.
+    vi.resetModules();
+
+    // We can't easily detect a non-import, so instead verify: after calling
+    // setAgentCoreProvider with the flag off, providerName stays at the
+    // injected provider's name (not 'agentcore').
+    const { ContainerAgentService } = await import(
+      '@/services/container-agent/container-agent.service'
+    );
+    const service = new ContainerAgentService(
+      { query: { tasks: { findMany: vi.fn().mockResolvedValue([]) } } } as never,
+      { name: 'docker' } as never,
+      { publish: vi.fn() } as never,
+      { getDecryptedKey: vi.fn() } as never
+    );
+    await service.setAgentCoreProvider({
+      region: 'us-east-1',
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      runtimeArn: 'arn:aws:agentcore:test',
+    });
+    expect(service.providerName).toBe('docker');
+    service.dispose();
   });
 });
 

--- a/tests/services/container-agent.service.test.ts
+++ b/tests/services/container-agent.service.test.ts
@@ -1,5 +1,5 @@
 /**
- * Comprehensive tests for ContainerAgentService — the largest service file.
+ * Comprehensive tests for ContainerAgentService — the largest service file (3076 LOC).
  *
  * Covers:
  * - Constructor and disposal
@@ -13,6 +13,7 @@
  * - Environment variable construction
  * - Sandbox mode handling (shared vs per-project)
  * - Concurrency guards (startingAgents set)
+ * - AgentCore provider management
  * - cleanupExpiredPlans
  * - isAgentRunning / getRunningAgent / getRunningAgents
  * - translatePathForContainer
@@ -45,6 +46,26 @@ vi.mock('../../src/lib/agents/container-bridge.js', () => ({
       stop: mockBridgeStop,
     };
   }),
+}));
+
+// Mock the AgentCore bridge
+vi.mock('../../src/lib/agents/agentcore-bridge.js', () => ({
+  createAgentCoreBridge: vi.fn(() => ({
+    processStream: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+  })),
+}));
+
+// Mock the AgentCore provider factory
+vi.mock('../../src/lib/sandbox/providers/agentcore-sandbox-provider.js', () => ({
+  createAgentCoreProvider: vi.fn(() => ({
+    name: 'agentcore',
+    get: vi.fn(),
+    create: vi.fn(),
+    getOrCreateSession: vi.fn().mockReturnValue('runtime-session-123'),
+    removeSession: vi.fn(),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 // Mock git-token-resolver
@@ -1956,6 +1977,50 @@ describe('ContainerAgentService', () => {
 
       const plan = await service.getPendingPlan(task.id);
       expect(plan).toBeDefined();
+    });
+  });
+
+  // =========================================================================
+  // AgentCore provider management
+  // =========================================================================
+
+  describe('AgentCore provider management', () => {
+    it('setAgentCoreProvider configures the provider', async () => {
+      // theme-04 P1-02: AgentCore is gated on AGENTCORE_ENABLED
+      const prev = process.env.AGENTCORE_ENABLED;
+      process.env.AGENTCORE_ENABLED = 'true';
+      try {
+        await service.setAgentCoreProvider({
+          region: 'us-east-1',
+          accessKeyId: 'AKIA...',
+          secretAccessKey: 'secret',
+          runtimeArn: 'arn:aws:agentcore:...',
+        });
+        expect(service.providerName).toBe('agentcore');
+      } finally {
+        if (prev === undefined) delete process.env.AGENTCORE_ENABLED;
+        else process.env.AGENTCORE_ENABLED = prev;
+      }
+    });
+
+    it('clearAgentCoreProvider resets to container provider', async () => {
+      const prev = process.env.AGENTCORE_ENABLED;
+      process.env.AGENTCORE_ENABLED = 'true';
+      try {
+        await service.setAgentCoreProvider({
+          region: 'us-east-1',
+          accessKeyId: 'AKIA...',
+          secretAccessKey: 'secret',
+          runtimeArn: 'arn:aws:agentcore:...',
+        });
+        expect(service.providerName).toBe('agentcore');
+
+        service.clearAgentCoreProvider();
+        expect(service.providerName).toBe('docker');
+      } finally {
+        if (prev === undefined) delete process.env.AGENTCORE_ENABLED;
+        else process.env.AGENTCORE_ENABLED = prev;
+      }
     });
   });
 


### PR DESCRIPTION
## Why

PR #202 (W2-D) deleted the AgentCore service path under the assumption it was dead code per F04-04 / F04-05 of the April 29 architecture review. **The user has confirmed AgentCore is in active service** — the deletion was incorrect and is being reverted to restore production functionality.

## What's restored

This is a clean `git revert` of c0124e33. Restored:

- `src/services/container-agent/agentcore-bridge.service.ts` (561 LOC)
- `src/lib/sandbox/providers/agentcore-sandbox-instance.ts` (402 LOC including AWS SigV4)
- `src/lib/sandbox/providers/agentcore-sandbox-provider.ts` (379 LOC)
- `src/lib/agents/agentcore-bridge.ts` (324 LOC SSE→DurableStreams glue)
- `src/lib/errors/agentcore-errors.ts`
- `agent-runner/src/agentcore-handler.ts` (BedrockAgentCoreApp runtime)
- `docker/Dockerfile.agentcore`
- All `__tests__/agentcore-*.test.ts`
- `AGENTCORE_ENABLED` env var, `setAgentCoreProvider`/`clearAgentCoreProvider`, `agentCoreProvider` field, `isAgentCoreProvider()` guard in `ContainerAgentService`
- `runningAgentCoreAgents` map and helpers in `SandboxStateManager`
- AgentCore branch in `PlanApprovalService.approvePlan()`
- `'agentcore'` in `SANDBOX_TYPES`, `'sandbox.agentcore'` in settings allowlist, `SandboxProviderType` union
- AgentCore fields in sandbox route schemas
- `@aws-sdk/client-sts` and `bedrock-agentcore` dependencies

## Follow-up for F04-04 / F04-05

The original review findings still stand at the architectural level — the AgentCore code is statically imported regardless of `AGENTCORE_ENABLED`, and the SigV4 signer ships always. **A follow-up PR should make the gate work properly without deletion** (lazy-load via dynamic import + factory, or condition the static imports on a build-time flag). Tracked separately; this PR is purely the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
