### PR TITLE
fix(arch29-W2-L): RBAC tag filter on collections (F06-NEW-07)

### DIFF
--- a/src/lib/api/auth-middleware.ts
+++ b/src/lib/api/auth-middleware.ts
@@ -46,6 +46,23 @@ export interface AuthContext {
     codespaceId: string | null;
     tags: string[] | null;
   };
+  /**
+   * Tag-based collection filter populated by `requireTagAccess` for tag-restricted
+   * tokens hitting collection (list) endpoints. Route handlers must consult this
+   * value and filter their results to the union of resources whose tags overlap
+   * the token's `scopeTags`.
+   *
+   * Cross-ref: F06-NEW-07. The middleware would otherwise have to either deny
+   * the entire list (defeating the list-and-select workflow) or skip the gate
+   * silently (leaking every resource to a tag-restricted token). The fix is to
+   * pass the scope through and filter in the handler.
+   */
+  tagFilter?: {
+    /** The resource type derived from the request path (e.g. 'codespace'). */
+    resourceType: 'codespace' | 'task' | 'session' | 'agent';
+    /** The token's scope tags — non-empty when this filter is set. */
+    scopeTags: string[];
+  };
 }
 
 /**

--- a/src/lib/api/rbac-middleware.ts
+++ b/src/lib/api/rbac-middleware.ts
@@ -5,7 +5,7 @@
  * Slots in after the existing authMiddleware in the request pipeline.
  */
 
-import { eq, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import type { Context, Next } from 'hono';
 import {
   RBAC_ROLE_LEVEL,
@@ -439,14 +439,85 @@ const TAG_RESOLVERS: { [K in 'codespace' | 'task' | 'session' | 'agent']: TagRes
 /** Map URL path prefixes to resource types */
 type TagResourceType = keyof typeof TAG_RESOLVERS;
 const PATH_TO_RESOURCE: Array<[string, TagResourceType]> = [
-  ['/api/codespaces/', 'codespace'],
-  ['/api/tasks/', 'task'],
-  ['/api/sessions/', 'session'],
-  ['/api/agents/', 'agent'],
+  ['/api/codespaces', 'codespace'],
+  ['/api/tasks', 'task'],
+  ['/api/sessions', 'session'],
+  ['/api/agents', 'agent'],
 ];
 
 /**
+ * Match a request path against a resource-prefix table.
+ *
+ * Accepts both bare collection (`/api/codespaces`) and any sub-path
+ * (`/api/codespaces/<id>`, `/api/codespaces/summaries`, etc.). Critically,
+ * `/api/codespaces` and `/api/codespaces/` are both treated as collection
+ * endpoints, while `/api/codespaces-of-something-else` does NOT match
+ * (the next char after the prefix must be `/` or end-of-string).
+ */
+function matchResourceType(path: string): TagResourceType | null {
+  for (const [prefix, type] of PATH_TO_RESOURCE) {
+    if (path === prefix || path.startsWith(`${prefix}/`)) {
+      return type;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure-path resource ID detector.
+ *
+ * `requireTagAccess` is wired as a wildcard middleware (`/api/*`), which means
+ * Hono has not yet matched the specific route — `c.req.param('id')` returns
+ * undefined for ALL paths, even single-resource fetches like `/api/tasks/<id>`.
+ * The original implementation relied on per-route mounting, which was lost in
+ * the global pipeline.
+ *
+ * To recover correctness without restructuring the middleware tree, derive the
+ * resource ID directly from the path: anything past the prefix that isn't a
+ * known sub-collection name (e.g. `summaries`, `create-with-ai`) is treated as
+ * a `:id`-style segment.
+ *
+ * Returns `null` when the path is a collection endpoint (no id segment) or a
+ * known sub-collection.
+ */
+const KNOWN_SUB_COLLECTIONS: { [K in TagResourceType]?: ReadonlySet<string> } = {
+  codespace: new Set(['summaries', 'create-with-ai']),
+  task: new Set(['create-with-ai']),
+};
+
+function extractResourceId(path: string, resourceType: TagResourceType): string | null {
+  const prefix = PATH_TO_RESOURCE.find(([_, type]) => type === resourceType)?.[0];
+  if (!prefix) return null;
+  // Strip the prefix and any leading slash.
+  const tail = path === prefix ? '' : path.slice(prefix.length + 1);
+  if (tail.length === 0) return null;
+
+  // The first segment after the prefix is either a resource ID or a
+  // sub-collection name. Sub-collections (like `summaries`) should NOT be
+  // treated as a resource ID — they are themselves collection endpoints.
+  const firstSegment = tail.split('/')[0] ?? '';
+  if (firstSegment.length === 0) return null;
+
+  const subCollections = KNOWN_SUB_COLLECTIONS[resourceType];
+  if (subCollections?.has(firstSegment)) return null;
+
+  return firstSegment;
+}
+
+/**
  * Middleware that checks tag-based access for API tokens with tag restrictions.
+ *
+ * Two modes:
+ * 1. **Resource endpoint** (`:id` present): resolve the resource's tags and
+ *    deny if there is no overlap with the token's scope tags.
+ * 2. **Collection endpoint** (no `:id`, recognized resource type): set
+ *    `auth.tagFilter` on the request context so the route handler can filter
+ *    its results. Without this hook, F06-NEW-07 lets tag-restricted tokens
+ *    list every resource (because the middleware previously 403'd, which
+ *    forced operators to either grant unrestricted tokens or strip
+ *    `requireTagAccess` from their global pipeline).
+ *
+ * Unrecognized resource paths still return 403.
  */
 export function requireTagAccess(db: Database) {
   return async (c: Context, next: Next) => {
@@ -470,14 +541,9 @@ export function requireTagAccess(db: Database) {
     const scopeTags = auth.tokenScope.tags;
     const path = c.req.path;
 
-    // Determine resource type from path
-    let resourceType: TagResourceType | null = null;
-    for (const [prefix, type] of PATH_TO_RESOURCE) {
-      if (path.startsWith(prefix)) {
-        resourceType = type;
-        break;
-      }
-    }
+    // Determine resource type from path. The matcher accepts the bare
+    // collection (`/api/codespaces`) and any sub-path under it.
+    const resourceType: TagResourceType | null = matchResourceType(path);
 
     if (!resourceType) {
       log.warn('Tag-restricted token denied on unrecognized resource path', {
@@ -495,18 +561,27 @@ export function requireTagAccess(db: Database) {
       );
     }
 
-    const resourceId = c.req.param('id');
+    // Prefer path-based detection because the middleware is mounted at
+    // `/api/*` (before Hono's route matching populates `c.req.param('id')`).
+    // We fall back to the param if the runtime did pre-match (e.g. tests that
+    // attach the middleware per-route).
+    const resourceId = extractResourceId(path, resourceType) ?? c.req.param('id');
     if (!resourceId) {
-      log.warn('Tag-restricted token denied on collection endpoint (no resource ID)', {
-        data: { path, resourceType, tokenId: auth.tokenScope.tokenId },
-      });
-      return c.json(
-        {
-          ok: false,
-          error: { code: 'FORBIDDEN', message: 'Tag-restricted tokens must specify a resource ID' },
+      // F06-NEW-07: collection endpoint. Set the tag filter on the auth context
+      // and pass through; the route handler is responsible for narrowing its
+      // result set via `applyTokenTagFilter` (see helpers below).
+      const updatedAuth: AuthContext = {
+        ...auth,
+        tagFilter: {
+          resourceType,
+          scopeTags,
         },
-        403
-      );
+      };
+      c.set('auth', updatedAuth);
+      log.debug('Tag-restricted token: collection filter applied', {
+        data: { path, resourceType, tokenId: auth.tokenScope.tokenId, scopeTags },
+      });
+      return next();
     }
 
     const resolver = TAG_RESOLVERS[resourceType];
@@ -548,4 +623,134 @@ export function requireTagAccess(db: Database) {
 
     return next();
   };
+}
+
+/**
+ * Resolve the set of resource IDs of a given type that a tag-restricted token
+ * should be able to see, based on the token's scope tags.
+ *
+ * Semantics mirror the per-resource `TAG_RESOLVERS`:
+ *   - **codespace**: codespaces directly tagged with any of `scopeTags`.
+ *   - **task**: tasks directly tagged OR tasks whose parent codespace is tagged.
+ *   - **session**: sessions whose linked task or parent codespace is tagged.
+ *   - **agent**: agents whose parent codespace is tagged.
+ *
+ * Returns `null` to mean *no filter*. Returns an empty array to mean *no
+ * accessible resources* (and therefore the list result must be empty).
+ *
+ * F06-NEW-07: this helper is the engine behind `applyTokenTagFilter` and is
+ * exported for routes that need to filter directly in their Drizzle queries
+ * (e.g. via `inArray(table.id, ids)`) rather than post-fetch.
+ */
+export async function getAccessibleResourceIds(
+  db: Database,
+  resourceType: 'codespace' | 'task' | 'session' | 'agent',
+  scopeTags: string[]
+): Promise<string[]> {
+  if (scopeTags.length === 0) {
+    // No tags = no restriction, so an empty filter would mean *no results*.
+    // Callers should treat `[]` as "deny everything"; that's the safe default
+    // for tag-restricted tokens with empty scope tags (which the middleware
+    // already short-circuits, but we keep the invariant explicit).
+    return [];
+  }
+
+  // Step 1: codespaces directly tagged with any scope tag.
+  const taggedCodespaceRows = await db
+    .select({ codespaceId: codespaceTags.codespaceId })
+    .from(codespaceTags)
+    .where(inArray(codespaceTags.tagId, scopeTags));
+  const taggedCodespaceIds = Array.from(new Set(taggedCodespaceRows.map((r) => r.codespaceId)));
+
+  if (resourceType === 'codespace') {
+    return taggedCodespaceIds;
+  }
+
+  if (resourceType === 'task') {
+    // Tasks directly tagged.
+    const directTaggedRows = await db
+      .select({ taskId: taskTags.taskId })
+      .from(taskTags)
+      .where(inArray(taskTags.tagId, scopeTags));
+    const directIds = directTaggedRows.map((r) => r.taskId);
+
+    // Tasks under a tagged codespace (inheritance).
+    let inheritedIds: string[] = [];
+    if (taggedCodespaceIds.length > 0) {
+      const inheritedRows = await db
+        .select({ id: tasks.id })
+        .from(tasks)
+        .where(inArray(tasks.codespaceId, taggedCodespaceIds));
+      inheritedIds = inheritedRows.map((r) => r.id);
+    }
+    return Array.from(new Set([...directIds, ...inheritedIds]));
+  }
+
+  if (resourceType === 'agent') {
+    if (taggedCodespaceIds.length === 0) return [];
+    const rows = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(inArray(agents.codespaceId, taggedCodespaceIds));
+    return rows.map((r) => r.id);
+  }
+
+  // session: union of (sessions whose taskId is in accessible-tasks) and
+  // (sessions whose codespaceId is in tagged-codespaces).
+  const accessibleTaskIds = await getAccessibleResourceIds(db, 'task', scopeTags);
+  const accessibleSessionIds = new Set<string>();
+
+  if (accessibleTaskIds.length > 0) {
+    const byTask = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(inArray(sessions.taskId, accessibleTaskIds));
+    for (const row of byTask) accessibleSessionIds.add(row.id);
+  }
+  if (taggedCodespaceIds.length > 0) {
+    const byCodespace = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(inArray(sessions.codespaceId, taggedCodespaceIds));
+    for (const row of byCodespace) accessibleSessionIds.add(row.id);
+  }
+  return Array.from(accessibleSessionIds);
+}
+
+/**
+ * Filter a list of fetched resources to only those visible to a tag-restricted
+ * token. Returns the input unchanged when no `tagFilter` is set on the auth
+ * context (i.e. unrestricted tokens, session/dev auth, or scoped resource
+ * routes that already enforce per-ID access).
+ *
+ * Use this from list-route handlers AFTER fetching the result set:
+ *
+ * ```ts
+ * const auth = c.get('auth') as AuthContext | undefined;
+ * const filtered = await applyTokenTagFilter(db, auth, items, (item) => item.id);
+ * ```
+ *
+ * `getId` extracts the resource ID from each item — kept generic so the helper
+ * works against `Codespace`, `Task`, `Session`, or `Agent` shapes without
+ * coupling to specific schemas.
+ *
+ * F06-NEW-07: this is the read-time enforcement that prevents tag-restricted
+ * tokens from seeing every resource via `GET /api/codespaces` and friends.
+ */
+export async function applyTokenTagFilter<T>(
+  db: Database,
+  auth: AuthContext | undefined,
+  items: T[],
+  getId: (item: T) => string
+): Promise<T[]> {
+  if (!auth?.tagFilter) return items;
+  if (items.length === 0) return items;
+
+  const accessibleIds = await getAccessibleResourceIds(
+    db,
+    auth.tagFilter.resourceType,
+    auth.tagFilter.scopeTags
+  );
+  const idSet = new Set(accessibleIds);
+  return items.filter((item) => idSet.has(getId(item)));
 }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -516,12 +516,12 @@ export function createRouter(deps: RouterDependencies) {
     '/api/project-folders',
     createProjectFoldersRoutes({ projectFolderService: deps.projectFolderService })
   );
-  app.route('/api/agents', createAgentsRoutes({ agentService: deps.agentService }));
+  app.route('/api/agents', createAgentsRoutes({ agentService: deps.agentService, db: deps.db }));
   app.route(
     '/api/tasks/create-with-ai',
     createTaskCreationRoutes({ taskCreationService: deps.taskCreationService })
   );
-  app.route('/api/tasks', createTasksRoutes({ taskService: deps.taskService }));
+  app.route('/api/tasks', createTasksRoutes({ taskService: deps.taskService, db: deps.db }));
   app.route('/api/workflows', createWorkflowsRoutes({ workflowService: deps.workflowService }));
   app.route('/api/templates', createTemplatesRoutes({ templateService: deps.templateService }));
   app.route(
@@ -532,6 +532,7 @@ export function createRouter(deps: RouterDependencies) {
     '/api/sessions',
     createSessionsRoutes({
       sessionService: deps.sessionService,
+      db: deps.db,
     })
   );
   app.route('/api/github', createGitHubRoutes({ githubService: deps.githubService }));

--- a/src/server/routes/__tests__/agents.test.ts
+++ b/src/server/routes/__tests__/agents.test.ts
@@ -22,7 +22,10 @@ function createMockAgentService() {
 
 function createTestApp() {
   const agentService = createMockAgentService();
-  const routes = createAgentsRoutes({ agentService: agentService as never });
+  // Minimal stub DB for the tag-filter helper. Tests do not exercise tag
+  // restrictions; the helper short-circuits when `auth.tagFilter` is unset.
+  const db = {} as never;
+  const routes = createAgentsRoutes({ agentService: agentService as never, db });
   const app = new Hono();
   app.route('/api/agents', routes);
   return { app, agentService };

--- a/src/server/routes/__tests__/sessions.test.ts
+++ b/src/server/routes/__tests__/sessions.test.ts
@@ -20,7 +20,10 @@ function createMockSessionService() {
 
 function createTestApp() {
   const sessionService = createMockSessionService();
-  const routes = createSessionsRoutes({ sessionService: sessionService as never });
+  // Minimal stub DB for the tag-filter helper. Tests do not exercise tag
+  // restrictions; the helper short-circuits when `auth.tagFilter` is unset.
+  const db = {} as never;
+  const routes = createSessionsRoutes({ sessionService: sessionService as never, db });
   const app = new Hono();
   app.route('/api/sessions', routes);
   app.onError((err, c) => {

--- a/src/server/routes/__tests__/tasks.test.ts
+++ b/src/server/routes/__tests__/tasks.test.ts
@@ -25,7 +25,10 @@ function createMockTaskService() {
 
 function createTestApp() {
   const taskService = createMockTaskService();
-  const routes = createTasksRoutes({ taskService: taskService as never });
+  // Minimal stub DB for the tag-filter helper. Tests do not exercise tag
+  // restrictions; the helper short-circuits when `auth.tagFilter` is unset.
+  const db = {} as never;
+  const routes = createTasksRoutes({ taskService: taskService as never, db });
   const app = new Hono();
   app.route('/api/tasks', routes);
   return { app, taskService };

--- a/src/server/routes/agents.ts
+++ b/src/server/routes/agents.ts
@@ -4,7 +4,10 @@
 
 import { Hono } from 'hono';
 import type { AgentConfig } from '../../db/schema';
+import type { AuthContext } from '../../lib/api/auth-middleware.js';
+import { applyTokenTagFilter } from '../../lib/api/rbac-middleware.js';
 import type { AgentService } from '../../services/agent.service.js';
+import type { Database } from '../../types/database.js';
 import { errorResponse, json, requireQueryId, validateIdParam } from '../shared.js';
 import {
   agentResumeSchema,
@@ -16,10 +19,11 @@ import {
 
 interface AgentsDeps {
   agentService: AgentService;
+  db: Database;
 }
 
-export function createAgentsRoutes({ agentService }: AgentsDeps) {
-  const app = new Hono();
+export function createAgentsRoutes({ agentService, db }: AgentsDeps) {
+  const app = new Hono<{ Variables: { auth: AuthContext } }>();
 
   // GET /api/agents
   app.get('/', async (c) => {
@@ -35,7 +39,11 @@ export function createAgentsRoutes({ agentService }: AgentsDeps) {
       );
     }
 
-    return json({ ok: true, data: result.value });
+    // F06-NEW-07: filter by tag scope when the token is tag-restricted.
+    const auth = c.get('auth') as AuthContext | undefined;
+    const filtered = await applyTokenTagFilter(db, auth, result.value, (a) => a.id);
+
+    return json({ ok: true, data: filtered });
   });
 
   // POST /api/agents

--- a/src/server/routes/codespaces.ts
+++ b/src/server/routes/codespaces.ts
@@ -8,6 +8,8 @@ import path from 'node:path';
 import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { agents } from '../../db/schema';
+import type { AuthContext } from '../../lib/api/auth-middleware.js';
+import { applyTokenTagFilter } from '../../lib/api/rbac-middleware.js';
 import { createLogger } from '../../lib/logging/logger.js';
 import { deriveGitHubFromPath } from '../../lib/sandbox/git-token-resolver.js';
 import type { CodespaceService } from '../../services/codespace.service.js';
@@ -25,7 +27,7 @@ interface CodespacesDeps {
 }
 
 export function createCodespacesRoutes({ codespaceService, templateService, db }: CodespacesDeps) {
-  const app = new Hono();
+  const app = new Hono<{ Variables: { auth: AuthContext } }>();
 
   // GET /api/codespaces
   app.get('/', async (c) => {
@@ -40,10 +42,14 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
       );
     }
 
+    // F06-NEW-07: filter by tag scope when the token is tag-restricted.
+    const auth = c.get('auth') as AuthContext | undefined;
+    const filteredItems = await applyTokenTagFilter(db, auth, result.value, (cs) => cs.id);
+
     return json({
       ok: true,
       data: {
-        items: result.value.map((p) => ({
+        items: filteredItems.map((p) => ({
           id: p.id,
           name: p.name,
           path: p.path,
@@ -54,7 +60,7 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
         })),
         nextCursor: null,
         hasMore: false,
-        totalCount: result.value.length,
+        totalCount: filteredItems.length,
       },
     });
   });
@@ -136,10 +142,19 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
 
       const summaries = result.value;
 
+      // F06-NEW-07: filter by tag scope when the token is tag-restricted.
+      const auth = c.get('auth') as AuthContext | undefined;
+      const filteredSummaries = await applyTokenTagFilter(
+        db,
+        auth,
+        summaries,
+        (s) => s.codespace.id
+      );
+
       return json({
         ok: true,
         data: {
-          items: summaries.map((s) => ({
+          items: filteredSummaries.map((s) => ({
             codespace: {
               id: s.codespace.id,
               name: s.codespace.name,
@@ -163,7 +178,7 @@ export function createCodespacesRoutes({ codespaceService, templateService, db }
           })),
           nextCursor: null,
           hasMore: false,
-          totalCount: summaries.length,
+          totalCount: filteredSummaries.length,
         },
       });
     } catch (error) {

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -5,8 +5,11 @@
 import { Hono } from 'hono';
 import type { SessionStatus } from '../../db/schema/shared/enums.js';
 import { SESSION_STATUS } from '../../db/schema/shared/enums.js';
+import type { AuthContext } from '../../lib/api/auth-middleware.js';
 import { decodeRequestCursor, paginate } from '../../lib/api/pagination.js';
+import { applyTokenTagFilter } from '../../lib/api/rbac-middleware.js';
 import type { SessionService } from '../../services/session.service.js';
+import type { Database } from '../../types/database.js';
 import { errorResponse, json, parseLimit, parseOffset, validateIdParam } from '../shared.js';
 import { createSessionSchema, exportSessionSchema, parseJsonBody } from '../validation.js';
 
@@ -127,10 +130,11 @@ function formatEventsAsCsv(
 
 interface SessionsDeps {
   sessionService: SessionService;
+  db: Database;
 }
 
-export function createSessionsRoutes({ sessionService }: SessionsDeps) {
-  const app = new Hono();
+export function createSessionsRoutes({ sessionService, db }: SessionsDeps) {
+  const app = new Hono<{ Variables: { auth: AuthContext } }>();
 
   // GET /api/sessions
   //
@@ -172,14 +176,28 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
         return errorResponse(result);
       }
 
+      // F06-NEW-07: filter by tag scope when the token is tag-restricted.
+      const auth = c.get('auth') as AuthContext | undefined;
+      const filteredSessions = await applyTokenTagFilter(
+        db,
+        auth,
+        result.value.sessions,
+        (s) => s.id
+      );
+      // Adjust the total when a filter was applied so the UI badge counts
+      // reflect what the token can actually see. When no filter is set,
+      // `filteredSessions === result.value.sessions` and total is unchanged.
+      const totalDelta = result.value.sessions.length - filteredSessions.length;
+      const adjustedTotal = Math.max(0, result.value.total - totalDelta);
+
       return json({
         ok: true,
-        data: result.value.sessions,
+        data: filteredSessions,
         pagination: {
           limit,
           offset,
-          total: result.value.total,
-          hasMore: result.value.sessions.length === limit,
+          total: auth?.tagFilter ? adjustedTotal : result.value.total,
+          hasMore: filteredSessions.length === limit,
         },
       });
     }
@@ -238,7 +256,11 @@ export function createSessionsRoutes({ sessionService }: SessionsDeps) {
       return errorResponse(result);
     }
 
-    const body = paginate(result.value, { limit, sortField, order });
+    // F06-NEW-07: filter by tag scope when the token is tag-restricted.
+    const auth = c.get('auth') as AuthContext | undefined;
+    const filteredItems = await applyTokenTagFilter(db, auth, result.value, (s) => s.id);
+
+    const body = paginate(filteredItems, { limit, sortField, order });
     return json({
       ok: true,
       data: body.items,

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -3,9 +3,12 @@
  */
 
 import { Hono } from 'hono';
+import type { AuthContext } from '../../lib/api/auth-middleware.js';
 import { decodeRequestCursor, paginate } from '../../lib/api/pagination.js';
+import { applyTokenTagFilter } from '../../lib/api/rbac-middleware.js';
 import { createLogger } from '../../lib/logging/logger.js';
 import type { TaskService } from '../../services/task.service.js';
+import type { Database } from '../../types/database.js';
 import { errorResponse, json, parseLimit, requireQueryId, validateIdParam } from '../shared.js';
 import {
   approveTaskSchema,
@@ -22,10 +25,11 @@ const logger = createLogger('routes:tasks');
 
 interface TasksDeps {
   taskService: TaskService;
+  db: Database;
 }
 
-export function createTasksRoutes({ taskService }: TasksDeps) {
-  const app = new Hono();
+export function createTasksRoutes({ taskService, db }: TasksDeps) {
+  const app = new Hono<{ Variables: { auth: AuthContext } }>();
 
   // GET /api/tasks
   //
@@ -98,7 +102,13 @@ export function createTasksRoutes({ taskService }: TasksDeps) {
       return errorResponse(result);
     }
 
-    const body = paginate(result.value, { limit, sortField, order });
+    // F06-NEW-07: filter by tag scope when the token is tag-restricted.
+    // We filter the raw service result before paginate() so the cursor +
+    // hasMore semantics still hold for the visible-to-token subset.
+    const auth = c.get('auth') as AuthContext | undefined;
+    const filteredItems = await applyTokenTagFilter(db, auth, result.value, (t) => t.id);
+
+    const body = paginate(filteredItems, { limit, sortField, order });
     return json({ ok: true, data: body });
   });
 

--- a/tests/api/agents-lifecycle.test.ts
+++ b/tests/api/agents-lifecycle.test.ts
@@ -44,6 +44,7 @@ describe('Agent Lifecycle API', () => {
     vi.clearAllMocks();
     app = createAgentsRoutes({
       agentService: agentServiceMocks as never,
+      db: {} as never,
     });
   });
 

--- a/tests/api/agents.test.ts
+++ b/tests/api/agents.test.ts
@@ -42,6 +42,7 @@ describe('Agent API', () => {
     vi.clearAllMocks();
     app = createAgentsRoutes({
       agentService: agentServiceMocks as never,
+      db: {} as never,
     });
   });
 

--- a/tests/api/list-endpoint-contract.test.ts
+++ b/tests/api/list-endpoint-contract.test.ts
@@ -51,7 +51,7 @@ describe('List endpoint contract — sessions (flat shape)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createSessionsRoutes({ sessionService: sessionServiceMocks as never });
+    app = createSessionsRoutes({ sessionService: sessionServiceMocks as never, db: {} as never });
     sessionServiceMocks.list.mockResolvedValue(ok([sampleSession]));
     sessionServiceMocks.getSessionSummary.mockResolvedValue(
       ok({ turnsCount: 0, tokensUsed: 0, filesModified: 0, linesAdded: 0, linesRemoved: 0 })

--- a/tests/api/sessions.test.ts
+++ b/tests/api/sessions.test.ts
@@ -50,6 +50,7 @@ describe('Session API', () => {
     vi.clearAllMocks();
     app = createSessionsRoutes({
       sessionService: sessionServiceMocks as never,
+      db: {} as never,
     });
   });
 

--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -82,6 +82,7 @@ describe('Task API', () => {
     vi.clearAllMocks();
     tasksRoute = createTasksRoutes({
       taskService: taskServiceMocks as never,
+      db: {} as never,
     });
   });
 

--- a/tests/integration/rbac-tag-collection-filter.test.ts
+++ b/tests/integration/rbac-tag-collection-filter.test.ts
@@ -1,0 +1,639 @@
+/**
+ * Integration test for F06-NEW-07 (PR W2-L).
+ *
+ * RED → GREEN: tag-restricted tokens used to either be 403'd from collection
+ * endpoints (which forced operators to bypass the middleware) or to leak every
+ * resource when the middleware was skipped. This test verifies that
+ * `applyTokenTagFilter` (driven by `requireTagAccess` populating `tagFilter`
+ * on the auth context) narrows list endpoints to the resources the token's
+ * scope tags can actually access.
+ *
+ * Endpoints covered:
+ *   - GET /api/codespaces (list)
+ *   - GET /api/codespaces/summaries (list with summaries)
+ *   - GET /api/tasks      (list, codespace-scoped)
+ *   - GET /api/agents     (list, codespace-scoped)
+ *   - GET /api/sessions   (filtered list with codespaceId)
+ *   - GET /api/sessions   (global cursor list, no codespaceId)
+ *
+ * For each endpoint, we run the same request twice:
+ *   1. With session auth (no tag scope) → returns ALL resources.
+ *   2. With a tag-restricted api_token auth → returns only the tagged subset.
+ *
+ * The two-shot pattern is the regression bar: the *fix* is that case (2) is
+ * smaller than case (1) for tag-restricted tokens. Without the fix, both
+ * cases would be identical (which is the leak).
+ *
+ * Strategy: keep the services as small in-memory mocks that read from the
+ * real test DB (so the filter helper, which queries the DB directly, has a
+ * consistent view of seeded fixtures). The filter logic lives in
+ * `applyTokenTagFilter` — invoked by the route handlers — so this test
+ * exercises the production path end-to-end at the HTTP layer.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { Context, Next } from 'hono';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { agents, codespaces, projectFolders, sessions, tasks, taskTags } from '../../src/db/schema';
+import type { AuthContext } from '../../src/lib/api/auth-middleware';
+import { ok, type Result } from '../../src/lib/utils/result';
+import { createAgentsRoutes } from '../../src/server/routes/agents';
+import { createCodespacesRoutes } from '../../src/server/routes/codespaces';
+import { createSessionsRoutes } from '../../src/server/routes/sessions';
+import { createTasksRoutes } from '../../src/server/routes/tasks';
+import { clearTestDatabase, execRawSql, getTestDb, setupTestDatabase } from '../helpers/database';
+
+// ── Auth context helpers ────────────────────────────────────────────────────
+
+const SESSION_AUTH: AuthContext = {
+  userId: 'user-tagless',
+  authMethod: 'session',
+};
+
+function tagRestrictedAuth(scopeTags: string[]): AuthContext {
+  // Mirror the middleware: tag-restricted tokens hitting collection endpoints
+  // get `tagFilter` set on the auth context.
+  return {
+    userId: 'user-tag-restricted',
+    authMethod: 'api_token',
+    tokenScope: {
+      tokenId: 'tk-test',
+      role: 'admin',
+      codespaceId: null,
+      tags: scopeTags,
+    },
+    tagFilter: {
+      // resourceType is overwritten per-endpoint by the helper below.
+      resourceType: 'codespace',
+      scopeTags,
+    },
+  };
+}
+
+type ResourceType = NonNullable<AuthContext['tagFilter']>['resourceType'];
+
+function authMiddleware(auth: AuthContext, resourceType?: ResourceType) {
+  return async (c: Context, next: Next) => {
+    const a: AuthContext = { ...auth };
+    if (a.tagFilter && resourceType) {
+      a.tagFilter = { ...a.tagFilter, resourceType };
+    }
+    c.set('auth', a);
+    await next();
+  };
+}
+
+// ── Mock services (delegate to real DB so the filter helper stays consistent) ─
+
+function makeCodespaceService(db: ReturnType<typeof getTestDb>) {
+  return {
+    async list(): Promise<Result<unknown[], never>> {
+      const rows = await db.query.codespaces.findMany();
+      return ok(rows);
+    },
+    async listWithSummaries(): Promise<Result<unknown[], never>> {
+      const rows = await db.query.codespaces.findMany();
+      return ok(
+        rows.map((cs) => ({
+          codespace: cs,
+          taskCounts: {
+            backlog: 0,
+            inProgress: 0,
+            waitingApproval: 0,
+            verified: 0,
+            total: 0,
+          },
+          runningAgents: [],
+          status: 'idle' as const,
+          lastActivityAt: cs.updatedAt,
+        }))
+      );
+    },
+    async create(): Promise<Result<unknown, never>> {
+      return ok({});
+    },
+    async update(): Promise<Result<unknown, never>> {
+      return ok({});
+    },
+    async getById(): Promise<Result<unknown, never>> {
+      return ok({});
+    },
+    async delete(): Promise<Result<void, never>> {
+      return ok(undefined);
+    },
+  };
+}
+
+function makeTaskService(db: ReturnType<typeof getTestDb>) {
+  return {
+    async list(codespaceId: string): Promise<Result<unknown[], never>> {
+      const rows = await db.query.tasks.findMany({
+        where: eq(tasks.codespaceId, codespaceId),
+      });
+      return ok(rows);
+    },
+  };
+}
+
+function makeAgentService(db: ReturnType<typeof getTestDb>) {
+  return {
+    async list(codespaceId: string): Promise<Result<unknown[], never>> {
+      const rows = await db.query.agents.findMany({
+        where: eq(agents.codespaceId, codespaceId),
+      });
+      return ok(rows);
+    },
+  };
+}
+
+function makeSessionService(db: ReturnType<typeof getTestDb>) {
+  return {
+    async list(): Promise<Result<unknown[], never>> {
+      const rows = await db.query.sessions.findMany();
+      return ok(rows);
+    },
+    async listSessionsWithFilters(
+      codespaceId: string
+    ): Promise<Result<{ sessions: unknown[]; total: number }, never>> {
+      const rows = await db.query.sessions.findMany({
+        where: eq(sessions.codespaceId, codespaceId),
+      });
+      return ok({ sessions: rows, total: rows.length });
+    },
+    async getSessionSummary(): Promise<Result<unknown, never>> {
+      return ok({
+        turnsCount: 0,
+        tokensUsed: 0,
+        filesModified: 0,
+        linesAdded: 0,
+        linesRemoved: 0,
+      });
+    },
+  };
+}
+
+// ── Test infra ──────────────────────────────────────────────────────────────
+
+interface Fixtures {
+  prodCodespaceId: string;
+  stagingCodespaceId: string;
+  untaggedCodespaceId: string;
+  prodTaskIds: string[];
+  stagingTaskIds: string[];
+  untaggedTaskIds: string[];
+  prodAgentIds: string[];
+  stagingAgentIds: string[];
+  prodSessionIds: string[];
+  stagingSessionIds: string[];
+  untaggedSessionIds: string[];
+}
+
+async function seedFixtures(db: ReturnType<typeof getTestDb>): Promise<Fixtures> {
+  const folderId = 'default-folder';
+
+  // Ensure folder exists (idempotent)
+  await db
+    .insert(projectFolders)
+    .values({
+      id: folderId,
+      name: 'Default',
+      slug: 'default',
+      description: 'Test folder',
+      icon: 'Folder',
+      color: '#6B7280',
+    })
+    .onConflictDoNothing();
+
+  // Tags carry both `team_id` (legacy NOT NULL constraint) and
+  // `project_folder_id` (added by v19 migration). Use raw SQL to set both.
+  // We need a team to satisfy the FK on team_id.
+  execRawSql(
+    `INSERT OR IGNORE INTO teams (id, name, slug, description) VALUES ('team-test', 'Test Team', 'test-team', 'fixture team');
+     INSERT INTO tags (id, team_id, project_folder_id, name, color, created_at, updated_at)
+       VALUES ('tag-prod', 'team-test', '${folderId}', 'production', '#10B981', datetime('now'), datetime('now')),
+              ('tag-staging', 'team-test', '${folderId}', 'staging', '#F59E0B', datetime('now'), datetime('now'));`
+  );
+
+  const prodCs = 'cs-prod';
+  const stagingCs = 'cs-staging';
+  const untaggedCs = 'cs-untagged';
+
+  await db.insert(codespaces).values([
+    {
+      id: prodCs,
+      name: 'Prod',
+      path: '/test/prod',
+      description: 'Production',
+      projectFolderId: folderId,
+    },
+    {
+      id: stagingCs,
+      name: 'Staging',
+      path: '/test/staging',
+      description: 'Staging',
+      projectFolderId: folderId,
+    },
+    {
+      id: untaggedCs,
+      name: 'Untagged',
+      path: '/test/untagged',
+      description: 'No tags',
+      projectFolderId: folderId,
+    },
+  ]);
+
+  // codespace_tags table is missing the `assigned_at` column in the test
+  // bootstrap (schema-drift, tracked separately). Insert via raw SQL.
+  execRawSql(
+    `INSERT INTO codespace_tags (codespace_id, tag_id)
+       VALUES ('${prodCs}', 'tag-prod'), ('${stagingCs}', 'tag-staging');`
+  );
+
+  const prodTasks = ['task-prod-1', 'task-prod-2'];
+  const stagingTasks = ['task-staging-1', 'task-staging-2'];
+  const untaggedTasks = ['task-untagged-1'];
+
+  await db.insert(tasks).values([
+    { id: prodTasks[0], codespaceId: prodCs, title: 'P1', column: 'backlog', position: 1 },
+    { id: prodTasks[1], codespaceId: prodCs, title: 'P2', column: 'backlog', position: 2 },
+    { id: stagingTasks[0], codespaceId: stagingCs, title: 'S1', column: 'backlog', position: 1 },
+    { id: stagingTasks[1], codespaceId: stagingCs, title: 'S2', column: 'backlog', position: 2 },
+    { id: untaggedTasks[0], codespaceId: untaggedCs, title: 'U1', column: 'backlog', position: 1 },
+  ]);
+
+  const prodAgents = ['agent-prod-1', 'agent-prod-2'];
+  const stagingAgents = ['agent-staging-1'];
+
+  await db.insert(agents).values([
+    { id: prodAgents[0], codespaceId: prodCs, name: 'PA1', type: 'claude', status: 'idle' },
+    { id: prodAgents[1], codespaceId: prodCs, name: 'PA2', type: 'claude', status: 'idle' },
+    { id: stagingAgents[0], codespaceId: stagingCs, name: 'SA1', type: 'claude', status: 'idle' },
+  ]);
+
+  const prodSessions = ['sess-prod-1'];
+  const stagingSessions = ['sess-staging-1', 'sess-staging-2'];
+  const untaggedSessions = ['sess-untagged-1'];
+
+  await db.insert(sessions).values([
+    {
+      id: prodSessions[0],
+      codespaceId: prodCs,
+      taskId: prodTasks[0],
+      agentId: prodAgents[0],
+      title: 'PS',
+      status: 'closed',
+      url: '/sessions/sess-prod-1',
+    },
+    {
+      id: stagingSessions[0],
+      codespaceId: stagingCs,
+      taskId: stagingTasks[0],
+      agentId: stagingAgents[0],
+      title: 'SS1',
+      status: 'closed',
+      url: '/sessions/sess-staging-1',
+    },
+    {
+      id: stagingSessions[1],
+      codespaceId: stagingCs,
+      taskId: null,
+      agentId: stagingAgents[0],
+      title: 'SS2',
+      status: 'closed',
+      url: '/sessions/sess-staging-2',
+    },
+    {
+      id: untaggedSessions[0],
+      codespaceId: untaggedCs,
+      taskId: untaggedTasks[0],
+      agentId: null,
+      title: 'US',
+      status: 'closed',
+      url: '/sessions/sess-untagged-1',
+    },
+  ]);
+
+  return {
+    prodCodespaceId: prodCs,
+    stagingCodespaceId: stagingCs,
+    untaggedCodespaceId: untaggedCs,
+    prodTaskIds: prodTasks,
+    stagingTaskIds: stagingTasks,
+    untaggedTaskIds: untaggedTasks,
+    prodAgentIds: prodAgents,
+    stagingAgentIds: stagingAgents,
+    prodSessionIds: prodSessions,
+    stagingSessionIds: stagingSessions,
+    untaggedSessionIds: untaggedSessions,
+  };
+}
+
+describe('F06-NEW-07: tag-restricted tokens see filtered collections (PR W2-L)', () => {
+  let db: ReturnType<typeof getTestDb>;
+  let fixtures: Fixtures;
+
+  beforeEach(async () => {
+    await setupTestDatabase();
+    db = getTestDb();
+    fixtures = await seedFixtures(db);
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase();
+  });
+
+  // ── codespaces list ────────────────────────────────────────────────────────
+
+  it('GET /api/codespaces returns ALL codespaces for session auth (no tag scope)', async () => {
+    const codespaceService = makeCodespaceService(db);
+    const routes = createCodespacesRoutes({
+      codespaceService: codespaceService as never,
+      templateService: {} as never,
+      db: db as never,
+    });
+    const app = new Hono();
+    app.use('*', authMiddleware(SESSION_AUTH));
+    app.route('/', routes);
+
+    const res = await app.request('http://localhost/');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: { items: Array<{ id: string }> } };
+    expect(body.ok).toBe(true);
+    const ids = body.data.items.map((i) => i.id).sort();
+    expect(ids).toEqual(
+      [fixtures.prodCodespaceId, fixtures.stagingCodespaceId, fixtures.untaggedCodespaceId].sort()
+    );
+  });
+
+  it('GET /api/codespaces returns ONLY tag-matching codespaces for tag-restricted token', async () => {
+    const codespaceService = makeCodespaceService(db);
+    const routes = createCodespacesRoutes({
+      codespaceService: codespaceService as never,
+      templateService: {} as never,
+      db: db as never,
+    });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(['tag-prod']), 'codespace'));
+    app.route('/', routes);
+
+    const res = await app.request('http://localhost/');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: { items: Array<{ id: string }> } };
+    expect(body.ok).toBe(true);
+    const ids = body.data.items.map((i) => i.id);
+    expect(ids).toEqual([fixtures.prodCodespaceId]);
+    expect(ids).not.toContain(fixtures.stagingCodespaceId);
+    expect(ids).not.toContain(fixtures.untaggedCodespaceId);
+  });
+
+  // ── tasks list ─────────────────────────────────────────────────────────────
+
+  it('GET /api/tasks (codespace-scoped) returns ALL tasks for session auth', async () => {
+    const taskService = makeTaskService(db);
+    const routes = createTasksRoutes({ taskService: taskService as never, db: db as never });
+    const app = new Hono();
+    app.use('*', authMiddleware(SESSION_AUTH));
+    app.route('/', routes);
+
+    const res = await app.request(`http://localhost/?codespaceId=${fixtures.prodCodespaceId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { items: Array<{ id: string }> };
+    };
+    expect(body.ok).toBe(true);
+    const ids = body.data.items.map((i) => i.id).sort();
+    expect(ids).toEqual(fixtures.prodTaskIds.sort());
+  });
+
+  it('GET /api/tasks returns ONLY tag-matching tasks for tag-restricted token', async () => {
+    const taskService = makeTaskService(db);
+    const routes = createTasksRoutes({ taskService: taskService as never, db: db as never });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(['tag-prod']), 'task'));
+    app.route('/', routes);
+
+    // Staging codespace — token sees no tasks
+    const stagingRes = await app.request(
+      `http://localhost/?codespaceId=${fixtures.stagingCodespaceId}`
+    );
+    expect(stagingRes.status).toBe(200);
+    const stagingBody = (await stagingRes.json()) as {
+      ok: boolean;
+      data: { items: Array<{ id: string }> };
+    };
+    expect(stagingBody.data.items).toEqual([]);
+
+    // Prod codespace — token sees both prod tasks
+    const prodRes = await app.request(`http://localhost/?codespaceId=${fixtures.prodCodespaceId}`);
+    expect(prodRes.status).toBe(200);
+    const prodBody = (await prodRes.json()) as {
+      ok: boolean;
+      data: { items: Array<{ id: string }> };
+    };
+    const prodIds = prodBody.data.items.map((i) => i.id).sort();
+    expect(prodIds).toEqual(fixtures.prodTaskIds.sort());
+
+    // Untagged codespace — token sees nothing
+    const untaggedRes = await app.request(
+      `http://localhost/?codespaceId=${fixtures.untaggedCodespaceId}`
+    );
+    expect(untaggedRes.status).toBe(200);
+    const untaggedBody = (await untaggedRes.json()) as {
+      ok: boolean;
+      data: { items: Array<{ id: string }> };
+    };
+    expect(untaggedBody.data.items).toEqual([]);
+  });
+
+  it('GET /api/tasks honors per-task tag overrides (direct task_tags entry)', async () => {
+    // Tag a single staging task as 'tag-prod' — token scoped to 'tag-prod'
+    // should see THAT task even though its parent codespace is staging.
+    await db.insert(taskTags).values({
+      taskId: fixtures.stagingTaskIds[0],
+      tagId: 'tag-prod',
+    });
+
+    const taskService = makeTaskService(db);
+    const routes = createTasksRoutes({ taskService: taskService as never, db: db as never });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(['tag-prod']), 'task'));
+    app.route('/', routes);
+
+    const res = await app.request(`http://localhost/?codespaceId=${fixtures.stagingCodespaceId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { items: Array<{ id: string }> };
+    };
+    const ids = body.data.items.map((i) => i.id);
+    expect(ids).toEqual([fixtures.stagingTaskIds[0]]);
+    expect(ids).not.toContain(fixtures.stagingTaskIds[1]);
+  });
+
+  // ── agents list ────────────────────────────────────────────────────────────
+
+  it('GET /api/agents returns ALL agents for session auth', async () => {
+    const agentService = makeAgentService(db);
+    const routes = createAgentsRoutes({ agentService: agentService as never, db: db as never });
+    const app = new Hono();
+    app.use('*', authMiddleware(SESSION_AUTH));
+    app.route('/', routes);
+
+    const res = await app.request(`http://localhost/?codespaceId=${fixtures.prodCodespaceId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: Array<{ id: string }> };
+    expect(body.ok).toBe(true);
+    const ids = body.data.map((i) => i.id).sort();
+    expect(ids).toEqual(fixtures.prodAgentIds.sort());
+  });
+
+  it('GET /api/agents returns ONLY tag-matching agents for tag-restricted token', async () => {
+    const agentService = makeAgentService(db);
+    const routes = createAgentsRoutes({ agentService: agentService as never, db: db as never });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(['tag-prod']), 'agent'));
+    app.route('/', routes);
+
+    const stagingRes = await app.request(
+      `http://localhost/?codespaceId=${fixtures.stagingCodespaceId}`
+    );
+    expect(stagingRes.status).toBe(200);
+    const stagingBody = (await stagingRes.json()) as {
+      ok: boolean;
+      data: Array<{ id: string }>;
+    };
+    expect(stagingBody.data).toEqual([]);
+
+    const prodRes = await app.request(`http://localhost/?codespaceId=${fixtures.prodCodespaceId}`);
+    expect(prodRes.status).toBe(200);
+    const prodBody = (await prodRes.json()) as { ok: boolean; data: Array<{ id: string }> };
+    const prodIds = prodBody.data.map((i) => i.id).sort();
+    expect(prodIds).toEqual(fixtures.prodAgentIds.sort());
+  });
+
+  // ── sessions list ──────────────────────────────────────────────────────────
+
+  it('GET /api/sessions (codespace filter) returns ALL sessions for session auth', async () => {
+    const sessionService = makeSessionService(db);
+    const routes = createSessionsRoutes({
+      sessionService: sessionService as never,
+      db: db as never,
+    });
+    const app = new Hono();
+    app.use('*', authMiddleware(SESSION_AUTH));
+    app.route('/', routes);
+
+    const res = await app.request(`http://localhost/?codespaceId=${fixtures.stagingCodespaceId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: Array<{ id: string }> };
+    expect(body.ok).toBe(true);
+    const ids = body.data.map((i) => i.id).sort();
+    expect(ids).toEqual(fixtures.stagingSessionIds.sort());
+  });
+
+  it('GET /api/sessions (codespace filter) returns ONLY tag-matching sessions for tag-restricted token', async () => {
+    const sessionService = makeSessionService(db);
+    const routes = createSessionsRoutes({
+      sessionService: sessionService as never,
+      db: db as never,
+    });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(['tag-prod']), 'session'));
+    app.route('/', routes);
+
+    const stagingRes = await app.request(
+      `http://localhost/?codespaceId=${fixtures.stagingCodespaceId}`
+    );
+    expect(stagingRes.status).toBe(200);
+    const stagingBody = (await stagingRes.json()) as {
+      ok: boolean;
+      data: Array<{ id: string }>;
+    };
+    expect(stagingBody.data).toEqual([]);
+
+    const prodRes = await app.request(`http://localhost/?codespaceId=${fixtures.prodCodespaceId}`);
+    expect(prodRes.status).toBe(200);
+    const prodBody = (await prodRes.json()) as { ok: boolean; data: Array<{ id: string }> };
+    const prodIds = prodBody.data.map((i) => i.id).sort();
+    expect(prodIds).toEqual(fixtures.prodSessionIds.sort());
+  });
+
+  it('GET /api/sessions (global, no codespaceId) returns ONLY tag-matching sessions for tag-restricted token', async () => {
+    const sessionService = makeSessionService(db);
+    const routes = createSessionsRoutes({
+      sessionService: sessionService as never,
+      db: db as never,
+    });
+
+    // 1. session auth → all sessions
+    const allApp = new Hono();
+    allApp.use('*', authMiddleware(SESSION_AUTH));
+    allApp.route('/', routes);
+    const allRes = await allApp.request('http://localhost/');
+    const allBody = (await allRes.json()) as { ok: boolean; data: Array<{ id: string }> };
+    const allIds = new Set(allBody.data.map((i) => i.id));
+    expect(allIds.has(fixtures.prodSessionIds[0])).toBe(true);
+    expect(allIds.has(fixtures.stagingSessionIds[0])).toBe(true);
+    expect(allIds.has(fixtures.untaggedSessionIds[0])).toBe(true);
+
+    // 2. tag-restricted token → only prod sessions
+    const filteredApp = new Hono();
+    filteredApp.use('*', authMiddleware(tagRestrictedAuth(['tag-prod']), 'session'));
+    filteredApp.route('/', routes);
+    const filteredRes = await filteredApp.request('http://localhost/');
+    const filteredBody = (await filteredRes.json()) as {
+      ok: boolean;
+      data: Array<{ id: string }>;
+    };
+    const filteredIds = filteredBody.data.map((i) => i.id);
+    expect(filteredIds).toContain(fixtures.prodSessionIds[0]);
+    expect(filteredIds).not.toContain(fixtures.stagingSessionIds[0]);
+    expect(filteredIds).not.toContain(fixtures.stagingSessionIds[1]);
+    expect(filteredIds).not.toContain(fixtures.untaggedSessionIds[0]);
+  });
+
+  // ── codespaces summaries list ──────────────────────────────────────────────
+
+  it('GET /api/codespaces/summaries filters tag-restricted tokens', async () => {
+    const codespaceService = makeCodespaceService(db);
+    const routes = createCodespacesRoutes({
+      codespaceService: codespaceService as never,
+      templateService: {} as never,
+      db: db as never,
+    });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(['tag-staging']), 'codespace'));
+    app.route('/', routes);
+
+    const res = await app.request('http://localhost/summaries');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { items: Array<{ codespace: { id: string } }> };
+    };
+    expect(body.ok).toBe(true);
+    const ids = body.data.items.map((i) => i.codespace.id);
+    expect(ids).toEqual([fixtures.stagingCodespaceId]);
+  });
+
+  // ── empty scope tags edge case ─────────────────────────────────────────────
+
+  it('tag-restricted token with no overlap sees nothing', async () => {
+    const orphanScope = ['tag-orphan'];
+
+    const codespaceService = makeCodespaceService(db);
+    const routes = createCodespacesRoutes({
+      codespaceService: codespaceService as never,
+      templateService: {} as never,
+      db: db as never,
+    });
+    const app = new Hono();
+    app.use('*', authMiddleware(tagRestrictedAuth(orphanScope), 'codespace'));
+    app.route('/', routes);
+    const res = await app.request('http://localhost/');
+    const body = (await res.json()) as { ok: boolean; data: { items: unknown[] } };
+    expect(body.data.items).toEqual([]);
+  });
+});

--- a/tests/integration/route-sessions.test.ts
+++ b/tests/integration/route-sessions.test.ts
@@ -38,6 +38,7 @@ describe('Sessions Routes (IT-1250)', () => {
     mockService = createMockSessionService();
     app = createSessionsRoutes({
       sessionService: mockService as any,
+      db: {} as never,
     });
   });
 

--- a/tests/integration/route-tasks.test.ts
+++ b/tests/integration/route-tasks.test.ts
@@ -41,6 +41,7 @@ describe('Tasks Routes (IT-1350)', () => {
     mockService = createMockTaskService();
     app = createTasksRoutes({
       taskService: mockService as any,
+      db: {} as never,
     });
   });
 

--- a/tests/lib/api/rbac-middleware.test.ts
+++ b/tests/lib/api/rbac-middleware.test.ts
@@ -906,6 +906,212 @@ describe('requireTagAccess', () => {
     expect(body.error.code).toBe('FORBIDDEN');
     expect(body.error.message).toBe('Tag-restricted tokens cannot access this resource type');
   });
+
+  // ── F06-NEW-07: collection-endpoint passthrough ─────────────────────────
+  //
+  // Before the W2-L fix, tag-restricted tokens hitting collection endpoints
+  // (no `:id` param) got 403'd. The new behaviour is to pass through, with
+  // a `tagFilter` on the auth context so the route handler can narrow its
+  // result set. These tests pin that contract.
+
+  it('passes through on /api/codespaces collection (no :id) and sets tagFilter for tag-restricted token', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: ['production'],
+      },
+    };
+
+    let capturedAuth: AuthContext | undefined;
+    const mw = requireTagAccess(mockDb as never) as never;
+    const app = new Hono();
+    app.get('/api/codespaces', createAuthMiddleware(auth) as never, mw, (c) => {
+      capturedAuth = c.get('auth') as AuthContext | undefined;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/api/codespaces');
+    expect(res.status).toBe(200);
+    expect(capturedAuth?.tagFilter).toEqual({
+      resourceType: 'codespace',
+      scopeTags: ['production'],
+    });
+    // Critical: the middleware must NOT have done a DB lookup for collection
+    // paths — that's the handler's job via applyTokenTagFilter.
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('passes through on /api/tasks collection and tags it as task resource type', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: ['team-alpha', 'team-beta'],
+      },
+    };
+
+    let capturedAuth: AuthContext | undefined;
+    const mw = requireTagAccess(mockDb as never) as never;
+    const app = new Hono();
+    app.get('/api/tasks', createAuthMiddleware(auth) as never, mw, (c) => {
+      capturedAuth = c.get('auth') as AuthContext | undefined;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/api/tasks?codespaceId=cs-1');
+    expect(res.status).toBe(200);
+    expect(capturedAuth?.tagFilter?.resourceType).toBe('task');
+    expect(capturedAuth?.tagFilter?.scopeTags).toEqual(['team-alpha', 'team-beta']);
+  });
+
+  it('passes through on /api/agents and /api/sessions collection endpoints', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: ['infra'],
+      },
+    };
+
+    const mw = requireTagAccess(mockDb as never) as never;
+    const app = new Hono();
+    app.get('/api/agents', createAuthMiddleware(auth) as never, mw, (c) =>
+      c.json({ ok: true, type: (c.get('auth') as AuthContext).tagFilter?.resourceType })
+    );
+    app.get('/api/sessions', createAuthMiddleware(auth) as never, mw, (c) =>
+      c.json({ ok: true, type: (c.get('auth') as AuthContext).tagFilter?.resourceType })
+    );
+
+    const agentRes = await app.request('/api/agents?codespaceId=cs-1');
+    expect(agentRes.status).toBe(200);
+    expect(((await agentRes.json()) as { type: string }).type).toBe('agent');
+
+    const sessionRes = await app.request('/api/sessions');
+    expect(sessionRes.status).toBe(200);
+    expect(((await sessionRes.json()) as { type: string }).type).toBe('session');
+  });
+
+  // F06-NEW-07: in production the middleware is wired as
+  // `app.use('/api/*', requireTagAccess(db))` — wildcard middleware runs
+  // BEFORE route matching, so `c.req.param('id')` is undefined for all
+  // paths. The middleware must detect resource IDs from the path itself.
+
+  it('detects resource ID from path when wired as wildcard middleware', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: ['production'],
+      },
+    };
+
+    // Resource has matching tag — should be allowed
+    const chain = buildSelectChain([{ tagId: 'production' }]);
+    mockDb.select.mockReturnValue(chain);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    // Wildcard mount: mirrors production wiring at router.ts:405
+    app.use('/api/*', requireTagAccess(mockDb as never) as never);
+    // No `:id` in the route — Hono won't populate c.req.param('id'),
+    // so the middleware MUST extract the ID from the path.
+    app.get('/api/codespaces/proj-1', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/codespaces/proj-1');
+    expect(res.status).toBe(200);
+    expect(mockDb.select).toHaveBeenCalled();
+  });
+
+  it('denies wildcard-mounted tag-restricted access when path-extracted resource has no matching tag', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: ['production'],
+      },
+    };
+
+    // Resource has staging tag, token requires production
+    const chain = buildSelectChain([{ tagId: 'staging' }]);
+    mockDb.select.mockReturnValue(chain);
+
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('/api/*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/codespaces/proj-1', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/api/codespaces/proj-1');
+    expect(res.status).toBe(403);
+  });
+
+  it('treats /api/codespaces/summaries as a collection (not a resource ID)', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: ['production'],
+      },
+    };
+
+    let capturedAuth: AuthContext | undefined;
+    const app = new Hono();
+    app.use('*', createAuthMiddleware(auth) as never);
+    app.use('/api/*', requireTagAccess(mockDb as never) as never);
+    app.get('/api/codespaces/summaries', (c) => {
+      capturedAuth = c.get('auth') as AuthContext | undefined;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/api/codespaces/summaries');
+    expect(res.status).toBe(200);
+    expect(capturedAuth?.tagFilter?.resourceType).toBe('codespace');
+    // No DB lookup happened — `summaries` is recognised as a sub-collection.
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('does not set tagFilter for non-tag-restricted tokens', async () => {
+    const auth: AuthContext = {
+      userId: 'user-123',
+      authMethod: 'api_token',
+      tokenScope: {
+        tokenId: 'tk-1',
+        role: 'admin',
+        codespaceId: null,
+        tags: null,
+      },
+    };
+
+    let capturedAuth: AuthContext | undefined;
+    const mw = requireTagAccess(mockDb as never) as never;
+    const app = new Hono();
+    app.get('/api/codespaces', createAuthMiddleware(auth) as never, mw, (c) => {
+      capturedAuth = c.get('auth') as AuthContext | undefined;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/api/codespaces');
+    expect(res.status).toBe(200);
+    expect(capturedAuth?.tagFilter).toBeUndefined();
+  });
 });
 
 // =============================================================================

--- a/tests/routes/tasks-plan-approval.test.ts
+++ b/tests/routes/tasks-plan-approval.test.ts
@@ -39,7 +39,7 @@ describe('Task plan approval API routes', () => {
 
   beforeEach(() => {
     taskService = createMockTaskService();
-    const routes = createTasksRoutes({ taskService });
+    const routes = createTasksRoutes({ taskService, db: {} as never });
     app = new Hono();
     app.route('/api/tasks', routes);
   });
@@ -73,7 +73,7 @@ describe('Task plan approval API routes', () => {
             err({ code: 'SANDBOX_PLAN_NOT_FOUND', message: 'No pending plan', status: 404 })
           ),
       });
-      const routes = createTasksRoutes({ taskService });
+      const routes = createTasksRoutes({ taskService, db: {} as never });
       app = new Hono();
       app.route('/api/tasks', routes);
 
@@ -93,7 +93,7 @@ describe('Task plan approval API routes', () => {
             err({ code: 'SANDBOX_AGENT_START_FAILED', message: 'DB error', status: 500 })
           ),
       });
-      const routes = createTasksRoutes({ taskService });
+      const routes = createTasksRoutes({ taskService, db: {} as never });
       app = new Hono();
       app.route('/api/tasks', routes);
 
@@ -140,7 +140,7 @@ describe('Task plan approval API routes', () => {
             err({ code: 'SANDBOX_PLAN_NOT_FOUND', message: 'No pending plan', status: 404 })
           ),
       });
-      const routes = createTasksRoutes({ taskService });
+      const routes = createTasksRoutes({ taskService, db: {} as never });
       app = new Hono();
       app.route('/api/tasks', routes);
 


### PR DESCRIPTION
## Summary

Tag-restricted API tokens previously hit one of two failure modes on collection (list) endpoints:

1. `requireTagAccess` returned 403 for any path lacking a `:id` param — forcing operators to either grant unrestricted tokens or strip the middleware from their `/api/*` pipeline. Either workaround leaks every resource.
2. With the middleware skipped, `GET /api/codespaces`, `GET /api/tasks`, `GET /api/agents`, `GET /api/sessions` all returned the full result set regardless of the token's tag scope.

This PR replaces the silent skip with an actual result-set filter:

- `requireTagAccess` now extracts the resource ID from the path (the middleware is mounted as `/api/*` before Hono's route matching populates `c.req.param('id')`). Collection endpoints get `auth.tagFilter` set and pass through; resource endpoints keep the existing per-id enforcement.
- New `applyTokenTagFilter(db, auth, items, getId)` helper — invoked from list-route handlers — narrows the response to resources whose tags overlap the token's scope tags.
- New `getAccessibleResourceIds()` helper resolves the visible-id set per resource type, exported for routes that prefer in-query filtering via `inArray()`.
- Inheritance mirrors the existing `TAG_RESOLVERS`: tasks fall back to parent codespace tags, sessions to task-or-codespace tags, agents to codespace tags.
- List endpoints wired to the helper:
  - `GET /api/codespaces` (and `/summaries`)
  - `GET /api/tasks` (codespace-scoped + cross-codespace)
  - `GET /api/agents`
  - `GET /api/sessions` (filtered + global cursor)
- Sub-collection paths (`/api/codespaces/summaries`) are recognised so they keep collection semantics rather than being treated as `:id`.

## Status vs April 29 review

- **F06-NEW-07 (P1)**: RESOLVED. Tag-restricted tokens see ONLY tagged resources via list endpoints. Verified by `tests/integration/rbac-tag-collection-filter.test.ts` (12 cases, all four endpoints).

## Test plan

Red → green:

- **before**: `tests/integration/rbac-tag-collection-filter.test.ts` (FAIL — list endpoints return all resources for tag-restricted tokens, breaching F06-NEW-07).
- **after**: `tests/integration/rbac-tag-collection-filter.test.ts` (PASS — 12 tests cover the four list endpoints + summaries + per-task tag overrides + zero-overlap edge case).

Additional coverage:
- `tests/lib/api/rbac-middleware.test.ts` (+6 new cases) — collection-passthrough behaviour, wildcard-mounted resource ID detection, `summaries` sub-collection handling, no-tagFilter for unrestricted tokens.

Gates:
- [x] `npx tsc --noEmit` passes
- [x] `npx @biomejs/biome check --max-diagnostics=500 --diagnostic-level=error` passes for changed files
- [x] `npx vitest run --no-coverage tests/lib/api/rbac-middleware.test.ts tests/integration/rbac-tag-collection-filter.test.ts tests/integration/rbac-tag-access.test.ts tests/integration/rbac-token-ceiling.test.ts tests/integration/rbac-role-resolution.test.ts tests/services/rbac.service.test.ts tests/integration/route-codespaces.test.ts tests/integration/route-tasks.test.ts tests/integration/route-sessions.test.ts` — 232 tests pass
- [x] No new lint/type/test regressions across `tests/api/`, `tests/routes/`, `src/server/routes/__tests__/` (1454/1455 pass; the 1 failure is pre-existing F07-15 territory, unrelated to this PR).

Cross-ref: `specs/arch_review_april29/06-security.md` § F06-NEW-07.

Signed-off-by: Simon Lynch <srlynch@gmail.com>

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
