### PR TITLE
fix(arch29-W2-M): body size limits + CSP (F06-NEW-09, F06-NEW-10)

### DIFF
--- a/src/server/middleware/__tests__/body-limit.test.ts
+++ b/src/server/middleware/__tests__/body-limit.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the body-size limit middleware (`bodyLimit`) backing
+ * F06-NEW-09 from the April 29 architecture review.
+ *
+ * Verifies:
+ *  - 413 fast path when `Content-Length` exceeds the cap
+ *  - allow path when `Content-Length` is at-or-under the cap
+ *  - 413 slow path when chunked / unknown-length body exceeds the cap
+ *  - methods without bodies (GET/HEAD/OPTIONS/DELETE) bypass the wrap
+ *  - default cap is 5MB to match the spec
+ */
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { bodyLimit, DEFAULT_BODY_LIMIT_BYTES } from '../body-limit.js';
+
+function createApp(maxBytes?: number) {
+  const app = new Hono();
+  app.use('/api/*', bodyLimit(maxBytes !== undefined ? { maxBytes } : undefined));
+  app.post('/api/echo', async (c) => {
+    const body = await c.req.text();
+    return c.json({ ok: true, length: body.length });
+  });
+  app.get('/api/ping', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('bodyLimit middleware', () => {
+  it('exposes a 5MB default cap', () => {
+    expect(DEFAULT_BODY_LIMIT_BYTES).toBe(5 * 1024 * 1024);
+  });
+
+  describe('Content-Length fast path', () => {
+    it('rejects with 413 when Content-Length exceeds the cap (6MB > 5MB default)', async () => {
+      const app = createApp();
+      const headers = new Headers({
+        'Content-Type': 'application/json',
+        'Content-Length': String(6 * 1024 * 1024),
+      });
+      // Note: we don't actually send the 6MB body — Content-Length alone
+      // triggers the fast-path rejection before any read.
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers,
+          body: '{}',
+        })
+      );
+      expect(res.status).toBe(413);
+      const body = await res.json();
+      expect(body).toEqual({
+        ok: false,
+        error: {
+          code: 'PAYLOAD_TOO_LARGE',
+          message: expect.stringContaining('byte limit'),
+        },
+      });
+    });
+
+    it('accepts a request whose Content-Length equals the cap', async () => {
+      const cap = 1024;
+      const app = createApp(cap);
+      const payload = 'a'.repeat(cap);
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain', 'Content-Length': String(cap) },
+          body: payload,
+        })
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ ok: true, length: cap });
+    });
+
+    it('accepts a request whose Content-Length is below the cap', async () => {
+      const app = createApp(1024);
+      const payload = 'hello';
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain', 'Content-Length': String(payload.length) },
+          body: payload,
+        })
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ ok: true, length: payload.length });
+    });
+
+    it('rejects when Content-Length is just over the cap (cap+1 bytes)', async () => {
+      const cap = 1024;
+      const app = createApp(cap);
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain', 'Content-Length': String(cap + 1) },
+          body: 'a'.repeat(cap + 1),
+        })
+      );
+      expect(res.status).toBe(413);
+    });
+  });
+
+  describe('chunked / streaming path (no Content-Length)', () => {
+    it('rejects with 413 when the streamed body exceeds the cap', async () => {
+      const cap = 1024;
+      const app = createApp(cap);
+
+      // Build a streaming body of 2KB (above the 1KB cap). ReadableStream
+      // forces the chunked path because we omit Content-Length.
+      const chunk = new TextEncoder().encode('a'.repeat(512));
+      let chunksRemaining = 4; // 4 * 512 = 2KB
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (chunksRemaining === 0) {
+            controller.close();
+            return;
+          }
+          chunksRemaining -= 1;
+          controller.enqueue(chunk);
+        },
+      });
+
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/octet-stream' },
+          body: stream,
+          // @ts-expect-error duplex is not yet in the standard RequestInit type
+          duplex: 'half',
+        })
+      );
+
+      expect(res.status).toBe(413);
+      const body = await res.json();
+      expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    });
+
+    it('accepts a streamed body that stays under the cap', async () => {
+      const cap = 1024;
+      const app = createApp(cap);
+
+      const chunk = new TextEncoder().encode('a'.repeat(256));
+      let chunksRemaining = 2; // 2 * 256 = 512 (under cap)
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (chunksRemaining === 0) {
+            controller.close();
+            return;
+          }
+          chunksRemaining -= 1;
+          controller.enqueue(chunk);
+        },
+      });
+
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/octet-stream' },
+          body: stream,
+          // @ts-expect-error duplex is not yet in the standard RequestInit type
+          duplex: 'half',
+        })
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ ok: true, length: 512 });
+    });
+  });
+
+  describe('method handling', () => {
+    it('does not block GET requests (no body)', async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request('http://localhost/api/ping', {
+          method: 'GET',
+        })
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('does not block GET requests even with bogus huge Content-Length', async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request('http://localhost/api/ping', {
+          method: 'GET',
+          // GET requests with bodies are unusual; the middleware skips method
+          // entirely so this should pass through.
+          headers: { 'Content-Length': String(100 * 1024 * 1024) },
+        })
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('error envelope', () => {
+    it('returns the canonical { ok: false, error: { code, message } } shape', async () => {
+      const app = createApp(100);
+      const res = await app.fetch(
+        new Request('http://localhost/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/plain', 'Content-Length': '500' },
+          body: 'a'.repeat(500),
+        })
+      );
+      expect(res.status).toBe(413);
+      expect(res.headers.get('Content-Type')).toMatch(/application\/json/);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+      expect(typeof body.error.message).toBe('string');
+    });
+  });
+});

--- a/src/server/middleware/body-limit.ts
+++ b/src/server/middleware/body-limit.ts
@@ -1,0 +1,165 @@
+/**
+ * Body-size limit middleware (F06-NEW-09).
+ *
+ * Caps incoming request body size so the API and webhook surfaces cannot be
+ * OOM'd by an attacker streaming arbitrarily large payloads. Bun's default
+ * body limit is generous (~100MB); combined with the in-memory rate limiter
+ * this would let a single client send tens of GB/min into Hono's memory.
+ *
+ * Behaviour:
+ * - Reads `Content-Length` and short-circuits with 413 BEFORE the handler
+ *   parses the body. This avoids buffering large payloads at all.
+ * - For chunked / unknown-length requests (no `Content-Length`, e.g. with
+ *   `Transfer-Encoding: chunked`), we wrap the request body in a streaming
+ *   reader that aborts the stream once `maxBytes` is exceeded. The handler
+ *   that calls `c.req.text()` / `c.req.json()` will then fail; we map that
+ *   failure to a 413 response.
+ *
+ * Returns the canonical API error envelope `{ ok: false, error: { code,
+ * message } }` so existing client error handling works unchanged. Errors use
+ * the `PAYLOAD_TOO_LARGE` code, mirroring the cli-monitor route's existing
+ * cap (`src/server/routes/cli-monitor.ts`).
+ *
+ * Usage:
+ * ```ts
+ * app.use('/api/*', bodyLimit({ maxBytes: 5 * 1024 * 1024 }));
+ * app.use('/hooks/*', bodyLimit({ maxBytes: 5 * 1024 * 1024 }));
+ * ```
+ *
+ * Cross-ref: spec `arch_review_april29/06-security.md` finding F06-NEW-09.
+ */
+
+import type { Context, MiddlewareHandler, Next } from 'hono';
+
+/** Default cap applied to `/api/*` and `/hooks/*` per April 29 review. */
+export const DEFAULT_BODY_LIMIT_BYTES = 5 * 1024 * 1024; // 5MB
+
+export interface BodyLimitOptions {
+  /** Maximum allowed body size in bytes. Defaults to {@link DEFAULT_BODY_LIMIT_BYTES}. */
+  maxBytes?: number;
+}
+
+/** Internal sentinel marking a stream that exceeded the cap mid-read. */
+class BodyLimitExceededError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} byte limit`);
+    this.name = 'BodyLimitExceededError';
+  }
+}
+
+function tooLarge(c: Context, maxBytes: number): Response {
+  return c.json(
+    {
+      ok: false,
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+        message: `Request body exceeds ${maxBytes} byte limit`,
+      },
+    },
+    413
+  );
+}
+
+/**
+ * Hono middleware that caps request body size.
+ *
+ * Methods that never carry a body (GET, HEAD, OPTIONS, DELETE) are skipped
+ * to avoid wrapping unrelated requests in a stream reader.
+ */
+export function bodyLimit(options: BodyLimitOptions = {}): MiddlewareHandler {
+  const maxBytes = options.maxBytes ?? DEFAULT_BODY_LIMIT_BYTES;
+
+  return async function bodyLimitMiddleware(c: Context, next: Next): Promise<Response | void> {
+    // No body to inspect for read-only methods.
+    const method = c.req.method.toUpperCase();
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS' || method === 'DELETE') {
+      return next();
+    }
+
+    // Fast path: reject by Content-Length before reading anything.
+    const contentLengthHeader = c.req.header('content-length');
+    if (contentLengthHeader) {
+      const contentLength = Number.parseInt(contentLengthHeader, 10);
+      if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+        return tooLarge(c, maxBytes);
+      }
+    }
+
+    // Slow path: chunked or missing Content-Length — wrap the body so we
+    // can abort once we've read more than `maxBytes`. Skip when the body
+    // is absent (e.g. a POST with no body).
+    const rawBody = c.req.raw.body;
+    if (rawBody) {
+      let totalRead = 0;
+      const reader = rawBody.getReader();
+      const wrapped = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const { done, value } = await reader.read();
+            if (done) {
+              controller.close();
+              return;
+            }
+            totalRead += value.byteLength;
+            if (totalRead > maxBytes) {
+              controller.error(new BodyLimitExceededError(maxBytes));
+              return;
+            }
+            controller.enqueue(value);
+          } catch (err) {
+            controller.error(err);
+          }
+        },
+        cancel(reason) {
+          // Propagate cancellation upstream.
+          reader.cancel(reason).catch(() => {
+            /* swallow — reader already errored */
+          });
+        },
+      });
+
+      // Replace the raw request with one whose body is bounded.
+      c.req.raw = new Request(c.req.raw, {
+        body: wrapped,
+        // `duplex: 'half'` is required by the Fetch spec for streaming bodies.
+        // @ts-expect-error duplex is not yet in the standard RequestInit type
+        duplex: 'half',
+      });
+    }
+
+    try {
+      await next();
+    } catch (err) {
+      if (isBodyLimitError(err)) {
+        return tooLarge(c, maxBytes);
+      }
+      throw err;
+    }
+
+    // The handler may swallow stream errors via `c.req.text().catch(...)`
+    // or — more commonly — Hono catches the throw internally and stores
+    // it on `c.error` while the runtime returns a default 500 response.
+    // Override that response with our 413 envelope. We also match by
+    // name as a fallback because Bun's stream pipeline can wrap
+    // controller errors in a way that breaks `instanceof`.
+    if (isBodyLimitError(c.error)) {
+      // Hono's compose layer already set c.res to a 500 when the handler
+      // threw. Replace it with our 413 envelope and clear `c.error` so
+      // the global onError handler doesn't double-respond / re-log.
+      c.res = tooLarge(c, maxBytes);
+      c.error = undefined;
+    }
+  };
+}
+
+/**
+ * Identity check that survives realm-boundary serialisation. Bun's stream
+ * pipeline can wrap controller errors in such a way that `instanceof`
+ * yields `false` even when the same class was thrown — the only stable
+ * marker is the constructor `name`.
+ */
+function isBodyLimitError(err: unknown): boolean {
+  if (err instanceof BodyLimitExceededError) return true;
+  if (err instanceof Error && err.name === 'BodyLimitExceededError') return true;
+  return false;
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -48,6 +48,7 @@ import type { TerraformComposeService } from '../services/terraform-compose.serv
 import type { TerraformRegistryService } from '../services/terraform-registry.service.js';
 import type { WorkflowService } from '../services/workflow.service.js';
 import type { Database } from '../types/database.js';
+import { bodyLimit, DEFAULT_BODY_LIMIT_BYTES } from './middleware/body-limit.js';
 import { createAdminMetricsRoutes } from './routes/admin-metrics.js';
 import { createAgentsRoutes } from './routes/agents.js';
 import { createApiKeysRoutes } from './routes/api-keys.js';
@@ -175,6 +176,34 @@ export function __resetMetricsRouteCache(): void {
   observedMetricsRoutes.clear();
 }
 
+/**
+ * F06-NEW-10: production CSP. The April 29 security review (`specs/
+ * arch_review_april29/06-security.md`) tightened this from the prior
+ * `script-src 'self'` baseline to:
+ *
+ * - `'wasm-unsafe-eval'` in `script-src` — Shiki uses WebAssembly for
+ *   grammar parsing (`markdown-content.tsx`, `terraform-right-panel.tsx`).
+ *   Without this directive Chrome blocks the WASM compile and syntax
+ *   highlighting silently degrades to plain text.
+ * - `https://avatars.githubusercontent.com` in `img-src` — the team-member
+ *   list and codespace owner views render avatars from GitHub's CDN.
+ *   Without this allow-list the avatars showed as broken images in
+ *   production builds.
+ *
+ * The remaining directives stay minimal: `default-src 'self'` so anything
+ * not explicitly allowed above is denied; `style-src 'unsafe-inline'`
+ * because Tailwind injects classes (no inline styles produced by the
+ * framework, but third-party SVGs may carry inline `<style>`). `data:` is
+ * kept on `img-src` for inline icon data URIs used by Phosphor.
+ */
+const PRODUCTION_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'wasm-unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https://avatars.githubusercontent.com",
+  "connect-src 'self'",
+].join('; ');
+
 async function securityHeaders(c: Context, next: Next) {
   await next();
   c.header('X-Content-Type-Options', 'nosniff');
@@ -183,10 +212,7 @@ async function securityHeaders(c: Context, next: Next) {
   c.header('Referrer-Policy', 'strict-origin-when-cross-origin');
   if (process.env.NODE_ENV === 'production') {
     c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-    c.header(
-      'Content-Security-Policy',
-      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
-    );
+    c.header('Content-Security-Policy', PRODUCTION_CSP);
   }
 }
 
@@ -337,6 +363,16 @@ export function createRouter(deps: RouterDependencies) {
   app.use('*', securityHeaders);
   // F10-01: record per-request counters for /api/metrics.
   app.use('*', metricsMiddleware);
+  // F06-NEW-09: cap incoming body size on the public-facing surfaces.
+  // Default is 5MB (matches the prior cli-monitor cap). Applied early so
+  // webhook handlers that call `c.req.text()` and route handlers that call
+  // `zValidator('json', ...)` reject oversized payloads before any
+  // buffering. cli-monitor keeps its existing 5MB cap (in
+  // `src/server/routes/cli-monitor.ts`) — same value, applied at the
+  // route handler for backward compatibility with that service's own
+  // error envelope.
+  app.use('/api/*', bodyLimit({ maxBytes: DEFAULT_BODY_LIMIT_BYTES }));
+  app.use('/hooks/*', bodyLimit({ maxBytes: DEFAULT_BODY_LIMIT_BYTES }));
   // Public webhook endpoint - no auth required (signature-verified by plugin)
   if (deps.eventProcessingService) {
     // Rate-limit webhooks: 60 requests per minute per IP

--- a/tests/server/router.test.ts
+++ b/tests/server/router.test.ts
@@ -7,7 +7,7 @@
  * error handling, auth middleware, and the notFound handler by creating a
  * real Hono app via createRouter() with stubbed service dependencies.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRouter, type RouterDependencies } from '@/server/router';
 
 // ---------------------------------------------------------------------------
@@ -179,6 +179,118 @@ describe('createRouter', () => {
     it('sets Referrer-Policy header', async () => {
       const res = await appFetch(app, '/api/healthz');
       expect(res.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    });
+
+    // F06-NEW-10: Production CSP must allow Shiki's WASM and GitHub avatars.
+    describe('Content-Security-Policy (production)', () => {
+      let originalEnv: string | undefined;
+      let prodApp: ReturnType<typeof createRouter>;
+
+      beforeEach(() => {
+        originalEnv = process.env.NODE_ENV;
+        // The CSP header is only emitted when NODE_ENV === 'production'.
+        process.env.NODE_ENV = 'production';
+        prodApp = createRouter(createMinimalDeps());
+      });
+
+      afterEach(() => {
+        if (originalEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalEnv;
+        }
+      });
+
+      it("includes 'wasm-unsafe-eval' in script-src so Shiki can compile its grammar WASM", async () => {
+        const res = await appFetch(prodApp, '/api/healthz');
+        const csp = res.headers.get('Content-Security-Policy') ?? '';
+        expect(csp).toMatch(/script-src[^;]*'wasm-unsafe-eval'/);
+      });
+
+      it('allows GitHub avatar host in img-src', async () => {
+        const res = await appFetch(prodApp, '/api/healthz');
+        const csp = res.headers.get('Content-Security-Policy') ?? '';
+        expect(csp).toMatch(/img-src[^;]*https:\/\/avatars\.githubusercontent\.com/);
+      });
+
+      it('keeps default-src self', async () => {
+        const res = await appFetch(prodApp, '/api/healthz');
+        const csp = res.headers.get('Content-Security-Policy') ?? '';
+        expect(csp).toMatch(/default-src 'self'/);
+      });
+
+      it('keeps script-src self alongside wasm-unsafe-eval (defence in depth)', async () => {
+        const res = await appFetch(prodApp, '/api/healthz');
+        const csp = res.headers.get('Content-Security-Policy') ?? '';
+        // Both directives must be present in the script-src list.
+        expect(csp).toMatch(/script-src 'self' 'wasm-unsafe-eval'/);
+      });
+
+      it('keeps img-src self and data: alongside the GitHub avatar host', async () => {
+        const res = await appFetch(prodApp, '/api/healthz');
+        const csp = res.headers.get('Content-Security-Policy') ?? '';
+        expect(csp).toMatch(/img-src 'self' data: https:\/\/avatars\.githubusercontent\.com/);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // F06-NEW-09 — Body size limits on /api/* and /hooks/*
+  // -------------------------------------------------------------------------
+
+  describe('Body size limits', () => {
+    it('returns 413 when /api/* request exceeds 5MB Content-Length', async () => {
+      // Pick any route under /api/* — the body-limit middleware runs before
+      // auth, so the response is 413 not 401.
+      const res = await appFetch(app, '/api/codespaces', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(6 * 1024 * 1024), // 6MB
+        },
+        body: '{}',
+      });
+      expect(res.status).toBe(413);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    });
+
+    it('returns 413 when /hooks/* request exceeds 5MB Content-Length', async () => {
+      const mockProcessing = stubService({
+        processIncomingEvent: vi.fn().mockResolvedValue({ ok: true, value: {} }),
+      });
+      const appWithEvents = createRouter(
+        createMinimalDeps({ eventProcessingService: mockProcessing })
+      );
+      const res = await appFetch(appWithEvents, '/hooks/events/test-slug', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(6 * 1024 * 1024),
+        },
+        body: '{}',
+      });
+      expect(res.status).toBe(413);
+      const body = await res.json();
+      expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+      // The handler must not have run — verify processIncomingEvent was not called.
+      expect(mockProcessing.processIncomingEvent).not.toHaveBeenCalled();
+    });
+
+    it('allows /api/* requests within the 5MB cap', async () => {
+      // 4MB body is under the 5MB cap. The route returns 401 (no auth) — proving
+      // the body-limit middleware passed the request through to the auth layer.
+      const res = await appFetch(app, '/api/codespaces', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(4 * 1024 * 1024),
+        },
+        body: JSON.stringify({ small: 'payload' }),
+      });
+      // 401 from auth — not 413 from body limit.
+      expect(res.status).toBe(401);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes both **F06-NEW-09** (P1) and **F06-NEW-10** (P1) from `specs/arch_review_april29/06-security.md` in a single PR.

### F06-NEW-09 — `/api/*` and `/hooks/*` accept unbounded request bodies

The cli-monitor route ships a 5MB cap, but every other public-facing surface accepted whatever Bun would buffer (~100MB default). Combined with the in-memory rate limiter (200 req/min on `/api/*`, 60 req/min on `/hooks/*`), a single attacker could OOM the process by sending 200 × 100MB = 20 GB/min into Hono's memory.

**Fix**: new `bodyLimit` middleware at `src/server/middleware/body-limit.ts`:

- Reads `Content-Length` and short-circuits with **413 BEFORE** the handler parses the body (fast path; no buffering at all).
- For chunked / unknown-length requests, wraps the body in a bounded `ReadableStream` that errors once `maxBytes` is exceeded; maps the error to a 413 response.
- Returns the canonical `{ ok: false, error: { code: 'PAYLOAD_TOO_LARGE', message } }` envelope.
- Skips read-only methods (GET/HEAD/OPTIONS/DELETE).

Applied to `/api/*` and `/hooks/*` with the 5MB default. cli-monitor's existing route-level cap stays in place (same value).

### F06-NEW-10 — CSP missing `'wasm-unsafe-eval'` and avatar host

Production CSP was `default-src 'self'; script-src 'self'; ...` which broke two real-world UX paths:

1. **Shiki's WASM grammar parser** silently failed (syntax highlighting degraded to plain text).
2. **GitHub avatars** rendered as broken images everywhere they appeared (team list, codespace owner, etc).

**Fix**: tighten production CSP in `securityHeaders`:

```
default-src 'self';
script-src 'self' 'wasm-unsafe-eval';
style-src 'self' 'unsafe-inline';
img-src 'self' data: https://avatars.githubusercontent.com;
connect-src 'self'
```

## Test plan (red → green)

Verified red→green by stashing `src/server/router.ts` and running the suite: **6 of 52 router tests fail without the fix; all 52 pass with it.**

- `before:Body size limits > returns 413 when /api/* request exceeds 5MB Content-Length` (FAIL — returns 401, auth ran first) → `after: PASS` (returns 413 PAYLOAD_TOO_LARGE)
- `before:Body size limits > returns 413 when /hooks/* request exceeds 5MB Content-Length` (FAIL — returns 200, handler ran) → `after: PASS` (handler not called)
- `before:Body size limits > allows /api/* requests within the 5MB cap` — verifies 4MB body still reaches auth (returns 401)
- `before:Content-Security-Policy (production) > 'wasm-unsafe-eval' in script-src` (FAIL — header is `script-src 'self'`) → `after: PASS`
- `before:Content-Security-Policy (production) > GitHub avatar host in img-src` (FAIL — header missing avatar host) → `after: PASS`
- 3 additional CSP shape tests (default-src, defence-in-depth script-src, img-src order)

Plus 10 unit tests in `src/server/middleware/__tests__/body-limit.test.ts` covering Content-Length fast path (above/at/under cap), chunked streaming path, method-skip behaviour, and error envelope shape.

- [x] `npx vitest run --project unit src/server/middleware/__tests__/body-limit.test.ts` — 10/10 pass
- [x] `npx vitest run --project db tests/server/router.test.ts` — 52/52 pass
- [x] `npx vitest run --project unit src/server/routes/__tests__/cli-monitor.test.ts` — 39/39 pass (no regression)
- [x] `npx @biomejs/biome check --max-diagnostics=500 --diagnostic-level=error src/server/middleware/ src/server/router.ts tests/server/router.test.ts` — clean
- [x] `npx tsc --noEmit` — clean

## Files

- `src/server/middleware/body-limit.ts` (NEW) — generic Hono body-size middleware with 5MB default and `PAYLOAD_TOO_LARGE` envelope.
- `src/server/middleware/__tests__/body-limit.test.ts` (NEW) — 10 unit tests.
- `src/server/router.ts` — register `bodyLimit` on `/api/*` and `/hooks/*`; tighten production CSP via the new `PRODUCTION_CSP` constant.
- `tests/server/router.test.ts` — 5 CSP regression tests + 3 body-size regression tests.

## Status vs April 29 review

- **F06-NEW-09** (P1) — Fixed.
- **F06-NEW-10** (P1) — Fixed.

## Constraints honoured

- No new infrastructure (no Redis, Kafka, Vault, OTEL).
- Both findings closed in the same PR (CLAUDE.md "no half-finished implementations").
- Biome + tsc clean. Unit + db (router) + cli-monitor tests pass.

Signed-off-by: Simon Lynch <srlynch@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
