### PR TITLE
fix(arch29-W2-O): MetricsService wire-up (F10-14)

### DIFF
--- a/src/lib/db/with-latency.ts
+++ b/src/lib/db/with-latency.ts
@@ -1,0 +1,42 @@
+/**
+ * F10-14 — DB latency instrumentation helper.
+ *
+ * Wraps a Drizzle query (or any async DB operation) and records the elapsed
+ * milliseconds against {@link MetricsService.recordDbLatency}. The label is a
+ * coarse query-type string (e.g. 'select_task', 'insert_event'); cardinality
+ * stays bounded because callers are expected to use a small fixed set of
+ * labels rather than dynamic ones.
+ *
+ * Failures inside the wrapped operation are recorded too — the timing always
+ * reaches the metrics service, then the original error is rethrown so callers
+ * see no behavioural change. A best-effort try/catch around the metrics call
+ * itself prevents instrumentation bugs from breaking the underlying query.
+ *
+ * @example
+ * const task = await withDbLatency('select_task', () =>
+ *   db.query.tasks.findFirst({ where: eq(tasks.id, taskId) })
+ * );
+ */
+
+import { getMetricsService } from '../../services/metrics.service.js';
+import { createLogger } from '../logging/logger.js';
+
+const log = createLogger('withDbLatency');
+
+export async function withDbLatency<T>(queryType: string, fn: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  try {
+    return await fn();
+  } finally {
+    try {
+      getMetricsService().recordDbLatency(queryType, Date.now() - start);
+    } catch (metricsErr) {
+      // Instrumentation must never break a query, but failures should be
+      // visible so broken metrics don't silently decay.
+      log.warn('withDbLatency: recordDbLatency failed', {
+        error: metricsErr instanceof Error ? metricsErr.message : String(metricsErr),
+        data: { queryType },
+      });
+    }
+  }
+}

--- a/src/lib/events/event-router.ts
+++ b/src/lib/events/event-router.ts
@@ -14,9 +14,28 @@
  * the review's F05-07 for Caddy-side quota work.
  */
 
+import { getMetricsService } from '../../services/metrics.service.js';
 import { createLogger } from '../logging/logger.js';
 
 const log = createLogger('EventRouter');
+
+/**
+ * F10-14: Best-effort metrics call. Wrapped to ensure that an instrumentation
+ * failure can never break SSE acquire/release. Failures are logged but
+ * swallowed so the router's behaviour is unchanged.
+ */
+function recordMetric(direction: 'inc' | 'dec'): void {
+  try {
+    const metrics = getMetricsService();
+    if (direction === 'inc') metrics.incSse();
+    else metrics.decSse();
+  } catch (metricsErr) {
+    log.warn('SSE metrics recording failed', {
+      error: metricsErr instanceof Error ? metricsErr.message : String(metricsErr),
+      data: { direction },
+    });
+  }
+}
 
 /** Global cap across all in-process SSE routes. */
 export const EVENT_ROUTER_GLOBAL_CAP = 200;
@@ -95,6 +114,9 @@ export function acquireSseSlot(route: string, userId?: string | null): AcquireRe
   counters.total += 1;
   counters.byUser.set(user, perUser + 1);
   counters.byRoute.set(route, (counters.byRoute.get(route) ?? 0) + 1);
+  // F10-14: shadow the EventRouter total in MetricsService so /api/metrics
+  // surfaces the same active-SSE count without consulting two sources.
+  recordMetric('inc');
   return { ok: true, total: counters.total, perUser: perUser + 1 };
 }
 
@@ -136,6 +158,11 @@ export function releaseSseSlot(route: string, userId?: string | null): void {
   } else {
     counters.byRoute.set(route, prevRoute - 1);
   }
+
+  // F10-14: mirror the decrement to MetricsService so /api/metrics matches
+  // EventRouter's view. Only fires when we actually decremented above (the
+  // `prevUser <= 0 || prevRoute <= 0` guard returns early without calling).
+  recordMetric('dec');
 }
 
 /** Snapshot for admin metrics. */

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -4,6 +4,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Hono } from 'hono';
+import { withDbLatency } from '../../lib/db/with-latency.js';
 import type { GitHubTokenService } from '../../services/github-token.service.js';
 import type { Database, PostgresDatabase, SqliteDatabase } from '../../types/database.js';
 import { json } from '../shared.js';
@@ -295,7 +296,9 @@ export function createHealthRoutes({
   app.get('/readiness', async (_c) => {
     try {
       const dbStart = Date.now();
-      await db.query.codespaces.findFirst();
+      // F10-14: instrument the readiness DB probe so /api/metrics gets a
+      // steady stream of select_codespace samples (one per readiness poll).
+      await withDbLatency('readiness_probe', () => db.query.codespaces.findFirst());
       return json({
         ok: true,
         status: 'ready',

--- a/src/services/agent/agent-execution.service.ts
+++ b/src/services/agent/agent-execution.service.ts
@@ -11,6 +11,7 @@ import type {
   PreToolUseHook as SdkPreToolUseHook,
 } from '../../lib/agents/types.js';
 import { ALLOW_ALL_TOOLS } from '../../lib/constants/tools.js';
+import { withDbLatency } from '../../lib/db/with-latency.js';
 
 import type { AgentError } from '../../lib/errors/agent-errors.js';
 import { AgentErrors } from '../../lib/errors/agent-errors.js';
@@ -27,6 +28,7 @@ import { err, ok } from '../../lib/utils/result.js';
 import type { Database } from '../../types/database.js';
 import type { MemoryService, MemorySessionRef, TaskOutcome } from '../memory/index.js';
 import type { SkillTrackingService } from '../memory/skill-tracking.service.js';
+import { getMetricsService } from '../metrics.service.js';
 import { createSessionEventWithMetadata } from '../session/event-metadata.js';
 import {
   DEFAULT_AGENT_MAX_RUNTIME_MS,
@@ -176,6 +178,57 @@ export class AgentExecutionService {
         data: { agentId },
       });
     });
+  }
+
+  /**
+   * F10-14: refresh the agent running/idle gauges in MetricsService.
+   *
+   * `running` is taken from the in-memory AbortController map (the
+   * authoritative process-local view), and `idle` is queried from the DB so
+   * the snapshot covers cross-process state too. Any failure is logged and
+   * swallowed — gauge instrumentation must never break a transition.
+   */
+  private async refreshAgentGauges(): Promise<void> {
+    try {
+      const metrics = getMetricsService();
+      const running = this.runningAgents.size;
+      // Best-effort idle count across all codespaces. Cardinality stays low.
+      let idle = 0;
+      try {
+        const [row] = await this.db
+          .select({ value: count() })
+          .from(agents)
+          .where(eq(agents.status, 'idle'));
+        idle = row?.value ?? 0;
+      } catch (countErr) {
+        log.warn('refreshAgentGauges: idle count query failed', {
+          error: countErr instanceof Error ? countErr.message : String(countErr),
+        });
+      }
+      metrics.setAgentGauge(running, idle);
+    } catch (gaugeErr) {
+      log.warn('refreshAgentGauges: setAgentGauge failed', {
+        error: gaugeErr instanceof Error ? gaugeErr.message : String(gaugeErr),
+      });
+    }
+  }
+
+  /**
+   * F10-14: bump a single agent lifecycle counter (started/completed/errored).
+   * Wrapped so an instrumentation failure cannot break a transition.
+   */
+  private incAgentMetric(kind: 'started' | 'completed' | 'errored'): void {
+    try {
+      const metrics = getMetricsService();
+      if (kind === 'started') metrics.incAgentStarted();
+      else if (kind === 'completed') metrics.incAgentCompleted();
+      else metrics.incAgentErrored();
+    } catch (metricsErr) {
+      log.warn('incAgentMetric failed', {
+        error: metricsErr instanceof Error ? metricsErr.message : String(metricsErr),
+        data: { kind },
+      });
+    }
   }
 
   /**
@@ -362,9 +415,12 @@ export class AgentExecutionService {
     agentId: string,
     taskId?: string
   ): Promise<Result<AgentStartResult, AgentError | ConcurrencyError>> {
-    const agent = await this.db.query.agents.findFirst({
-      where: eq(agents.id, agentId),
-    });
+    // F10-14: hot path — every drag-to-in_progress hits this lookup.
+    const agent = await withDbLatency('select_agent', () =>
+      this.db.query.agents.findFirst({
+        where: eq(agents.id, agentId),
+      })
+    );
 
     if (!agent) {
       return err(AgentErrors.NOT_FOUND);
@@ -375,21 +431,26 @@ export class AgentExecutionService {
       return err(AgentErrors.ALREADY_RUNNING(agent.currentTaskId ?? undefined));
     }
 
+    // F10-14: hot read on the task table during start().
     let task = taskId
-      ? await this.db.query.tasks.findFirst({
-          where: eq(tasks.id, taskId),
-        })
+      ? await withDbLatency('select_task', () =>
+          this.db.query.tasks.findFirst({
+            where: eq(tasks.id, taskId),
+          })
+        )
       : null;
 
     if (!task) {
       // Look for queued tasks first (FIFO), then backlog
-      task = await this.db.query.tasks.findFirst({
-        where: and(
-          eq(tasks.codespaceId, agent.codespaceId),
-          inArray(tasks.column, ['queued', 'backlog'])
-        ),
-        orderBy: asc(tasks.updatedAt),
-      });
+      task = await withDbLatency('select_next_task', () =>
+        this.db.query.tasks.findFirst({
+          where: and(
+            eq(tasks.codespaceId, agent.codespaceId),
+            inArray(tasks.column, ['queued', 'backlog'])
+          ),
+          orderBy: asc(tasks.updatedAt),
+        })
+      );
     }
 
     if (!task) {
@@ -519,6 +580,11 @@ export class AgentExecutionService {
     const controller = new AbortController();
     this.runningAgents.set(agentId, controller);
     this.agentStartTimes.set(agentId, Date.now());
+
+    // F10-14: bump the agent_started counter and refresh the gauges. The
+    // gauge refresh is async but fire-and-forget — it must not delay start().
+    this.incAgentMetric('started');
+    void this.refreshAgentGauges();
 
     // Get codespace for model configuration
     const codespace = await this.db.query.codespaces.findFirst({
@@ -820,6 +886,10 @@ export class AgentExecutionService {
             completedAt: new Date().toISOString(),
           })
           .where(eq(tasks.id, taskId));
+
+        // F10-14: planning completed without needing user approval is rare but
+        // does happen (e.g. trivial task) — count it as a completed run.
+        this.incAgentMetric('completed');
       } else if (result.status === 'turn_limit' || result.status === 'paused') {
         await this.db
           .update(agents)
@@ -844,6 +914,9 @@ export class AgentExecutionService {
             currentTurn: result.turnCount,
           })
           .where(eq(agents.id, agentId));
+
+        // F10-14: planning-phase error counted as an errored run.
+        this.incAgentMetric('errored');
       }
 
       // Read insight IDs before cleanup deletes them (fire-and-forget race fix)
@@ -872,6 +945,9 @@ export class AgentExecutionService {
       this.preToolHooks.delete(agentId);
       this.postToolHooks.delete(agentId);
 
+      // F10-14: refresh running/idle gauges after the runningAgents map shrinks.
+      void this.refreshAgentGauges();
+
       // Auto-dequeue: when an agent completes, check if there's a queued task to pick up
       if (result.status === 'completed' && this.queueService) {
         this.tryDequeueAndStart(agentId).catch((dequeueErr) => {
@@ -891,6 +967,8 @@ export class AgentExecutionService {
         taskId,
         sessionId,
       });
+      // F10-14: planning-phase throw counts as an errored run.
+      this.incAgentMetric('errored');
       this.finalizeMemorySession(memoryRef, agentId, 'planning error', { status: 'failed' });
 
       const errMsg = errorMessage(error);
@@ -977,6 +1055,9 @@ export class AgentExecutionService {
       this.agentStartTimes.delete(agentId);
       this.preToolHooks.delete(agentId);
       this.postToolHooks.delete(agentId);
+
+      // F10-14: refresh running/idle gauges after the planning-phase failure.
+      void this.refreshAgentGauges();
     }
   }
 
@@ -1018,6 +1099,9 @@ export class AgentExecutionService {
         updatedAt: new Date().toISOString(),
       })
       .where(eq(agents.id, agentId));
+
+    // F10-14: agent moved to idle — refresh the gauges.
+    void this.refreshAgentGauges();
 
     return ok(undefined);
   }
@@ -1108,6 +1192,9 @@ export class AgentExecutionService {
         this.agentStartTimes.delete(agentId);
         this.preToolHooks.delete(agentId);
         this.postToolHooks.delete(agentId);
+        // F10-14: errored at resume-execution boundary.
+        this.incAgentMetric('errored');
+        void this.refreshAgentGauges();
       });
 
       return ok({
@@ -1223,6 +1310,9 @@ export class AgentExecutionService {
         this.agentStartTimes.delete(agentId);
         this.preToolHooks.delete(agentId);
         this.postToolHooks.delete(agentId);
+        // F10-14: missing-agent during execution counts as an errored run.
+        this.incAgentMetric('errored');
+        void this.refreshAgentGauges();
         return;
       }
 
@@ -1389,6 +1479,9 @@ export class AgentExecutionService {
             completedAt: new Date().toISOString(),
           })
           .where(eq(tasks.id, task.id));
+
+        // F10-14: execution completed → bump completed counter.
+        this.incAgentMetric('completed');
       } else if (result.status === 'turn_limit' || result.status === 'paused') {
         await this.db
           .update(agents)
@@ -1412,6 +1505,9 @@ export class AgentExecutionService {
             currentTurn: result.turnCount,
           })
           .where(eq(agents.id, agentId));
+
+        // F10-14: execution-phase error counter.
+        this.incAgentMetric('errored');
       }
 
       // Read insight IDs before cleanup deletes them (fire-and-forget race fix)
@@ -1441,6 +1537,9 @@ export class AgentExecutionService {
       this.preToolHooks.delete(agentId);
       this.postToolHooks.delete(agentId);
 
+      // F10-14: refresh running/idle gauges after the runningAgents map shrinks.
+      void this.refreshAgentGauges();
+
       // Auto-dequeue: when agent completes execution, check for queued tasks
       if (result.status === 'completed' && this.queueService) {
         this.tryDequeueAndStart(agentId).catch((dequeueErr) => {
@@ -1460,6 +1559,8 @@ export class AgentExecutionService {
         taskId: task.id,
         sessionId,
       });
+      // F10-14: execution-phase throw counts as an errored run.
+      this.incAgentMetric('errored');
       this.finalizeMemorySession(memoryRef, agentId, 'execution error', {
         status: 'failed',
       });
@@ -1545,6 +1646,9 @@ export class AgentExecutionService {
       this.agentStartTimes.delete(agentId);
       this.preToolHooks.delete(agentId);
       this.postToolHooks.delete(agentId);
+
+      // F10-14: refresh running/idle gauges after execution-phase failure.
+      void this.refreshAgentGauges();
     }
   }
 
@@ -1641,6 +1745,8 @@ export class AgentExecutionService {
           data: { agentId, taskId },
         });
       }
+      // F10-14: agent stopped via plan rejection — refresh gauges.
+      void this.refreshAgentGauges();
     }
 
     // CAS-move: only reject if the task is still in the `planning` status.
@@ -1801,6 +1907,7 @@ export class AgentExecutionService {
       });
 
     const now = Date.now();
+    let sweptAny = false;
     for (const [agentId, startTime] of this.agentStartTimes) {
       if (now - startTime > this.maxAgentRuntimeMs) {
         log.warn('Sweeping orphaned agent', {
@@ -1826,8 +1933,14 @@ export class AgentExecutionService {
               data: { agentId },
             });
           });
+
+        // F10-14: orphaned agent counts as an errored run.
+        this.incAgentMetric('errored');
+        sweptAny = true;
       }
     }
+    // F10-14: only refresh gauges when at least one agent was swept.
+    if (sweptAny) void this.refreshAgentGauges();
   }
 
   /**
@@ -1845,6 +1958,16 @@ export class AgentExecutionService {
       controller.abort();
     }
     this.runningAgents.clear();
+    // F10-14: reset gauges when shutting down. Idle count is best-effort 0;
+    // the next periodic gauge refresh from any subsequent transition will
+    // reconcile against the DB.
+    try {
+      getMetricsService().setAgentGauge(0, 0);
+    } catch (gaugeErr) {
+      log.warn('stopAll: setAgentGauge failed', {
+        error: gaugeErr instanceof Error ? gaugeErr.message : String(gaugeErr),
+      });
+    }
     this.agentStartTimes.clear();
     this.preToolHooks.clear();
     this.postToolHooks.clear();

--- a/tests/integration/metrics-wire-up.test.ts
+++ b/tests/integration/metrics-wire-up.test.ts
@@ -1,0 +1,351 @@
+/**
+ * F10-14 — MetricsService wire-up integration tests.
+ *
+ * Verifies that real service code paths populate the metrics surface so the
+ * `/api/metrics` endpoint is no longer a hollow shell. Each test exercises
+ * the actual production call site (not direct metricsService method calls)
+ * and asserts the snapshot reflects the change.
+ *
+ * Test bar (red→green):
+ *  - Without the wire-up: counters return 0.
+ *  - With the wire-up: counters increment as side effects of normal flow.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agents } from '../../src/db/schema';
+import {
+  __resetEventRouterForTests,
+  acquireSseSlot,
+  releaseSseSlot,
+} from '../../src/lib/events/event-router';
+import { AgentExecutionService } from '../../src/services/agent/agent-execution.service';
+import { __resetMetricsService, getMetricsService } from '../../src/services/metrics.service';
+import { createTestAgent } from '../factories/agent.factory';
+import { createTestProject } from '../factories/project.factory';
+import { createTestSession } from '../factories/session.factory';
+import { createTestTask } from '../factories/task.factory';
+import { createTestWorktree } from '../factories/worktree.factory';
+import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
+
+// Mock external I/O boundaries so async background execution does not race
+// with assertions. Mirrors the pattern from agent-execution-service.test.ts.
+vi.mock('../../src/lib/agents/stream-handler.js', () => ({
+  runAgentPlanning: vi.fn().mockReturnValue(new Promise(() => {})),
+  runAgentExecution: vi.fn().mockReturnValue(new Promise(() => {})),
+}));
+vi.mock('../../src/lib/agents/recovery.js', () => ({
+  handleAgentError: vi.fn().mockReturnValue({ action: 'stop', retry: false }),
+}));
+vi.mock('../../src/services/settings.service.js', () => ({
+  getGlobalDefaultModel: vi.fn().mockResolvedValue('claude-sonnet-4-6'),
+  getAgentMaxRuntimeMs: vi.fn().mockResolvedValue(4 * 60 * 60 * 1000),
+  DEFAULT_AGENT_MAX_RUNTIME_MS: 4 * 60 * 60 * 1000,
+}));
+vi.mock('../../src/lib/utils/resolve-model.js', () => ({
+  resolveModel: vi.fn().mockReturnValue('claude-sonnet-4-6'),
+}));
+vi.mock('../../src/services/session/event-metadata.js', () => ({
+  createSessionEventWithMetadata: vi.fn().mockImplementation((input) => ({
+    ...input,
+    id: 'test-event-id',
+    timestamp: new Date().toISOString(),
+  })),
+}));
+
+const mockWorktreeService = {
+  create: vi.fn(),
+  remove: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+};
+const mockSessionService = {
+  create: vi.fn(),
+  delete: vi.fn().mockResolvedValue({ ok: true, value: { deleted: true } }),
+  publish: vi.fn().mockResolvedValue({ ok: true, value: { offset: 0 } }),
+};
+const mockTaskService = {
+  moveColumn: vi.fn().mockResolvedValue({ ok: true }),
+};
+
+describe('F10-14 — MetricsService wire-up', () => {
+  let db: ReturnType<typeof getTestDb>;
+  let service: AgentExecutionService;
+
+  beforeEach(async () => {
+    await setupTestDatabase();
+    db = getTestDb();
+    vi.clearAllMocks();
+
+    // Reset the in-memory metrics + SSE counters so each test starts at zero.
+    __resetMetricsService();
+    __resetEventRouterForTests();
+
+    service = new AgentExecutionService(
+      // biome-ignore lint/suspicious/noExplicitAny: Test-only constructor injection.
+      db as any,
+      // biome-ignore lint/suspicious/noExplicitAny: Test-only constructor injection.
+      mockWorktreeService as any,
+      // biome-ignore lint/suspicious/noExplicitAny: Test-only constructor injection.
+      mockTaskService as any,
+      // biome-ignore lint/suspicious/noExplicitAny: Test-only constructor injection.
+      mockSessionService as any
+    );
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+    service.stopAll();
+  });
+
+  describe('agent_started counter', () => {
+    it('reports zero before any agent has started (baseline)', () => {
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.started).toBe(0);
+      expect(snap.agent.completed).toBe(0);
+      expect(snap.agent.errored).toBe(0);
+      expect(snap.agent.running).toBe(0);
+    });
+
+    it('increments after AgentExecutionService.start() succeeds', async () => {
+      const codespace = await createTestProject({ maxConcurrentAgents: 3 });
+      const agent = await createTestAgent(codespace.id, { status: 'idle' });
+      const task = await createTestTask(codespace.id, { column: 'backlog' });
+      const worktree = await createTestWorktree(codespace.id, { taskId: task.id });
+      const session = await createTestSession(codespace.id, {
+        taskId: task.id,
+        agentId: agent.id,
+      });
+
+      mockWorktreeService.create.mockResolvedValue({ ok: true, value: worktree });
+      mockSessionService.create.mockResolvedValue({
+        ok: true,
+        value: { ...session, presence: {} },
+      });
+
+      // Baseline: zero before start.
+      expect(getMetricsService().snapshot().agent.started).toBe(0);
+
+      const result = await service.start(agent.id, task.id);
+      expect(result.ok).toBe(true);
+
+      // The wire-up bumps the counter immediately after the controller is
+      // registered; the gauge refresh is fire-and-forget so we await a
+      // microtask flush before reading.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.started).toBeGreaterThanOrEqual(1);
+      expect(snap.agent.running).toBeGreaterThanOrEqual(1);
+    });
+
+    it('increments multiple times across multiple successful starts', async () => {
+      const codespace = await createTestProject({ maxConcurrentAgents: 5 });
+
+      // Two independent agent+task pairs, both started successfully.
+      for (let i = 0; i < 2; i++) {
+        const agent = await createTestAgent(codespace.id, {
+          status: 'idle',
+          name: `Agent ${i}`,
+        });
+        const task = await createTestTask(codespace.id, {
+          column: 'backlog',
+          title: `Task ${i}`,
+        });
+        const worktree = await createTestWorktree(codespace.id, { taskId: task.id });
+        const session = await createTestSession(codespace.id, {
+          taskId: task.id,
+          agentId: agent.id,
+        });
+
+        mockWorktreeService.create.mockResolvedValueOnce({ ok: true, value: worktree });
+        mockSessionService.create.mockResolvedValueOnce({
+          ok: true,
+          value: { ...session, presence: {} },
+        });
+
+        const result = await service.start(agent.id, task.id);
+        expect(result.ok).toBe(true);
+      }
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.started).toBe(2);
+    });
+
+    it('does not increment when start() fails (NOT_FOUND)', async () => {
+      const result = await service.start('nonexistent-agent-id');
+      expect(result.ok).toBe(false);
+
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.started).toBe(0);
+    });
+  });
+
+  describe('agent gauge (running/idle)', () => {
+    it('reflects running agents after start()', async () => {
+      const codespace = await createTestProject({ maxConcurrentAgents: 3 });
+      const agent = await createTestAgent(codespace.id, { status: 'idle' });
+      const task = await createTestTask(codespace.id, { column: 'backlog' });
+      const worktree = await createTestWorktree(codespace.id, { taskId: task.id });
+      const session = await createTestSession(codespace.id, {
+        taskId: task.id,
+        agentId: agent.id,
+      });
+
+      mockWorktreeService.create.mockResolvedValue({ ok: true, value: worktree });
+      mockSessionService.create.mockResolvedValue({
+        ok: true,
+        value: { ...session, presence: {} },
+      });
+
+      await service.start(agent.id, task.id);
+
+      // The gauge refresh is async; wait for it to land.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.running).toBe(1);
+    });
+
+    it('returns running back to zero after stop()', async () => {
+      const codespace = await createTestProject({ maxConcurrentAgents: 3 });
+      const agent = await createTestAgent(codespace.id, { status: 'idle' });
+      const task = await createTestTask(codespace.id, { column: 'backlog' });
+      const worktree = await createTestWorktree(codespace.id, { taskId: task.id });
+      const session = await createTestSession(codespace.id, {
+        taskId: task.id,
+        agentId: agent.id,
+      });
+
+      mockWorktreeService.create.mockResolvedValue({ ok: true, value: worktree });
+      mockSessionService.create.mockResolvedValue({
+        ok: true,
+        value: { ...session, presence: {} },
+      });
+
+      await service.start(agent.id, task.id);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Force agent into a state that allows ABORT (stop()'s state-machine
+      // check rejects 'starting'/'planning' transitions). Mirroring the
+      // production path: planning → running via approval, then stop.
+      await db.update(agents).set({ status: 'running' }).where(eq(agents.id, agent.id));
+
+      const stopResult = await service.stop(agent.id);
+      expect(stopResult.ok).toBe(true);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.running).toBe(0);
+    });
+  });
+
+  describe('SSE active-connections gauge', () => {
+    it('increments on acquireSseSlot() and decrements on releaseSseSlot()', () => {
+      // Baseline.
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(0);
+
+      // Acquire two slots on different routes.
+      const a = acquireSseSlot('/api/events', 'user-1');
+      expect(a.ok).toBe(true);
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(1);
+
+      const b = acquireSseSlot('/api/cli-monitor/stream', 'user-2');
+      expect(b.ok).toBe(true);
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(2);
+
+      // Release one — gauge drops by one.
+      releaseSseSlot('/api/events', 'user-1');
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(1);
+
+      // Release the other.
+      releaseSseSlot('/api/cli-monitor/stream', 'user-2');
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(0);
+    });
+
+    it('does not decrement on a stale release (no matching acquire)', () => {
+      // No active slots; releasing should be a no-op.
+      releaseSseSlot('/api/events', 'phantom-user');
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(0);
+
+      // Now acquire one and try to release a different route — also no-op
+      // because the route side guard refuses unmatched releases.
+      const a = acquireSseSlot('/api/events', 'user-1');
+      expect(a.ok).toBe(true);
+      releaseSseSlot('/api/cli-monitor/stream', 'user-1');
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(1);
+
+      // Cleanup.
+      releaseSseSlot('/api/events', 'user-1');
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(0);
+    });
+
+    it('gauge clamps at zero on over-release (parity with metrics service)', () => {
+      const a = acquireSseSlot('/api/events', 'user-1');
+      expect(a.ok).toBe(true);
+      releaseSseSlot('/api/events', 'user-1');
+      // Second release is stale (router guard returns early).
+      releaseSseSlot('/api/events', 'user-1');
+      expect(getMetricsService().snapshot().sse.activeConnections).toBe(0);
+    });
+  });
+
+  describe('DB latency histogram', () => {
+    it('records select_agent latency on AgentExecutionService.start() lookup', async () => {
+      // Cold call: agent does not exist. The lookup still goes through
+      // withDbLatency('select_agent'), so a sample should be recorded.
+      const result = await service.start('nonexistent-agent-id');
+      expect(result.ok).toBe(false);
+
+      const snap = getMetricsService().snapshot();
+      const selectAgent = snap.db.byQueryType.find((q) => q.queryType === 'select_agent');
+      expect(selectAgent).toBeDefined();
+      expect(selectAgent?.count).toBeGreaterThanOrEqual(1);
+    });
+
+    it('aggregates samples across multiple start() calls', async () => {
+      // Three failed starts → three select_agent samples.
+      for (let i = 0; i < 3; i++) {
+        await service.start(`nonexistent-${i}`);
+      }
+
+      const snap = getMetricsService().snapshot();
+      const selectAgent = snap.db.byQueryType.find((q) => q.queryType === 'select_agent');
+      expect(selectAgent?.count).toBe(3);
+      expect(selectAgent?.totalMs).toBeGreaterThanOrEqual(0);
+      expect(selectAgent?.maxMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('end-to-end: /api/metrics surfaces non-zero values', () => {
+    it('a successful start() produces a non-zero agent_started count in the snapshot', async () => {
+      const codespace = await createTestProject({ maxConcurrentAgents: 3 });
+      const agent = await createTestAgent(codespace.id, { status: 'idle' });
+      const task = await createTestTask(codespace.id, { column: 'backlog' });
+      const worktree = await createTestWorktree(codespace.id, { taskId: task.id });
+      const session = await createTestSession(codespace.id, {
+        taskId: task.id,
+        agentId: agent.id,
+      });
+
+      mockWorktreeService.create.mockResolvedValue({ ok: true, value: worktree });
+      mockSessionService.create.mockResolvedValue({
+        ok: true,
+        value: { ...session, presence: {} },
+      });
+
+      await service.start(agent.id, task.id);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // This is the contract enforced by the F10-14 fix:
+      // /api/metrics → MetricsService.snapshot() → agent.started > 0.
+      // Without the wire-up this assertion would fail because the counter
+      // would still be 0.
+      const snap = getMetricsService().snapshot();
+      expect(snap.agent.started).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`MetricsService` was a hollow shell — `incAgentStarted`, `setAgentGauge`, `incSse`/`decSse`, and `recordDbLatency` had **zero** call sites outside the metrics module itself. The `/api/metrics` endpoint exposed them but always reported zeros for `agent.*` and `db.byQueryType`. Operations could not answer "how many agents are running right now" or "what's the p95 DB latency" from the production metrics surface.

This PR wires call sites for **all four** method families.

### Wire-up

1. **Agent lifecycle** (`src/services/agent/agent-execution.service.ts`)
   - `incAgentStarted()` after a successful `start()` registers the AbortController.
   - `incAgentCompleted()` on success branches (planning + execution).
   - `incAgentErrored()` on every error branch — including outer try/catch, orphan sweep, resume-execution failure, and missing-agent paths.
   - `setAgentGauge(running, idle)` via a new `refreshAgentGauges()` helper, called after every transition that mutates the `runningAgents` map. Idle count comes from a `COUNT(*)` agents query so cross-process state is reflected.
   - All metric calls wrapped in best-effort try/catch so instrumentation can never break a transition.

2. **SSE acquire/release** (`src/lib/events/event-router.ts`)
   - `incSse()` on successful `acquireSseSlot()`.
   - `decSse()` on `releaseSseSlot()` after the actual decrement (the existing stale-release guard returns early without calling, matching the no-op semantics).
   - Single choke point covers both `/api/events` and `/api/cli-monitor/stream`.

3. **DB latency** (`src/lib/db/with-latency.ts` — new helper)
   - `withDbLatency('query_type', () => db.query...)` wraps a Drizzle call and records elapsed ms.
   - Wired at the readiness probe (`readiness_probe`) and `AgentExecutionService.start()` agent + task lookups (`select_agent`, `select_task`, `select_next_task`).
   - Try/finally ensures timing is recorded even on error; original error is rethrown.

### Test plan

- [x] **Integration test** `tests/integration/metrics-wire-up.test.ts` — 12 tests covering every wired counter. Without the fix, `agent.started === 0` after a successful start; with the fix, `agent.started >= 1`.
- [x] SSE gauge: increments on acquire, decrements on release, clamps at zero on stale releases.
- [x] DB latency samples appear in `db.byQueryType` after a `start()` attempt (even a failed one — the agent lookup still runs through `withDbLatency`).
- [x] Pre-existing tests remain green (81-test sweep across event-router, durable-streams, agent-execution-lifecycle, agent-concurrency-guard, health, cli-monitor, metrics service + route).
- [x] `npx tsc --noEmit` clean.
- [x] `npx @biomejs/biome check src/` clean.

### Hard constraints

- No new infrastructure (no prom-client deploy).
- All four method families wired, not partial.
- Biome + tsc + integration tests pass.

### Cross-links

- F10-14 (April 29 review, P1) — the missing wiring for April 20's F10-01.

Signed-off-by: Simon Lynch <srlynch@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
