### PR TITLE
fix(arch29-W2-N): rate limiter SQLite persistence (F06-NEW-08)

### DIFF
--- a/src/db/migrations-pg/0016_add_rate_limit_buckets.sql
+++ b/src/db/migrations-pg/0016_add_rate_limit_buckets.sql
@@ -1,0 +1,14 @@
+-- F06-NEW-08: Persist rate-limit counters across process restarts.
+--
+-- Mirrors SQLite migration 0022_add_rate_limit_buckets.sql.
+
+CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+  key TEXT NOT NULL,
+  window_start BIGINT NOT NULL,
+  window_ms BIGINT NOT NULL,
+  count BIGINT NOT NULL DEFAULT 0,
+  updated_at BIGINT NOT NULL,
+  PRIMARY KEY (key, window_start)
+);
+
+CREATE INDEX IF NOT EXISTS rate_limit_buckets_updated_at_idx ON rate_limit_buckets(updated_at);

--- a/src/db/migrations-pg/meta/_journal.json
+++ b/src/db/migrations-pg/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777852800000,
       "tag": "0015_add_session_events_stream_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777939200000,
+      "tag": "0016_add_rate_limit_buckets",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/0022_add_rate_limit_buckets.sql
+++ b/src/db/migrations/0022_add_rate_limit_buckets.sql
@@ -1,0 +1,19 @@
+-- F06-NEW-08: Persist rate-limit counters across process restarts.
+--
+-- The previous in-memory `Map`-backed limiter would reset every time the
+-- server restarted, making the limiter trivially bypassable. Each row is
+-- a single bucket: (key, window_start, count). Composite primary key on
+-- (key, window_start) lets concurrent inserts dedupe via INSERT ... ON
+-- CONFLICT DO UPDATE. Cleanup of expired buckets older than 24h runs as
+-- a BackgroundJob.
+
+CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+  key TEXT NOT NULL,
+  window_start INTEGER NOT NULL,
+  window_ms INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (key, window_start)
+);
+
+CREATE INDEX IF NOT EXISTS rate_limit_buckets_updated_at_idx ON rate_limit_buckets(updated_at);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777852800000,
       "tag": "0021_add_session_events_stream_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1777939200000,
+      "tag": "0022_add_rate_limit_buckets",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/postgres/index.ts
+++ b/src/db/schema/postgres/index.ts
@@ -20,6 +20,7 @@ export * from './memory-insights';
 export * from './memory-messages';
 export * from './plan-sessions';
 export * from './project-folders';
+export * from './rate-limit-buckets';
 export * from './relations';
 export * from './sandbox-configs';
 export * from './sandboxes';

--- a/src/db/schema/postgres/rate-limit-buckets.ts
+++ b/src/db/schema/postgres/rate-limit-buckets.ts
@@ -1,0 +1,25 @@
+/**
+ * rate_limit_buckets — F06-NEW-08 (Postgres).
+ *
+ * Mirrors the SQLite schema. See `sqlite/rate-limit-buckets.ts` for full notes.
+ */
+
+import { bigint, index, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+
+export const rateLimitBuckets = pgTable(
+  'rate_limit_buckets',
+  {
+    key: text('key').notNull(),
+    windowStart: bigint('window_start', { mode: 'number' }).notNull(),
+    windowMs: bigint('window_ms', { mode: 'number' }).notNull(),
+    count: bigint('count', { mode: 'number' }).notNull().default(0),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.key, table.windowStart] }),
+    index('rate_limit_buckets_updated_at_idx').on(table.updatedAt),
+  ]
+);
+
+export type RateLimitBucketRow = typeof rateLimitBuckets.$inferSelect;
+export type NewRateLimitBucketRow = typeof rateLimitBuckets.$inferInsert;

--- a/src/db/schema/sqlite/index.ts
+++ b/src/db/schema/sqlite/index.ts
@@ -20,6 +20,7 @@ export * from './memory-insights';
 export * from './memory-messages';
 export * from './plan-sessions';
 export * from './project-folders';
+export * from './rate-limit-buckets';
 export * from './relations';
 export * from './sandbox-configs';
 export * from './sandboxes';

--- a/src/db/schema/sqlite/rate-limit-buckets.ts
+++ b/src/db/schema/sqlite/rate-limit-buckets.ts
@@ -1,0 +1,42 @@
+/**
+ * rate_limit_buckets — F06-NEW-08.
+ *
+ * Persists rate-limit counters across process restarts. The previous in-memory
+ * `Map`-backed limiter would reset every time the server restarted, which made
+ * the limiter trivially bypassable on a deploy or crash. Each row represents a
+ * single bucket: `(key, windowStart, count)`.
+ *
+ * The composite primary key on `(key, window_start)` ensures concurrent inserts
+ * for the same bucket dedupe via `onConflictDoUpdate`. Cleanup of expired
+ * buckets older than 24h runs as a {@link BackgroundJob} so the table is
+ * bounded.
+ *
+ * Hard constraint: no Redis. SQLite + Drizzle is the only durable store
+ * available and is sufficient for single-instance deployments. Multi-instance
+ * deployments still suffer the same drift documented at `rate-limiter.ts:131`.
+ */
+
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const rateLimitBuckets = sqliteTable(
+  'rate_limit_buckets',
+  {
+    /** Bucket identifier (e.g. `user:abc`, `token:xyz`, `ip:1.2.3.4`). */
+    key: text('key').notNull(),
+    /** Window start timestamp in epoch ms. Buckets are quantised on this. */
+    windowStart: integer('window_start').notNull(),
+    /** Window length in ms (60_000 by default). Stored so cleanup can compute expiry. */
+    windowMs: integer('window_ms').notNull(),
+    /** Number of requests counted in this window. */
+    count: integer('count').notNull().default(0),
+    /** Epoch ms — set on every increment for cleanup ordering. */
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.key, table.windowStart] }),
+    index('rate_limit_buckets_updated_at_idx').on(table.updatedAt),
+  ]
+);
+
+export type RateLimitBucketRow = typeof rateLimitBuckets.$inferSelect;
+export type NewRateLimitBucketRow = typeof rateLimitBuckets.$inferInsert;

--- a/src/lib/api/rate-limiter.ts
+++ b/src/lib/api/rate-limiter.ts
@@ -6,18 +6,24 @@
  * present, and finally falls back to the (trusted-proxy-aware) client IP
  * for unauthenticated requests.
  *
- * Storage is in-process (`Map`) for the default backend. Swapping in Redis
- * is a drop-in change: implement the tiny `RateLimitBackend` interface and
- * pass it in via `rateLimiter({ backend: redisBackend })`. The in-memory
- * backend logs a one-time warning on startup so multi-instance deployments
- * know they are running with per-instance counters until Redis is wired.
+ * F06-NEW-08: persistence backends.
+ *   - `createInMemoryBackend()` — default for tests / dev. Counters reset on
+ *     restart, so do not use in production.
+ *   - `createSqliteBackend(db)` — persists buckets in the `rate_limit_buckets`
+ *     Drizzle table. Counters survive process restarts so a deploy or crash
+ *     no longer grants every limited client a fresh quota. Uses `INSERT ...
+ *     ON CONFLICT DO UPDATE` for atomic per-tick increment.
  *
- * IMPORTANT (AR-031): When running multiple app instances behind a load
- * balancer, the in-memory backend multiplies the effective limit by the
- * number of instances. Use a Redis-backed `RateLimitBackend` in production.
+ * Hard constraint: no Redis, no external infrastructure. Multi-instance
+ * deployments still suffer the documented drift at `:131-141` because each
+ * process owns its own SQLite file; for hosted multi-instance, a follow-up
+ * is needed to share state. Single-instance is the supported topology.
  */
 
+import { lt, sql } from 'drizzle-orm';
 import type { Context, Next } from 'hono';
+import { rateLimitBuckets } from '../../db/schema/sqlite/rate-limit-buckets.js';
+import type { Database } from '../../types/database.js';
 import { createLogger } from '../logging/logger.js';
 import type { AuthContext } from './auth-middleware.js';
 
@@ -180,6 +186,153 @@ export function createInMemoryBackend(): RateLimitBackend {
       }
       entry.count += 1;
       return entry;
+    },
+  };
+}
+
+/**
+ * F06-NEW-08: SQLite-backed rate-limit backend.
+ *
+ * Each rate-limit window is persisted as a row in `rate_limit_buckets`. The
+ * window-start timestamp quantises the bucket: every request inside the same
+ * window upserts the same `(key, windowStart)` row, atomically incrementing
+ * `count` via Drizzle's `onConflictDoUpdate`. On process restart the rows
+ * persist, so a client that exceeded the limit before the restart is still
+ * blocked for the remainder of the window.
+ *
+ * Drizzle-only — no raw SQL. Per-tick latency adds one upsert; the composite
+ * primary key on `(key, window_start)` makes this an O(log n) write. The
+ * cleanup job (see {@link createRateLimitCleanupJob}) trims expired rows
+ * older than 24h so the table stays bounded.
+ *
+ * Caveats:
+ *   - Multi-instance deployments still drift because each process writes to
+ *     its own SQLite file (per the hard "no Redis" constraint). The single
+ *     supported topology is single-instance. Hosted multi-instance is a
+ *     follow-up; the architectural note at `:131-141` still applies.
+ *   - The window is *aligned*, not *sliding* — `windowStart = floor(now /
+ *     windowMs) * windowMs`. A burst that crosses a window boundary may
+ *     temporarily exceed the soft cap by 2x just like the in-memory limiter.
+ *     This matches the original Map-backed semantics; a sliding window would
+ *     require a different schema (rolling sum or token bucket).
+ */
+export function createSqliteBackend(db: Database): RateLimitBackend {
+  return {
+    incr: async (key, windowMs) => {
+      const now = Date.now();
+      // Align the bucket to the windowMs boundary so the same window
+      // accumulates into a single row regardless of when the request hits.
+      const windowStart = Math.floor(now / windowMs) * windowMs;
+      const resetAt = windowStart + windowMs;
+
+      // Drizzle-only upsert: insert a fresh row for a new bucket, or atomically
+      // bump count + updatedAt for an existing one. The composite primary key
+      // (key, windowStart) guarantees per-bucket dedupe under concurrent
+      // requests. `count + 1` runs server-side so two concurrent inserts can
+      // never lose an increment.
+      const inserted = await db
+        .insert(rateLimitBuckets)
+        .values({
+          key,
+          windowStart,
+          windowMs,
+          count: 1,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [rateLimitBuckets.key, rateLimitBuckets.windowStart],
+          set: {
+            count: sql`${rateLimitBuckets.count} + 1`,
+            updatedAt: now,
+          },
+        })
+        .returning({ count: rateLimitBuckets.count });
+
+      const count = inserted[0]?.count ?? 1;
+      return { count, resetAt };
+    },
+  };
+}
+
+/**
+ * F06-NEW-08: BackgroundJob that periodically deletes expired rate-limit
+ * rows. Kept as a standalone job so it can register with the existing
+ * {@link import('../background/job.js').BackgroundJobRegistry} alongside
+ * EventCleanup, EventOutboxRelay, etc.
+ *
+ * Cleanup policy: rows whose window ended >24h ago are deleted. The 24h
+ * grace period is generous — a 1-minute window's row is "expired" the
+ * moment `windowStart + windowMs < now`, but we keep them around for the
+ * same period as a session-event retention floor so audit queries can see
+ * "did this IP get rate-limited yesterday?".
+ */
+const CLEANUP_RETENTION_MS = 24 * 60 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+
+export interface RateLimitCleanupJob {
+  readonly name: string;
+  start(): void;
+  stop(): void;
+  /** Run a single cleanup pass synchronously — useful in tests. */
+  runOnce(): Promise<number>;
+  healthSnapshot(): { name: string; running: boolean; lastRunAt?: string; lastError?: string };
+}
+
+export function createRateLimitCleanupJob(db: Database): RateLimitCleanupJob {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let running = false;
+  let lastRunAt: string | null = null;
+  let lastError: string | null = null;
+
+  async function runOnce(): Promise<number> {
+    const cutoff = Date.now() - CLEANUP_RETENTION_MS;
+    try {
+      // Delete rows whose window ended (windowStart + windowMs) before the cutoff.
+      // We compare on `updatedAt` because it always points at the most recent
+      // touch; an idle bucket will not be re-touched and is safe to prune.
+      const result = await db
+        .delete(rateLimitBuckets)
+        .where(lt(rateLimitBuckets.updatedAt, cutoff))
+        .returning({ key: rateLimitBuckets.key });
+      lastRunAt = new Date().toISOString();
+      lastError = null;
+      return result.length;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      log.warn('Rate-limit cleanup failed', { data: { error: lastError } });
+      return 0;
+    }
+  }
+
+  return {
+    name: 'rateLimitCleanup',
+    start() {
+      if (running) return;
+      running = true;
+      // First sweep happens on a delay so we don't stall the boot phase.
+      timer = setInterval(() => {
+        void runOnce();
+      }, CLEANUP_INTERVAL_MS);
+      if (timer && typeof timer === 'object' && 'unref' in timer) {
+        (timer as { unref: () => void }).unref();
+      }
+    },
+    stop() {
+      if (!running) return;
+      running = false;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    runOnce,
+    healthSnapshot() {
+      return {
+        name: 'rateLimitCleanup',
+        running,
+        lastRunAt: lastRunAt ?? undefined,
+        lastError: lastError ?? undefined,
+      };
     },
   };
 }

--- a/src/lib/bootstrap/migrations/index.ts
+++ b/src/lib/bootstrap/migrations/index.ts
@@ -527,4 +527,25 @@ CREATE INDEX IF NOT EXISTS session_events_session_type_idx ON session_events(ses
 CREATE INDEX IF NOT EXISTS session_events_stream_kind_session_idx ON session_events(stream_kind, session_id);
 `,
   },
+
+  // 35. F06-NEW-08: persist rate-limit counters across restarts.
+  // Each row is a single bucket: (key, window_start, count). Composite primary
+  // key on (key, window_start) lets concurrent inserts dedupe via INSERT ...
+  // ON CONFLICT DO UPDATE. Cleanup of expired buckets older than 24h runs as
+  // a BackgroundJob.
+  {
+    version: 35,
+    name: 'rate-limit-buckets',
+    sql: `
+CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+  key TEXT NOT NULL,
+  window_start INTEGER NOT NULL,
+  window_ms INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (key, window_start)
+);
+CREATE INDEX IF NOT EXISTS rate_limit_buckets_updated_at_idx ON rate_limit_buckets(updated_at);
+`,
+  },
 ];

--- a/src/server/bootstrap/phases/schedulers.ts
+++ b/src/server/bootstrap/phases/schedulers.ts
@@ -10,6 +10,7 @@
  * failure in one job's `stop()` does not strand timers in another.
  */
 
+import { createRateLimitCleanupJob } from '../../../lib/api/rate-limiter.js';
 import { type BackgroundJob, BackgroundJobRegistry } from '../../../lib/background/job.js';
 import { createLogger } from '../../../lib/logging/logger.js';
 import { EventCleanupService } from '../../../services/event-cleanup.service.js';
@@ -58,6 +59,13 @@ export async function startSchedulers(
   // wire, every non-ephemeral `DurableStreamsService.publish()` call would
   // silently accumulate rows in `event_outbox` that never get delivered.
   registry.register(services.eventOutboxRelayService satisfies BackgroundJob);
+
+  // F06-NEW-08: register the rate-limit cleanup job. The SQLite-backed
+  // backend writes one row per (key, windowStart); without this sweep the
+  // table grows unbounded. Trim policy: rows older than 24h are deleted
+  // hourly. The job is a thin wrapper around a Drizzle DELETE so registering
+  // a fresh instance per bootstrap is safe.
+  registry.register(createRateLimitCleanupJob(db) satisfies BackgroundJob);
 
   // Register the registry drain with the shutdown handler *before* any
   // scheduler-start failure can return early. Without this, a task scheduler

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -13,7 +13,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { apiTokens } from '../db/schema/sqlite/api-tokens.js';
 import { userSessions } from '../db/schema/sqlite/user-sessions.js';
 import { getAuthContext } from '../lib/api/auth-middleware.js';
-import { rateLimiter } from '../lib/api/rate-limiter.js';
+import { createSqliteBackend, rateLimiter } from '../lib/api/rate-limiter.js';
 import { enrichAuthContext, requireRole, requireTagAccess } from '../lib/api/rbac-middleware.js';
 import { requestContextStorage } from '../lib/context/request-context.js';
 import { publishEventToStream } from '../lib/events/event-bus.js';
@@ -315,6 +315,13 @@ function useRoleGuard(
 export function createRouter(deps: RouterDependencies) {
   const app = new Hono();
 
+  // F06-NEW-08: shared SQLite-backed rate-limit store. Persists buckets so a
+  // process restart does not reset limit counters. The same backend instance
+  // is reused across all four rate-limit middlewares below — they only differ
+  // in `max`, `windowMs`, and `keyFrom`, so sharing the backend avoids
+  // creating four independent in-memory stores.
+  const rateLimitBackend = createSqliteBackend(deps.db);
+
   // AR-026: CORS is configured as single-origin by design.
   // In production with Caddy as front door, browser requests are same-origin
   // so CORS is not strictly needed. However, CORS is kept for:
@@ -340,7 +347,10 @@ export function createRouter(deps: RouterDependencies) {
   // Public webhook endpoint - no auth required (signature-verified by plugin)
   if (deps.eventProcessingService) {
     // Rate-limit webhooks: 60 requests per minute per IP
-    app.use('/hooks/events/*', rateLimiter({ max: 60, windowMs: 60_000 }));
+    app.use(
+      '/hooks/events/*',
+      rateLimiter({ max: 60, windowMs: 60_000, backend: rateLimitBackend })
+    );
     app.post('/hooks/events/:slug', async (c) => {
       try {
         const slug = c.req.param('slug');
@@ -384,7 +394,10 @@ export function createRouter(deps: RouterDependencies) {
 
   // Public GitHub App webhook endpoint — no auth required (signature-verified)
   if (deps.githubAppService && deps.eventProcessingService) {
-    app.use('/hooks/github-app', rateLimiter({ max: 60, windowMs: 60_000 }));
+    app.use(
+      '/hooks/github-app',
+      rateLimiter({ max: 60, windowMs: 60_000, backend: rateLimitBackend })
+    );
     app.route(
       '/hooks/github-app',
       createGitHubAppWebhooksRoutes({
@@ -395,13 +408,16 @@ export function createRouter(deps: RouterDependencies) {
     );
   }
 
-  app.use('/api/*', rateLimiter({ max: 200, windowMs: 60_000 }));
+  app.use('/api/*', rateLimiter({ max: 200, windowMs: 60_000, backend: rateLimitBackend }));
   app.use('/api/*', createAuthMiddleware(deps.db));
   app.use('/api/*', enrichAuthContext(deps.db));
   // Per-token rate limiter: applies a stricter limit to API token requests.
   // Must run after enrichAuthContext which populates tokenScope on the auth context.
   // Non-token requests (session/dev auth) skip this limiter entirely.
-  app.use('/api/*', rateLimiter({ max: 100, windowMs: 60_000, keyOnToken: true }));
+  app.use(
+    '/api/*',
+    rateLimiter({ max: 100, windowMs: 60_000, keyOnToken: true, backend: rateLimitBackend })
+  );
   app.use('/api/*', requireTagAccess(deps.db));
 
   // --- RBAC role guards for existing routes ---

--- a/tests/helpers/database.ts
+++ b/tests/helpers/database.ts
@@ -287,6 +287,23 @@ CREATE INDEX IF NOT EXISTS session_events_stream_kind_session_idx ON session_eve
     // Idempotent — table may already have been rebuilt
   }
 
+  // F06-NEW-08: rate_limit_buckets (runtime v35).
+  try {
+    testSqlite.exec(`
+CREATE TABLE IF NOT EXISTS rate_limit_buckets (
+  key TEXT NOT NULL,
+  window_start INTEGER NOT NULL,
+  window_ms INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (key, window_start)
+);
+CREATE INDEX IF NOT EXISTS rate_limit_buckets_updated_at_idx ON rate_limit_buckets(updated_at);
+`);
+  } catch {
+    // Table may already exist
+  }
+
   return testDb;
 }
 
@@ -338,6 +355,7 @@ export async function clearTestDatabase(): Promise<void> {
       DELETE FROM audit_logs;
       DELETE FROM event_log;
       DELETE FROM event_outbox;
+      DELETE FROM rate_limit_buckets;
       DELETE FROM event_subscriptions;
       DELETE FROM event_sources;
       DELETE FROM agent_runs;

--- a/tests/integration/rate-limit-persistence.test.ts
+++ b/tests/integration/rate-limit-persistence.test.ts
@@ -1,0 +1,259 @@
+/**
+ * F06-NEW-08: SQLite-backed rate-limit persistence.
+ *
+ * Verifies that rate-limit counters survive a process restart.
+ *
+ *  - Without the fix (in-memory `Map`): the counter resets when a fresh
+ *    middleware is constructed, so a request that should be 429 returns 200.
+ *  - With the fix (`createSqliteBackend`): the counter is persisted in the
+ *    `rate_limit_buckets` table; a fresh middleware reads the persisted
+ *    state on the next request and still rejects with 429.
+ *
+ * Critical: the test must reuse the **same Drizzle DB instance** across the
+ * "two middleware lifetimes" because that mirrors the single-machine restart
+ * scenario where the SQLite file is preserved on disk while the process
+ * memory is wiped. We simulate the restart by creating two independent Hono
+ * apps pointing at the same backend factory call. With SQLite persistence
+ * the second app shares the bucket state via the table.
+ */
+
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { rateLimitBuckets } from '../../src/db/schema/sqlite/rate-limit-buckets.js';
+import {
+  createInMemoryBackend,
+  createRateLimitCleanupJob,
+  createSqliteBackend,
+  rateLimiter,
+} from '../../src/lib/api/rate-limiter.js';
+import {
+  clearTestDatabase,
+  closeTestDatabase,
+  getTestDb,
+  setupTestDatabase,
+} from '../helpers/database.js';
+
+function makeApp(opts: Parameters<typeof rateLimiter>[0]) {
+  const app = new Hono();
+  app.use('/*', rateLimiter(opts));
+  app.get('/test', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('Rate limiter SQLite persistence (F06-NEW-08)', () => {
+  beforeAll(async () => {
+    await setupTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearTestDatabase();
+  });
+
+  afterAll(async () => {
+    await closeTestDatabase();
+  });
+
+  it('persists buckets across restart — restart preserves 429 (red→green)', async () => {
+    const db = getTestDb();
+    // First "process lifetime": construct backend, exhaust the limit.
+    const backend1 = createSqliteBackend(db);
+    const app1 = makeApp({
+      max: 2,
+      windowMs: 60_000,
+      backend: backend1,
+      // Pin the key so both lifetimes target the same bucket.
+      keyFrom: () => 'ip:test-restart',
+    });
+
+    expect((await app1.request('/test')).status).toBe(200);
+    expect((await app1.request('/test')).status).toBe(200);
+    // Third request exhausts the limit.
+    expect((await app1.request('/test')).status).toBe(429);
+
+    // Persisted state assertion: the bucket exists in the table with count=3.
+    const persisted = await db.select().from(rateLimitBuckets);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]?.count).toBe(3);
+    expect(persisted[0]?.key).toBe('ip:test-restart');
+
+    // Simulate process restart: drop backend1, create a fresh backend pointing
+    // at the same DB. With persistence, the counter is still at 3 — so the
+    // next request must still be 429.
+    const backend2 = createSqliteBackend(db);
+    const app2 = makeApp({
+      max: 2,
+      windowMs: 60_000,
+      backend: backend2,
+      keyFrom: () => 'ip:test-restart',
+    });
+
+    const afterRestart = await app2.request('/test');
+    expect(
+      afterRestart.status,
+      'Restart-bypass detected: rate limiter forgot the bucket. Verify createSqliteBackend persists to rate_limit_buckets.'
+    ).toBe(429);
+  });
+
+  it('control: in-memory backend forgets the bucket on restart (proves the bug exists)', async () => {
+    // Same scenario but with the legacy in-memory backend. This documents
+    // the bug F06-NEW-08 was opened to fix: counters are lost on restart.
+    const backend1 = createInMemoryBackend();
+    const app1 = makeApp({
+      max: 2,
+      windowMs: 60_000,
+      backend: backend1,
+      keyFrom: () => 'ip:test-mem-restart',
+    });
+
+    expect((await app1.request('/test')).status).toBe(200);
+    expect((await app1.request('/test')).status).toBe(200);
+    expect((await app1.request('/test')).status).toBe(429);
+
+    // Restart: a fresh in-memory backend has an empty Map.
+    const backend2 = createInMemoryBackend();
+    const app2 = makeApp({
+      max: 2,
+      windowMs: 60_000,
+      backend: backend2,
+      keyFrom: () => 'ip:test-mem-restart',
+    });
+
+    // The bug: limit counter reset to zero, so this request is incorrectly 200.
+    const afterRestart = await app2.request('/test');
+    expect(afterRestart.status).toBe(200);
+  });
+
+  it('atomically increments concurrent requests via onConflictDoUpdate', async () => {
+    // The composite primary key means two concurrent requests on the same
+    // bucket must serialise into count: 2, not lose an increment.
+    const db = getTestDb();
+    const backend = createSqliteBackend(db);
+    const app = makeApp({
+      max: 100,
+      windowMs: 60_000,
+      backend,
+      keyFrom: () => 'ip:concurrent',
+    });
+
+    // 10 concurrent requests.
+    const responses = await Promise.all(Array.from({ length: 10 }, () => app.request('/test')));
+    for (const res of responses) {
+      expect(res.status).toBe(200);
+    }
+
+    const rows = await db.select().from(rateLimitBuckets);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.count).toBe(10);
+  });
+
+  it('quantises to the windowMs boundary so requests in the same window upsert the same row', async () => {
+    const db = getTestDb();
+    const backend = createSqliteBackend(db);
+    const app = makeApp({
+      max: 100,
+      windowMs: 60_000,
+      backend,
+      keyFrom: () => 'ip:window-test',
+    });
+
+    await app.request('/test');
+    await app.request('/test');
+    await app.request('/test');
+
+    // Both requests must hit the same window_start bucket.
+    const rows = await db.select().from(rateLimitBuckets);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.count).toBe(3);
+  });
+
+  it('different keys get different buckets (separate rows)', async () => {
+    const db = getTestDb();
+    const backend = createSqliteBackend(db);
+
+    let key = 'ip:user-A';
+    const app = makeApp({
+      max: 100,
+      windowMs: 60_000,
+      backend,
+      keyFrom: () => key,
+    });
+
+    await app.request('/test');
+    await app.request('/test');
+
+    key = 'ip:user-B';
+    await app.request('/test');
+
+    const rows = await db.select().from(rateLimitBuckets);
+    expect(rows.map((r) => r.key).sort()).toEqual(['ip:user-A', 'ip:user-B']);
+    const userA = rows.find((r) => r.key === 'ip:user-A');
+    const userB = rows.find((r) => r.key === 'ip:user-B');
+    expect(userA?.count).toBe(2);
+    expect(userB?.count).toBe(1);
+  });
+
+  it('cleanup job deletes rows older than 24h, preserves recent rows', async () => {
+    const db = getTestDb();
+    const cleanup = createRateLimitCleanupJob(db);
+    const now = Date.now();
+    const dayMs = 24 * 60 * 60 * 1000;
+
+    // Old row (older than 24h).
+    await db.insert(rateLimitBuckets).values({
+      key: 'ip:old',
+      windowStart: now - 2 * dayMs,
+      windowMs: 60_000,
+      count: 5,
+      updatedAt: now - 2 * dayMs,
+    });
+
+    // Recent row (10 minutes ago — well within retention).
+    await db.insert(rateLimitBuckets).values({
+      key: 'ip:recent',
+      windowStart: now - 10 * 60 * 1000,
+      windowMs: 60_000,
+      count: 3,
+      updatedAt: now - 10 * 60 * 1000,
+    });
+
+    const deleted = await cleanup.runOnce();
+    expect(deleted).toBe(1);
+
+    const remaining = await db.select().from(rateLimitBuckets);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.key).toBe('ip:recent');
+  });
+
+  it('cleanup job is a BackgroundJob with start/stop/healthSnapshot lifecycle', async () => {
+    const db = getTestDb();
+    const cleanup = createRateLimitCleanupJob(db);
+
+    expect(cleanup.name).toBe('rateLimitCleanup');
+    expect(cleanup.healthSnapshot().running).toBe(false);
+
+    cleanup.start();
+    expect(cleanup.healthSnapshot().running).toBe(true);
+
+    // Idempotent.
+    cleanup.start();
+    expect(cleanup.healthSnapshot().running).toBe(true);
+
+    cleanup.stop();
+    expect(cleanup.healthSnapshot().running).toBe(false);
+
+    // Idempotent.
+    cleanup.stop();
+    expect(cleanup.healthSnapshot().running).toBe(false);
+  });
+
+  it('cleanup job records lastRunAt after a successful sweep', async () => {
+    const db = getTestDb();
+    const cleanup = createRateLimitCleanupJob(db);
+
+    expect(cleanup.healthSnapshot().lastRunAt).toBeUndefined();
+    await cleanup.runOnce();
+    const snap = cleanup.healthSnapshot();
+    expect(snap.lastRunAt).toBeDefined();
+    expect(snap.lastError).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The in-memory `Map`-backed rate limiter resets on every process restart, which makes it trivially bypassable by triggering a deploy or crash. April 29 review **F06-NEW-08 (P1)** flagged this as a security regression.

This PR persists rate-limit buckets in a Drizzle table keyed on `(key, window_start)`, with an atomic upsert via `onConflictDoUpdate` on each request. Counters survive restarts.

**Hard constraint**: no Redis, no new infrastructure. SQLite + Drizzle is the only durable store available; the existing single-instance topology is preserved. Multi-instance drift remains documented in the file header.

## Changes

- **Schema**: new `rate_limit_buckets` table (SQLite + PostgreSQL) with composite PK on `(key, window_start)` and `updated_at` index for cleanup.
  - `src/db/schema/sqlite/rate-limit-buckets.ts`
  - `src/db/schema/postgres/rate-limit-buckets.ts`
- **Migrations**: SQLite `0022_add_rate_limit_buckets.sql` + PG `0016_add_rate_limit_buckets.sql` + runtime `MIGRATIONS` v35 entry so existing installs auto-create the table on boot.
- **Backend**: new `createSqliteBackend(db)` factory in `src/lib/api/rate-limiter.ts`. In-memory backend retained for tests / fallback. `onConflictDoUpdate` ensures atomic per-tick increment under concurrent requests.
- **Cleanup**: new `createRateLimitCleanupJob(db)` `BackgroundJob` registered alongside `EventCleanup` / `EventOutboxRelay` in `src/server/bootstrap/phases/schedulers.ts`. Trims rows older than 24h, hourly.
- **Wiring**: `src/server/router.ts` constructs one shared `createSqliteBackend(deps.db)` and passes it to all four rate-limiter middlewares (`/hooks/events/*`, `/hooks/github-app`, `/api/*` global, `/api/*` token-only).
- **Tests**: schema-drift suite auto-covers the new table; `tests/helpers/database.ts` creates the table for tests.

## Test plan (red → green)

**New test file**: `tests/integration/rate-limit-persistence.test.ts` (8 cases).

- `before:` `control: in-memory backend forgets the bucket on restart (proves the bug exists)` — documents the legacy bypassable behaviour.
- `after:` `persists buckets across restart — restart preserves 429 (red→green)` — exercises the fix; constructs `createSqliteBackend(db)`, exhausts the limit, drops the backend, creates a fresh one against the same DB, and asserts the next request still returns 429.
- Atomic concurrent increments via `onConflictDoUpdate` (10 parallel requests → count: 10 in DB).
- Window quantisation (multiple requests in the same `windowMs` upsert the same row).
- Per-key separation (different keys → different rows).
- Cleanup job: deletes rows older than 24h, preserves recent rows.
- Cleanup job lifecycle (start/stop idempotency, healthSnapshot).
- Cleanup job records `lastRunAt` after successful sweep.

**Regression coverage**:
- `tests/integration/schema-drift-all-tables.test.ts` auto-covers `rate_limit_buckets` ✓
- `tests/integration/middleware-auth.test.ts` 27 cases ✓
- `src/lib/api/__tests__/rate-limiter.test.ts` 16 cases ✓ (in-memory default backend backwards-compatible)
- `tests/integration/event-outbox-relay.test.ts`, `tests/integration/event-cleanup-service.test.ts` ✓ (shared `BackgroundJobRegistry` pattern unchanged)

**Local checks (all clean)**:
- [x] `npx tsc --noEmit`
- [x] `npx @biomejs/biome check src/ tests/` 
- [x] `npx vitest run tests/integration/rate-limit-persistence.test.ts` — 8 passed
- [x] `npx vitest run tests/integration/schema-drift-all-tables.test.ts` — 51 passed
- [x] `npx vitest run src/lib/api/__tests__/rate-limiter.test.ts` — 16 passed
- [x] All pre-commit hooks (Biome, tsc, secrets, schema drift, semgrep)

## Status vs April 29 review

**F06-NEW-08 (P1)** — closed. Restart-bypass is no longer possible on the supported single-instance topology. Multi-instance follow-up documented in the rate-limiter.ts header (still subject to the no-Redis hard constraint).

Signed-off-by: Simon Lynch <srlynch@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
