### PR TITLE
fix(arch29-W2-D-FIX): properly gate AgentCore behind AGENTCORE_ENABLED (F04-04, F04-05)

### DIFF
--- a/src/services/container-agent/container-agent.service.ts
+++ b/src/services/container-agent/container-agent.service.ts
@@ -9,7 +9,8 @@
  * - SandboxStateManager:    owns 3 Maps + 1 Set for state tracking
  * - WorktreeInitService:    worktree creation, path translation
  * - ContainerExecService:   container lifecycle management (Docker/K8s/Nomad)
- * - AgentCoreBridgeService: AgentCore start/stop, SSE bridge
+ * - AgentCoreBridgeService: AgentCore start/stop, SSE bridge (lazy-loaded
+ *                           only when `AGENTCORE_ENABLED=true`)
  * - PlanApprovalService:    plan ready/approve/reject handlers
  */
 
@@ -19,11 +20,14 @@ import { codespaces, tasks } from '../../db/schema';
 import type { SandboxError } from '../../lib/errors/sandbox-errors.js';
 import { SandboxErrors } from '../../lib/errors/sandbox-errors.js';
 import { createLogger } from '../../lib/logging/logger.js';
-// theme-04 P1-02: AgentCore provider types are imported with `import type` so
-// the concrete module (which pulls in the AWS SDK) is NOT added to the module
-// graph when AgentCore is disabled. The factory (`createAgentCoreProvider`) is
-// loaded via dynamic import inside `setAgentCoreProvider` only when
-// `AGENTCORE_ENABLED=true`.
+// theme-04 W2-D-FIX (F04-04, F04-05): AgentCore-related imports are TYPE-ONLY.
+// The concrete modules (which transitively pull in `agentcore-bridge.ts`,
+// `agentcore-sandbox-provider.ts`, `agentcore-sandbox-instance.ts`, the
+// hand-rolled SigV4 signer, and the AWS SDK) are loaded via dynamic `import()`
+// inside `setAgentCoreProvider` ONLY when `AGENTCORE_ENABLED=true`. Type
+// imports are erased at compile time and contribute zero bytes to the runtime
+// module graph, so when the gate is off none of the AgentCore code ships in
+// the loaded graph.
 import type {
   AgentCoreProviderConfig,
   AgentCoreSandboxProvider,
@@ -39,7 +43,12 @@ import type { SkillTrackingService } from '../memory/skill-tracking.service.js';
 import type { WorktreeService } from '../worktree.service.js';
 
 import { AgentReviewService } from './agent-review.service.js';
-import { AgentCoreBridgeService } from './agentcore-bridge.service.js';
+// theme-04 W2-D-FIX: AgentCoreBridgeService is intentionally TYPE-ONLY here.
+// The runtime module is loaded via dynamic import inside `loadAgentCoreBridge()`,
+// gated on `AGENTCORE_ENABLED=true`. The runtime import would otherwise pull
+// `lib/agents/agentcore-bridge.ts` (and its transitive `agentcore-sandbox-instance`
+// type re-export wires) into the loaded graph regardless of the flag.
+import type { AgentCoreBridgeService } from './agentcore-bridge.service.js';
 import { ContainerExecService } from './container-exec.service.js';
 import { PlanApprovalService } from './plan-approval.service.js';
 import { SandboxStateManager } from './sandbox-state.js';
@@ -49,10 +58,13 @@ import { WorktreeInitService } from './worktree-init.service.js';
 const log = createLogger('ContainerAgentService');
 
 /**
- * theme-04 P1-02: Feature flag for AgentCore.
+ * theme-04 P1-02 / W2-D-FIX: Feature flag for AgentCore.
  *
- * When this returns false (the default), the agentcore-sandbox-provider module
- * is never imported, so the AWS SDK does not land in the module graph. Set
+ * When this returns false (the default), NO AgentCore module is in the loaded
+ * module graph: `agentcore-bridge.service.ts`, `agentcore-bridge.ts`,
+ * `agentcore-sandbox-provider.ts`, `agentcore-sandbox-instance.ts` (which
+ * contains the hand-rolled SigV4 signer ~110 LOC), and the AWS SDK are all
+ * gated behind dynamic `import()` calls keyed off this flag. Set
  * `AGENTCORE_ENABLED=true` to opt in.
  */
 function isAgentCoreEnabled(): boolean {
@@ -63,9 +75,42 @@ export class ContainerAgentService {
   private state: SandboxStateManager;
   private worktreeInit: WorktreeInitService;
   private containerExec: ContainerExecService;
-  private agentCoreBridge: AgentCoreBridgeService;
+  /**
+   * theme-04 W2-D-FIX (F04-04): AgentCoreBridgeService is lazily loaded.
+   * Undefined until `setAgentCoreProvider()` is called with the flag enabled.
+   * The constructor MUST NOT instantiate this — doing so pulls the entire
+   * AgentCore module graph (including the hand-rolled SigV4 signer in
+   * `agentcore-sandbox-instance.ts`) into the loaded module set regardless
+   * of `AGENTCORE_ENABLED`.
+   */
+  private agentCoreBridge?: AgentCoreBridgeService;
   private planApproval: PlanApprovalService;
   private deps: ContainerAgentDeps;
+
+  /**
+   * Shared handlePlanReady callback used by both ContainerExecService (eager)
+   * and AgentCoreBridgeService (lazy). Stored as a field so the lazy AgentCore
+   * bridge can wire it up after construction without forcing an early load.
+   */
+  private readonly handlePlanReady: (
+    taskId: string,
+    sessionId: string,
+    codespaceId: string,
+    planData: {
+      plan: string;
+      turnCount: number;
+      sdkSessionId: string;
+      allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
+    }
+  ) => Promise<void>;
+
+  /**
+   * Provides access to the on-agent-complete callback. Stored as a closure so
+   * the lazy AgentCore bridge can read the latest registered callback.
+   */
+  private readonly getOnAgentCompleteCallback: () =>
+    | ((codespaceId: string, taskId: string) => Promise<void>)
+    | undefined;
 
   /** AgentCore sandbox provider (lazily initialized when AgentCore config is set) */
   private agentCoreProvider?: AgentCoreSandboxProvider;
@@ -107,36 +152,24 @@ export class ContainerAgentService {
     this.worktreeInit = new WorktreeInitService(this.deps);
 
     // handlePlanReady callback shared by both exec paths
-    const handlePlanReady = (
-      taskId: string,
-      sessionId: string,
-      codespaceId: string,
-      planData: {
-        plan: string;
-        turnCount: number;
-        sdkSessionId: string;
-        allowedPrompts?: Array<{ tool: 'Bash'; prompt: string }>;
-      }
-    ) => this.planApproval.handlePlanReady(taskId, sessionId, codespaceId, planData);
+    this.handlePlanReady = (taskId, sessionId, codespaceId, planData) =>
+      this.planApproval.handlePlanReady(taskId, sessionId, codespaceId, planData);
 
-    const getOnAgentCompleteCallback = () => this.onAgentCompleteCallback;
+    this.getOnAgentCompleteCallback = () => this.onAgentCompleteCallback;
 
     this.containerExec = new ContainerExecService(
       this.deps,
       this.state,
       this.worktreeInit,
-      handlePlanReady,
-      getOnAgentCompleteCallback
+      this.handlePlanReady,
+      this.getOnAgentCompleteCallback
     );
 
-    this.agentCoreBridge = new AgentCoreBridgeService(
-      this.deps,
-      this.state,
-      this.containerExec,
-      () => this.agentCoreProvider,
-      handlePlanReady,
-      getOnAgentCompleteCallback
-    );
+    // theme-04 W2-D-FIX: AgentCoreBridgeService is NOT instantiated here.
+    // It is lazily loaded by `loadAgentCoreBridge()` from `setAgentCoreProvider()`
+    // when (and only when) `AGENTCORE_ENABLED=true`. With the flag off the
+    // module graph contains zero AgentCore code — no bridge service, no
+    // SigV4 signer, no AWS SDK.
 
     const agentReview = new AgentReviewService(this.deps);
 
@@ -151,6 +184,37 @@ export class ContainerAgentService {
 
     // Wire circular reference: review service needs planApproval to call approvePlan()
     agentReview.setPlanApproval(this.planApproval);
+  }
+
+  /**
+   * theme-04 W2-D-FIX (F04-04, F04-05): Lazily load and construct the
+   * AgentCoreBridgeService. The dynamic `import()` is the gate that keeps
+   * `agentcore-bridge.service.ts`, `agentcore-bridge.ts`, and the SigV4
+   * signer in `agentcore-sandbox-instance.ts` out of the runtime module
+   * graph when `AGENTCORE_ENABLED=false`.
+   *
+   * Idempotent: once loaded, returns the cached instance. Returns undefined
+   * (and logs) if the gate is off, so callers can short-circuit gracefully.
+   */
+  private async loadAgentCoreBridge(): Promise<AgentCoreBridgeService | undefined> {
+    if (!isAgentCoreEnabled()) {
+      log.warn('loadAgentCoreBridge called but AGENTCORE_ENABLED is not set — skipping');
+      return undefined;
+    }
+    if (this.agentCoreBridge) {
+      return this.agentCoreBridge;
+    }
+    const { AgentCoreBridgeService: BridgeCtor } = await import('./agentcore-bridge.service.js');
+    this.agentCoreBridge = new BridgeCtor(
+      this.deps,
+      this.state,
+      this.containerExec,
+      () => this.agentCoreProvider,
+      this.handlePlanReady,
+      this.getOnAgentCompleteCallback
+    );
+    log.info('AgentCoreBridgeService lazily loaded (AGENTCORE_ENABLED=true)');
+    return this.agentCoreBridge;
   }
 
   /**
@@ -170,10 +234,11 @@ export class ContainerAgentService {
   /**
    * Configure the AgentCore sandbox provider.
    *
-   * theme-04 P1-02: This is a no-op unless `AGENTCORE_ENABLED=true` is set in
-   * the environment. The agentcore-sandbox-provider module (which pulls in
-   * the AWS SDK via dynamic import) is loaded lazily — with the feature flag
-   * off, the module never reaches the module graph.
+   * theme-04 P1-02 / W2-D-FIX (F04-04, F04-05): This is a no-op unless
+   * `AGENTCORE_ENABLED=true` is set. Both the AgentCore provider module and
+   * the bridge service are loaded via dynamic import — with the flag off,
+   * neither module (nor the SigV4 signer in `agentcore-sandbox-instance.ts`,
+   * nor the AWS SDK) ever reaches the runtime module graph.
    */
   async setAgentCoreProvider(config: AgentCoreProviderConfig): Promise<void> {
     if (!isAgentCoreEnabled()) {
@@ -187,6 +252,11 @@ export class ContainerAgentService {
       '../../lib/sandbox/providers/agentcore-sandbox-provider.js'
     );
     this.agentCoreProvider = createAgentCoreProvider(config);
+    // theme-04 W2-D-FIX: load the bridge service alongside the provider so
+    // both modules enter the graph together (or, with the flag off, neither
+    // does). Loading is idempotent — subsequent setAgentCoreProvider calls
+    // reuse the cached bridge.
+    await this.loadAgentCoreBridge();
     log.info('AgentCore provider configured', {
       data: { region: config.region, runtimeArn: config.runtimeArn },
     });
@@ -258,7 +328,22 @@ export class ContainerAgentService {
           where: eq(codespaces.id, input.codespaceId),
         });
         if (!codespace) return err(SandboxErrors.PROJECT_NOT_FOUND);
-        return this.agentCoreBridge.startAgentCoreAgent(input, codespace);
+        // theme-04 W2-D-FIX: bridge should already be loaded by
+        // setAgentCoreProvider(); load defensively in case a caller
+        // manually populated the provider via test injection.
+        const bridge = await this.loadAgentCoreBridge();
+        if (!bridge) {
+          // AGENTCORE_ENABLED is off but a provider was somehow set — surface
+          // this as an error rather than silently falling through to the
+          // container exec path, which would not produce the expected
+          // AgentCore semantics.
+          return err(
+            SandboxErrors.AGENT_START_FAILED(
+              'AgentCore provider is configured but AGENTCORE_ENABLED is not set; bridge unavailable'
+            )
+          );
+        }
+        return bridge.startAgentCoreAgent(input, codespace);
       }
       return this.containerExec.startAgent(input);
     } finally {
@@ -277,10 +362,22 @@ export class ContainerAgentService {
     // Clear starting guard
     this.state.clearStarting(taskId);
 
-    // AgentCore branch
+    // AgentCore branch — `acAgent` is only ever populated by the AgentCore
+    // bridge after a successful startAgentCoreAgent, so by the time we're
+    // here the bridge has already been lazy-loaded. We still call
+    // loadAgentCoreBridge() defensively to surface a clear error if the
+    // gate is somehow off.
     const acAgent = this.state.getRunningAgentCoreAgent(taskId);
     if (acAgent) {
-      return this.agentCoreBridge.stopAgentCoreAgent(acAgent);
+      const bridge = await this.loadAgentCoreBridge();
+      if (!bridge) {
+        return err(
+          SandboxErrors.AGENT_STOP_FAILED(
+            'AgentCore agent is running but AGENTCORE_ENABLED is not set; bridge unavailable'
+          )
+        );
+      }
+      return bridge.stopAgentCoreAgent(acAgent);
     }
 
     // Container exec branch

--- a/tests/integration/agentcore-lazy-load.test.ts
+++ b/tests/integration/agentcore-lazy-load.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration test for theme-04 W2-D-FIX (F04-04, F04-05): AgentCore lazy loading.
+ *
+ * Verifies that when `AGENTCORE_ENABLED=false` (the default), importing and
+ * constructing `ContainerAgentService` does NOT pull any AgentCore-specific
+ * module into the runtime module graph:
+ *
+ *   - src/services/container-agent/agentcore-bridge.service.ts (~561 LOC)
+ *   - src/lib/agents/agentcore-bridge.ts (SSE→DurableStreams glue)
+ *   - src/lib/sandbox/providers/agentcore-sandbox-provider.ts
+ *   - src/lib/sandbox/providers/agentcore-sandbox-instance.ts (hand-rolled
+ *     SigV4 signer, ~110 LOC of crypto code)
+ *
+ * And conversely, that with `AGENTCORE_ENABLED=true` calling
+ * `setAgentCoreProvider()` DOES load all four modules.
+ *
+ * Test strategy: spawn a child Bun process for each scenario. The child
+ * imports the service module, calls the relevant setup APIs, then probes
+ * Bun's module loader registry (`Loader.registry` via `bun:jsc` /
+ * `Bun.resolveSync`) and prints a JSON summary of which AgentCore-related
+ * paths have been loaded. The parent test asserts the expected pattern.
+ *
+ * Why a child process: vitest's worker shares a single module cache across
+ * the test file. We need a fresh module graph per scenario to verify the
+ * load-or-skip behavior cleanly. A child process gives us that.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+// ── Probe script ──────────────────────────────────────────────────────────────
+//
+// Runs inside a child Bun process. It imports ContainerAgentService, optionally
+// calls setAgentCoreProvider, then walks `require.cache` (CommonJS) and Bun's
+// loaded-module list to see which AgentCore-related modules are present.
+
+const PROBE_SCRIPT = `
+import { ContainerAgentService } from '${REPO_ROOT}/src/services/container-agent/container-agent.service.ts';
+
+// Build a minimal, in-memory ContainerAgentService.
+//
+// The constructor never touches DB / streams / git when neither startAgent nor
+// any provider configuration is invoked, so a stub-shaped object is safe for
+// the lazy-load probe.
+const stubDb = {
+  query: { tasks: { findMany: async () => [] }, codespaces: { findFirst: async () => null } },
+};
+const stubProvider = { name: 'docker' };
+const stubStreams = { publish: async () => {}, createStream: async () => {} };
+const stubApiKey = { getDecryptedKey: async () => null };
+
+const service = new ContainerAgentService(
+  stubDb,
+  stubProvider,
+  stubStreams,
+  stubApiKey
+);
+
+// If the parent passed --set-agentcore-provider, wire it up. This requires
+// AGENTCORE_ENABLED=true to actually load the bridge service — otherwise it's
+// a no-op (the gate logs a warning and skips).
+if (process.argv.includes('--set-agentcore-provider')) {
+  await service.setAgentCoreProvider({
+    region: 'us-east-1',
+    accessKeyId: 'AKIATEST',
+    secretAccessKey: 'secret',
+    runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123:runtime/stub',
+  });
+}
+
+// Probe Bun's module loader for known AgentCore paths. \`Bun.resolveSync\`
+// throws if the path isn't already loaded into the registry; \`Bun.resolve\`
+// without options returns whatever the loader has indexed (loaded or not).
+//
+// We instead inspect the global module registry via the documented
+// \`process.moduleLoadList\` (Node) or, on Bun, fall back to a heuristic: a
+// dynamic import that has not occurred is invisible to the loader UNLESS the
+// path was statically resolved at compile time, but Bun's static-import
+// resolver does NOT add paths to the registry without a runtime load.
+//
+// Cleanest cross-runtime check: try to enumerate ESM \`registry\` via the
+// \`process.binding('module_wrap')\` native binding when running on Node, or
+// inspect Bun's \`Loader.registry\`.
+//
+// For a robust signal, we do the following: each AgentCore module exports a
+// well-known sentinel symbol when loaded. We stash them on \`globalThis\`
+// at load time. The probe then reads back the global to see which ones fired.
+
+const sentinelKeys = {
+  bridgeService: '__agentpane_loaded_agentcore_bridge_service',
+  bridgeLib: '__agentpane_loaded_agentcore_bridge',
+  sandboxProvider: '__agentpane_loaded_agentcore_sandbox_provider',
+  sandboxInstance: '__agentpane_loaded_agentcore_sandbox_instance',
+};
+
+const result = {
+  bridgeService: Boolean(globalThis[sentinelKeys.bridgeService]),
+  bridgeLib: Boolean(globalThis[sentinelKeys.bridgeLib]),
+  sandboxProvider: Boolean(globalThis[sentinelKeys.sandboxProvider]),
+  sandboxInstance: Boolean(globalThis[sentinelKeys.sandboxInstance]),
+  agentcoreEnabled: process.env.AGENTCORE_ENABLED === 'true',
+  serviceConstructed: typeof service === 'object',
+};
+
+console.log(JSON.stringify(result));
+
+// Explicitly tear down the service so the plan-cleanup interval (set by
+// SandboxStateManager) does not keep the process alive. Without this, the
+// probe hangs until the parent's spawnSync timeout kicks in.
+service.dispose();
+// Force-exit to release any other handles (durable streams clients, etc).
+process.exit(0);
+`.trim();
+
+// ── Sentinel injection ────────────────────────────────────────────────────────
+//
+// The probe script relies on each AgentCore module exporting a side-effectful
+// \`globalThis\` write. Rather than modifying production code, we patch the four
+// modules with a tiny preload hook that wraps their default behavior.
+
+const PRELOAD_SCRIPT = `
+// Preload hook installed before the probe script imports anything.
+// Patches Bun's module loader so that when one of the AgentCore source files
+// is loaded, a sentinel is set on globalThis. Production code is unchanged.
+
+import { plugin } from 'bun';
+
+const sentinelMap = {
+  '/src/services/container-agent/agentcore-bridge.service.ts': '__agentpane_loaded_agentcore_bridge_service',
+  '/src/lib/agents/agentcore-bridge.ts': '__agentpane_loaded_agentcore_bridge',
+  '/src/lib/sandbox/providers/agentcore-sandbox-provider.ts': '__agentpane_loaded_agentcore_sandbox_provider',
+  '/src/lib/sandbox/providers/agentcore-sandbox-instance.ts': '__agentpane_loaded_agentcore_sandbox_instance',
+};
+
+plugin({
+  name: 'agentcore-load-tracker',
+  setup(build) {
+    build.onLoad({ filter: /\\/agentcore-(bridge|bridge\\.service|sandbox-provider|sandbox-instance)\\.ts$/ }, async (args) => {
+      const fs = await import('node:fs/promises');
+      const original = await fs.readFile(args.path, 'utf8');
+      // Find the matching sentinel
+      let sentinel = null;
+      for (const [suffix, key] of Object.entries(sentinelMap)) {
+        if (args.path.endsWith(suffix)) {
+          sentinel = key;
+          break;
+        }
+      }
+      if (!sentinel) return { contents: original, loader: 'ts' };
+      // Prepend the side effect so it executes the moment the module is loaded.
+      const patched = \`globalThis['\${sentinel}'] = true;\\n\` + original;
+      return { contents: patched, loader: 'ts' };
+    });
+  },
+});
+`.trim();
+
+let workDir: string;
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'agentcore-lazy-load-'));
+});
+
+afterAll(() => {
+  if (workDir) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+interface ProbeResult {
+  bridgeService: boolean;
+  bridgeLib: boolean;
+  sandboxProvider: boolean;
+  sandboxInstance: boolean;
+  agentcoreEnabled: boolean;
+  serviceConstructed: boolean;
+}
+
+function runProbe(opts: { agentcoreEnabled: boolean; setAgentCoreProvider: boolean }): ProbeResult {
+  const probePath = join(workDir, `probe-${Date.now()}-${Math.random()}.ts`);
+  const preloadPath = join(workDir, `preload-${Date.now()}-${Math.random()}.ts`);
+  writeFileSync(probePath, PROBE_SCRIPT, 'utf8');
+  writeFileSync(preloadPath, PRELOAD_SCRIPT, 'utf8');
+
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+  };
+  if (opts.agentcoreEnabled) {
+    env.AGENTCORE_ENABLED = 'true';
+  } else {
+    delete env.AGENTCORE_ENABLED;
+  }
+
+  // Bun argument order: `bun --preload <preload> <script> [args...]`.
+  // Putting `run` between `--preload` and the script causes Bun to interpret
+  // `run` as a subcommand and list package.json scripts.
+  const args = ['--preload', preloadPath, probePath];
+  if (opts.setAgentCoreProvider) {
+    args.push('--set-agentcore-provider');
+  }
+
+  const result = spawnSync('bun', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    env,
+    timeout: 30_000,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Probe exited ${result.status}\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+    );
+  }
+
+  // The probe prints exactly one JSON line. There may be other console output
+  // (e.g. AgentPane logger) before it — extract the last well-formed JSON
+  // object from stdout.
+  const lines = result.stdout
+    .trim()
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line?.startsWith('{')) continue;
+    try {
+      return JSON.parse(line) as ProbeResult;
+    } catch {
+      // Try the next-most-recent line
+    }
+  }
+  throw new Error(
+    `No JSON probe result found in stdout:\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+  );
+}
+
+describe('AgentCore lazy loading (theme-04 W2-D-FIX, F04-04 / F04-05)', () => {
+  it('AGENTCORE_ENABLED=false: ContainerAgentService construction loads NO AgentCore modules', () => {
+    const result = runProbe({ agentcoreEnabled: false, setAgentCoreProvider: false });
+
+    // Sanity
+    expect(result.agentcoreEnabled).toBe(false);
+    expect(result.serviceConstructed).toBe(true);
+
+    // The whole point of the fix: zero AgentCore code in the loaded graph.
+    expect(result.bridgeService).toBe(false);
+    expect(result.bridgeLib).toBe(false);
+    expect(result.sandboxProvider).toBe(false);
+    expect(result.sandboxInstance).toBe(false);
+  });
+
+  it('AGENTCORE_ENABLED=false + setAgentCoreProvider call: still NO AgentCore modules (gate blocks load)', () => {
+    const result = runProbe({ agentcoreEnabled: false, setAgentCoreProvider: true });
+
+    expect(result.agentcoreEnabled).toBe(false);
+    expect(result.serviceConstructed).toBe(true);
+
+    // setAgentCoreProvider short-circuits when the flag is off, so the
+    // dynamic imports for both the provider and the bridge service never
+    // execute — none of the AgentCore graph is reachable.
+    expect(result.bridgeService).toBe(false);
+    expect(result.bridgeLib).toBe(false);
+    expect(result.sandboxProvider).toBe(false);
+    expect(result.sandboxInstance).toBe(false);
+  });
+
+  it('AGENTCORE_ENABLED=true + setAgentCoreProvider call: ALL AgentCore modules load', () => {
+    const result = runProbe({ agentcoreEnabled: true, setAgentCoreProvider: true });
+
+    expect(result.agentcoreEnabled).toBe(true);
+    expect(result.serviceConstructed).toBe(true);
+
+    // Provider load is the entry that drags in the SigV4 signer
+    // (agentcore-sandbox-instance.ts) and the AWS SDK.
+    expect(result.sandboxProvider).toBe(true);
+    expect(result.sandboxInstance).toBe(true);
+
+    // Bridge service load was triggered by setAgentCoreProvider via
+    // loadAgentCoreBridge().
+    expect(result.bridgeService).toBe(true);
+    // bridge-lib (lib/agents/agentcore-bridge.ts) is a runtime dependency of
+    // the bridge service.
+    expect(result.bridgeLib).toBe(true);
+  });
+
+  it('AGENTCORE_ENABLED=true (no setAgentCoreProvider): bridge & provider stay UNLOADED until needed', () => {
+    // Even with the flag on, simply constructing ContainerAgentService should
+    // not trigger any AgentCore module load. The lazy contract is: load only
+    // when setAgentCoreProvider() (or a startAgent path) actually needs it.
+    const result = runProbe({ agentcoreEnabled: true, setAgentCoreProvider: false });
+
+    expect(result.agentcoreEnabled).toBe(true);
+    expect(result.serviceConstructed).toBe(true);
+
+    expect(result.bridgeService).toBe(false);
+    expect(result.bridgeLib).toBe(false);
+    expect(result.sandboxProvider).toBe(false);
+    expect(result.sandboxInstance).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PR #202 (W2-D) deleted AgentCore as 'dead code', but the user has confirmed AgentCore IS in active service. The deletion was reverted via PR #203. The original review findings F04-04 and F04-05 still apply — but the fix is to **make the gate actually work**, NOT delete the code.

This PR makes `AGENTCORE_ENABLED=false` (the default) actually skip loading the AgentCore module graph at runtime. Uses **lazy / dynamic imports** so the SigV4 signer + bridge service code only loads when the flag is true. **No AgentCore files are deleted.**

## Findings addressed

- **F04-04 (P1)** — `AgentCoreBridgeService` (~561 LOC) was statically imported and instantiated regardless of the flag. Now it's a type-only import at the static level; the runtime module is loaded inside `loadAgentCoreBridge()`, gated on `AGENTCORE_ENABLED=true`.
- **F04-05 (P1)** — The hand-rolled SigV4 signer in `agentcore-sandbox-instance.ts` (~110 LOC of crypto) is loaded only when the AgentCore provider is configured. With the flag off, it never enters the runtime module graph.

## What changed

### `src/services/container-agent/container-agent.service.ts`

- `AgentCoreBridgeService` import switched to `import type` — runtime module is loaded via dynamic `import()` inside `loadAgentCoreBridge()`, gated on `AGENTCORE_ENABLED=true`.
- `agentCoreBridge` field is now `?: AgentCoreBridgeService` — undefined until the gate opens.
- New `loadAgentCoreBridge()` method: idempotent, returns `undefined` and logs when the gate is off, otherwise dynamically imports the bridge module and caches the constructed instance.
- `setAgentCoreProvider()` now calls `loadAgentCoreBridge()` after constructing the provider, so both modules enter the graph together (or, with the flag off, neither does).
- `startAgent` / `stopAgent` defensively re-check the gate; if a caller manually populated the provider while the flag is off they get a clear `AGENT_START_FAILED` / `AGENT_STOP_FAILED` instead of a silent fall-through.

### New test: `tests/integration/agentcore-lazy-load.test.ts`

Spawns a Bun child process with a `--preload` plugin that injects a `globalThis['__loaded_<module>'] = true` sentinel into each AgentCore module. The probe imports `ContainerAgentService`, optionally calls `setAgentCoreProvider()`, then prints which sentinels fired.

Verifies all four scenarios:

| AGENTCORE_ENABLED | setAgentCoreProvider | bridgeService | bridgeLib | sandboxProvider | sandboxInstance |
|---|---|---|---|---|---|
| false | false | NOT loaded | NOT loaded | NOT loaded | NOT loaded |
| false | true (gate blocks) | NOT loaded | NOT loaded | NOT loaded | NOT loaded |
| true | false (still lazy) | NOT loaded | NOT loaded | NOT loaded | NOT loaded |
| true | true | LOADED | LOADED | LOADED | LOADED |

## What did NOT change

- **No AgentCore files deleted.** The user has confirmed AgentCore is in active service.
- **No new infrastructure.** No `await import()` polyfills, no module-replacement libs.
- All 117 existing AgentCore-related tests still pass:
  - `tests/integration/agentcore-bridge-service.test.ts` (the bridge service unit/integration tests)
  - `src/lib/sandbox/providers/__tests__/agentcore-sandbox-provider.test.ts`
  - `src/lib/sandbox/providers/__tests__/agentcore-sandbox-instance.test.ts`
  - `src/lib/agents/__tests__/agentcore-bridge.test.ts`
  - `src/services/__tests__/container-agent.service.test.ts`
  - `tests/integration/bootstrap-container-agent-reconcile.test.ts`

## Test plan

- [x] `npx vitest run` for all AgentCore-related tests (117 + 4 new = 121 cases, 7 files): all passing
- [x] `npx tsc --noEmit`: clean
- [x] `npx @biomejs/biome check`: clean
- [x] New lazy-load test exercises both `AGENTCORE_ENABLED=true` and `=false` paths
- [x] Existing `setAgentCoreProvider` semantics preserved (test sets the env var)
- [x] Provider name still resolves correctly for both code paths
- [x] `dispose()` still cleans up AgentCore resources when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
