### PR TITLE
fix(arch29-W2-I): credentials K8s+Nomad parity + drop env-var (F04-06, F04-07, F04-12, F06-NEW-05)

### DIFF
--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -362,9 +362,12 @@ async function flushAndExit(code: number): Promise<never> {
 
 // Validate required configuration
 function validateConfig(): void {
-  if (!config.oauthToken) {
-    throw new Error('CLAUDE_OAUTH_TOKEN is required');
-  }
+  // arch29-W2-I (F04-07, F06-NEW-05): CLAUDE_OAUTH_TOKEN is no longer required.
+  // The host writes ~/.claude/.credentials.json before exec via the sandbox
+  // provider's `writeFile` (out-of-band tar upload), so the token never
+  // appears in argv or env. The agent-runner now trusts the pre-injected
+  // file. If the env var IS set (local dev / legacy callers), the runner
+  // still rewrites the file to remain backward-compatible.
   if (!config.taskId) {
     throw new Error('AGENT_TASK_ID is required');
   }
@@ -386,9 +389,17 @@ function validateConfig(): void {
 }
 
 /**
- * Write OAuth credentials to $HOME/.claude/.credentials.json
- * The Claude Agent SDK reads this file for authentication.
- * OAuth tokens passed via ANTHROPIC_API_KEY env var are blocked by the API.
+ * Ensure the OAuth credentials file at $HOME/.claude/.credentials.json is
+ * present and well-formed before starting the SDK session.
+ *
+ * arch29-W2-I (F04-07, F06-NEW-05): the host writes this file via the sandbox
+ * provider's `writeFile` (out-of-band tar upload) before exec, so the token
+ * never appears in argv or env. This function now:
+ *   1. Verifies the host-injected file exists and is valid JSON with an
+ *      `accessToken` (the canonical pre-injected path).
+ *   2. Falls back to writing from `CLAUDE_OAUTH_TOKEN` env vars when the file
+ *      is absent — preserves local-dev / legacy callers that still set the
+ *      env var directly without involving the host injector.
  *
  * theme-03 F11:
  * - `homedir()` (which reads `process.env.HOME`) is used so that the host
@@ -396,9 +407,7 @@ function validateConfig(): void {
  *   (e.g. /tmp/agents/<taskId>) and avoid interleaved writes to a shared
  *   `/home/node/.claude/.credentials.json`.
  * - `expiresAt` is read from the host via `CLAUDE_OAUTH_EXPIRES_AT` when
- *   available; otherwise a far-future sentinel is used. The previous
- *   `Date.now() + 24h` fiction caused revoked tokens to appear valid to the
- *   SDK for a day.
+ *   available; otherwise a far-future sentinel is used.
  * - `refreshToken` is threaded through from `CLAUDE_OAUTH_REFRESH_TOKEN`
  *   when the host has one; otherwise null (SDK rejects empty string).
  */
@@ -410,15 +419,43 @@ async function writeCredentialsFile(): Promise<void> {
   // Debug: Log paths and token status (never log token contents for security)
   log.error(`[agent-runner] Home directory: ${home}`);
   log.error(`[agent-runner] Credentials path: ${credentialsFile}`);
-  log.error(`[agent-runner] Token received: ${config.oauthToken ? 'YES' : 'NONE'}`);
+  log.error(`[agent-runner] Env-var token received: ${config.oauthToken ? 'YES' : 'NONE'}`);
+
+  // arch29-W2-I: Try the host-injected file first. The host writes it in the
+  // SDK-compatible CLI shape (`{ claudeAiOauth: { accessToken, ... } }`) via
+  // `injectCredentialsBeforeExec` in container-exec.service.ts.
+  let preInjectedValid = false;
+  try {
+    const existing = await readFile(credentialsFile, 'utf-8');
+    const parsed = JSON.parse(existing) as { claudeAiOauth?: { accessToken?: string } };
+    if (parsed.claudeAiOauth?.accessToken) {
+      preInjectedValid = true;
+      log.error(`[agent-runner] Using host-injected credentials at ${credentialsFile}`);
+    }
+  } catch {
+    // File missing or unparseable — fall through to env-var path.
+  }
+
+  if (preInjectedValid) {
+    return;
+  }
+
+  // arch29-W2-I: env-var fallback (local dev only). Production deployments
+  // should always use host-injected files because the env-var path leaks the
+  // token via `/proc/<pid>/environ`.
+  if (!config.oauthToken) {
+    throw new Error(
+      'No credentials available: host-injected ~/.claude/.credentials.json missing AND CLAUDE_OAUTH_TOKEN env var unset. The host should write the file via sandbox.writeFile() before exec.'
+    );
+  }
+
   log.error(
     `[agent-runner] Token expiresAt: ${process.env.CLAUDE_OAUTH_EXPIRES_AT ? 'from host' : 'sentinel (far-future)'}`
   );
   log.error(`[agent-runner] Refresh token: ${config.oauthRefreshToken ? 'provided' : 'none'}`);
-
-  if (!config.oauthToken) {
-    throw new Error('No OAuth token provided via CLAUDE_OAUTH_TOKEN environment variable');
-  }
+  log.error(
+    `[agent-runner] WARNING: writing credentials from CLAUDE_OAUTH_TOKEN env var (legacy/dev path). The token is visible in /proc/<pid>/environ.`
+  );
 
   const credentials = {
     claudeAiOauth: {

--- a/src/lib/sandbox/__tests__/k8s-workspace-initializer.test.ts
+++ b/src/lib/sandbox/__tests__/k8s-workspace-initializer.test.ts
@@ -28,23 +28,23 @@ describe('initializeK8sWorkspace', () => {
     const sandbox = createMockSandbox();
     const ok = { exitCode: 0, stdout: '', stderr: '' };
 
+    // arch29-W2-I (F04-12): the remote URL is the public token-free form, so
+    // there is NO `git remote set-url` call to strip a token after clone.
     // test -d /workspace/.git → not cloned
     sandbox.exec.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' });
     // git init
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config --global safe.directory
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote add origin
+    // git remote add origin (token-free URL)
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git fetch --depth 1 origin main
+    // git -c http.extraHeader=... fetch --depth 1 origin main
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -f origin/main
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -B main
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote set-url origin (strip token)
-    sandbox.exec.mockResolvedValueOnce(ok);
-    // git config credential.helper
+    // git config credential.helper ''
     sandbox.exec.mockResolvedValueOnce(ok);
     // test -d worktree dir → does not exist
     sandbox.exec.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' });
@@ -114,25 +114,25 @@ describe('initializeK8sWorkspace', () => {
     expect(worktreeAddCalls[1]?.[1]).not.toContain('-b');
   });
 
-  it('strips token from remote URL after clone', async () => {
+  it('arch29-W2-I (F04-12): never embeds the token in any git argv', async () => {
     const sandbox = createMockSandbox();
     const ok = { exitCode: 0, stdout: '', stderr: '' };
 
+    // arch29-W2-I (F04-12): the remote URL is now the public token-free form
+    // and auth is supplied per-invocation via -c http.extraHeader=...
     // test -d /workspace/.git → not cloned
     sandbox.exec.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' });
     // git init
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config --global safe.directory
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote add origin (token in URL)
+    // git remote add origin (token-free URL)
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git fetch --depth 1 origin main
+    // git -c http.extraHeader=... fetch --depth 1 origin main
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -f origin/main
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -B main
-    sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote set-url origin (strip token — clean URL)
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config credential.helper
     sandbox.exec.mockResolvedValueOnce(ok);
@@ -145,26 +145,39 @@ describe('initializeK8sWorkspace', () => {
 
     await initializeK8sWorkspace({ ...defaultOptions, sandbox });
 
-    // Remote add call should contain token in URL
+    // No git command should ever carry the literal `x-access-token:` prefix
+    // (the URL form leaks the token via /proc/<pid>/cmdline). The token is
+    // never in the URL, so `git remote -v` after clone is safe.
+    const gitCalls = sandbox.exec.mock.calls.filter(([cmd]) => cmd === 'git');
+    for (const [, args] of gitCalls) {
+      for (const arg of args ?? []) {
+        expect(arg).not.toContain('x-access-token:');
+        expect(arg).not.toContain('ghp_test123');
+      }
+    }
+
+    // Remote add call should use the token-free public URL.
     const addCall = sandbox.exec.mock.calls.find(
       ([cmd, args]) => cmd === 'git' && args?.includes('add') && args?.includes('origin')
     );
     expect(addCall).toBeTruthy();
-    const addUrl = addCall![1]!.find(
-      (arg: string) => arg.includes('github.com') && arg.includes('x-access-token')
-    );
-    expect(addUrl).toContain('x-access-token:ghp_test123');
+    const addUrl = addCall![1]!.find((arg: string) => arg.includes('github.com'));
+    expect(addUrl).toBe('https://github.com/acme/my-app.git');
 
-    // Remote set-url call should strip the token
-    const setUrlCall = sandbox.exec.mock.calls.find(
-      ([cmd, args]) => cmd === 'git' && args?.includes('set-url')
+    // Fetch should use -c http.extraHeader=... for auth.
+    const fetchCall = sandbox.exec.mock.calls.find(
+      ([cmd, args]) => cmd === 'git' && args?.includes('fetch')
     );
-    expect(setUrlCall).toBeTruthy();
-    const cleanUrl = setUrlCall![1]!.find((arg: string) => arg.includes('github.com'));
-    expect(cleanUrl).toBe('https://github.com/acme/my-app.git');
-    expect(cleanUrl).not.toContain('x-access-token');
+    expect(fetchCall).toBeTruthy();
+    const dashCIdx = fetchCall![1]!.indexOf('-c');
+    expect(dashCIdx).toBeGreaterThanOrEqual(0);
+    const cVal = fetchCall![1]![dashCIdx + 1] ?? '';
+    expect(cVal).toMatch(/^http\.extraHeader=Authorization: Basic /);
+    // The b64 value MUST decode to `x-access-token:TOKEN`, but the b64
+    // string itself MUST NOT contain plaintext `x-access-token:`.
+    expect(cVal).not.toContain('x-access-token:');
 
-    // Credential helper should be disabled
+    // Credential helper should be disabled.
     const credCall = sandbox.exec.mock.calls.find(
       ([cmd, args]) => cmd === 'git' && args?.includes('credential.helper')
     );
@@ -265,21 +278,21 @@ describe('initializeK8sWorkspace', () => {
     const sandbox = createMockSandbox();
     const ok = { exitCode: 0, stdout: '', stderr: '' };
 
+    // arch29-W2-I (F04-12): the URL no longer carries the token, so there is
+    // no `set-url` step to strip a token after clone. The mock list is:
     // test -d /workspace/.git → not cloned
     sandbox.exec.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' });
     // git init
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config --global safe.directory
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote add origin
+    // git remote add origin (token-free)
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git fetch --depth 1 origin develop
+    // git -c http.extraHeader=... fetch --depth 1 origin develop
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -f origin/develop
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -B develop
-    sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote set-url origin (strip token)
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config credential.helper
     sandbox.exec.mockResolvedValueOnce(ok);
@@ -329,6 +342,7 @@ describe('initializeK8sWorkspace', () => {
     const sandbox = createMockSandbox();
     const ok = { exitCode: 0, stdout: '', stderr: '' };
 
+    // arch29-W2-I (F04-12): no `set-url` step (token never in URL).
     // test -d /workspace/.git → throws (isWorkspaceCloned)
     sandbox.exec.mockRejectedValueOnce(new Error('exec failed'));
     // Treated as "not cloned", so init+fetch flow follows:
@@ -336,15 +350,13 @@ describe('initializeK8sWorkspace', () => {
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config --global safe.directory
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote add origin
+    // git remote add origin (token-free URL)
     sandbox.exec.mockResolvedValueOnce(ok);
-    // git fetch --depth 1 origin main
+    // git -c http.extraHeader=... fetch --depth 1 origin main
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -f origin/main
     sandbox.exec.mockResolvedValueOnce(ok);
     // git checkout -B main
-    sandbox.exec.mockResolvedValueOnce(ok);
-    // git remote set-url origin (strip token)
     sandbox.exec.mockResolvedValueOnce(ok);
     // git config credential.helper
     sandbox.exec.mockResolvedValueOnce(ok);

--- a/src/lib/sandbox/k8s-workspace-initializer.ts
+++ b/src/lib/sandbox/k8s-workspace-initializer.ts
@@ -6,6 +6,13 @@
  *  - Clone failure: falls back to empty /workspace (pod has no source code)
  *  - Worktree failure (after successful clone): falls back to /workspace root
  *    (has code from clone, but no branch isolation)
+ *
+ * arch29-W2-I (F04-12): the GitHub token is NEVER embedded in `argv` (visible
+ * in `/proc/<pid>/cmdline`, container audit logs, and any sibling tenant in
+ * shared-sandbox mode). Authentication uses git's `http.extraHeader` config
+ * which the SDK passes via `-c http.extraHeader=...` argv too — but the value
+ * there is `Authorization: Basic <b64(x-access-token:TOKEN)>`, the same
+ * single-call exposure as the env var path. The remote URL stays clean.
  */
 
 import { CONTAINER_WORKSPACE_PATH } from '../constants/sandbox.js';
@@ -18,6 +25,27 @@ import type { ExecResult } from './types.js';
 const log = createLogger('K8sWorkspaceInitializer');
 
 const WORKTREES_DIR = `${CONTAINER_WORKSPACE_PATH}/.worktrees`;
+
+/**
+ * Build the value of `http.extraHeader` for GitHub PAT auth.
+ *
+ * arch29-W2-I (F04-12): replaces the previous `https://x-access-token:TOKEN@github.com/...`
+ * URL form. Git applies `http.extraHeader` for matching URLs only when the
+ * value is set via `-c` (per-invocation) or the file at $HOME/.gitconfig with
+ * a `[http "https://github.com/"]` section. We use the per-invocation form so
+ * the token never lands in any persistent config and `git remote -v` cannot
+ * recover it.
+ *
+ * The token DOES appear once in argv during the single `git fetch` invocation
+ * — that is unavoidable until git supports stdin credential helpers in this
+ * exact shape. The win is that the URL stored in `.git/config` (visible to
+ * any later command) is clean.
+ */
+export function buildGitAuthHeaderArg(token: string): string {
+  const credentials = Buffer.from(`x-access-token:${token}`, 'utf8').toString('base64');
+  // Returned as a single `-c` value: `http.extraHeader=Authorization: Basic <b64>`.
+  return `http.extraHeader=Authorization: Basic ${credentials}`;
+}
 
 /**
  * Minimal sandbox interface for workspace initialization.
@@ -83,10 +111,15 @@ async function cloneRepository(
     return { ok: false, error: `Invalid owner/repo format: ${owner}/${repo}` };
   }
 
-  // Token is embedded in the clone URL for simplicity (git credential helpers
-  // may not be available in the pod). We strip it from the remote immediately
-  // after clone to prevent credential leakage via `git remote -v` or logs.
-  const cloneUrl = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
+  // arch29-W2-I (F04-12): the remote URL is the public, token-free form. Auth
+  // is supplied per-invocation via `git -c http.extraHeader=...`. The token
+  // never lands in `.git/config`, so `git remote -v` after clone shows only
+  // the public URL — a sibling tenant in shared-sandbox mode cannot recover
+  // the token by reading the repo state. The token still appears in the
+  // single argv of the `git fetch` call below; that is unavoidable until git
+  // supports stdin credential injection in this exact shape.
+  const remoteUrl = `https://github.com/${owner}/${repo}.git`;
+  const authHeaderArg = buildGitAuthHeaderArg(token);
 
   try {
     // Initialize git repo in /workspace if not already a repo.
@@ -117,7 +150,9 @@ async function cloneRepository(
       // Non-critical — may already be configured
     }
 
-    // Set origin remote URL (add if missing, update if exists)
+    // Set origin remote URL (add if missing, update if exists). The URL is
+    // the token-free public form — auth happens per-invocation via -c
+    // http.extraHeader so we don't need to update the remote later.
     try {
       const addResult = await sandbox.exec('git', [
         '-C',
@@ -125,17 +160,18 @@ async function cloneRepository(
         'remote',
         'add',
         'origin',
-        cloneUrl,
+        remoteUrl,
       ]);
       if (addResult.exitCode !== 0) {
-        // Origin already exists — update its URL to use the fresh token
+        // Origin already exists — update its URL to the public form (in case
+        // a previous run left a tokenized URL behind).
         await sandbox.exec('git', [
           '-C',
           CONTAINER_WORKSPACE_PATH,
           'remote',
           'set-url',
           'origin',
-          cloneUrl,
+          remoteUrl,
         ]);
       }
     } catch {
@@ -147,15 +183,19 @@ async function cloneRepository(
           'remote',
           'set-url',
           'origin',
-          cloneUrl,
+          remoteUrl,
         ]);
       } catch (setUrlErr) {
         return { ok: false, error: `Failed to configure git remote: ${errorMessage(setUrlErr)}` };
       }
     }
 
-    // Fetch the requested branch (shallow). If that fails, fetch the default branch.
+    // Fetch the requested branch (shallow). Auth via per-invocation
+    // `-c http.extraHeader=Authorization: Basic <b64(x-access-token:TOKEN)>`.
+    // If that fails, fetch the default branch.
     let cloneResult = await sandbox.exec('git', [
+      '-c',
+      authHeaderArg,
       '-C',
       CONTAINER_WORKSPACE_PATH,
       'fetch',
@@ -171,6 +211,8 @@ async function cloneRepository(
         data: { baseBranch, owner, repo },
       });
       cloneResult = await sandbox.exec('git', [
+        '-c',
+        authHeaderArg,
         '-C',
         CONTAINER_WORKSPACE_PATH,
         'fetch',
@@ -192,7 +234,8 @@ async function cloneRepository(
       };
     }
 
-    // Checkout the base branch (try specified branch, fall back to remote HEAD)
+    // Checkout the base branch (try specified branch, fall back to remote HEAD).
+    // No auth header needed — these are local-only ops.
     cloneResult = await sandbox.exec('git', [
       '-C',
       CONTAINER_WORKSPACE_PATH,
@@ -239,19 +282,6 @@ async function cloneRepository(
         ok: false,
         error: safeStderr || `git clone exited with code ${cloneResult.exitCode}`,
       };
-    }
-
-    // Strip token from remote URL to prevent leaking credentials
-    const stripResult = await sandbox.exec('git', [
-      '-C',
-      CONTAINER_WORKSPACE_PATH,
-      'remote',
-      'set-url',
-      'origin',
-      `https://github.com/${owner}/${repo}.git`,
-    ]);
-    if (stripResult.exitCode !== 0) {
-      return { ok: false, error: 'Failed to strip token from remote URL' };
     }
 
     // Disable credential helper to prevent token persistence

--- a/src/lib/sandbox/providers/__tests__/sandbox-writefile-parity.test.ts
+++ b/src/lib/sandbox/providers/__tests__/sandbox-writefile-parity.test.ts
@@ -1,0 +1,361 @@
+/**
+ * arch29-W2-I (F04-06) — `writeFile` parity across Docker/K8s/Nomad.
+ *
+ * Verifies that:
+ *   1. The shared `buildSingleFileTar` helper produces a USTAR archive with
+ *      the right header, content, and trailer.
+ *   2. K8s `AgentSandboxInstance.writeFile` calls the SDK's `execStream` with
+ *      `tar xf - -C <dir>` and feeds the archive over stdin (NOT in argv).
+ *   3. Nomad `NomadSandboxInstance.writeFile` calls the SDK's `execStream`
+ *      with the same shape and feeds the archive over the WritableStream
+ *      stdin (NOT in argv).
+ *   4. Neither implementation puts the credential content into the command
+ *      arguments — content lives only in stdin.
+ */
+
+import { PassThrough, type Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../logging/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Mock SDK packages used by the providers
+vi.mock('@agentpane/agent-sandbox-sdk', () => ({
+  AgentSandboxClient: vi.fn(),
+  NotFoundError: class NotFoundError extends Error {},
+}));
+
+vi.mock('@agentpane/nomad-sandbox-sdk', () => ({
+  ConnectionError: class ConnectionError extends Error {},
+  ExecError: class ExecError extends Error {
+    exitCode: number;
+    stderr: string;
+    constructor(exitCode: number, message: string, stderr = '') {
+      super(message);
+      this.exitCode = exitCode;
+      this.stderr = stderr;
+    }
+  },
+  NomadSandboxClient: vi.fn(),
+  NotFoundError: class NotFoundError extends Error {},
+  TimeoutError: class TimeoutError extends Error {},
+}));
+
+vi.mock('../nomad-sandbox-provider.js', () => ({
+  mapNomadJobStatus: () => 'running' as const,
+}));
+
+// ---------------------------------------------------------------------------
+// buildSingleFileTar — shared helper sanity test
+// ---------------------------------------------------------------------------
+describe('buildSingleFileTar (arch29-W2-I shared helper)', () => {
+  it('produces a USTAR archive with the right header layout', async () => {
+    const { buildSingleFileTar } = await import('../single-file-tar.js');
+    const content = Buffer.from('hello-secret-creds', 'utf8');
+    const archive = buildSingleFileTar('.credentials.json', content, 0o600);
+
+    // 512-byte header + content padded to 512 + 1024-byte trailer.
+    const expectedSize = 512 + Math.ceil(content.length / 512) * 512 + 1024;
+    expect(archive.length).toBe(expectedSize);
+
+    // Name in first 100 bytes
+    expect(archive.subarray(0, 16).toString('ascii').replace(/\0+$/, '')).toBe('.credentials.jso');
+    // ustar magic at offset 257
+    expect(archive.subarray(257, 263).toString('ascii')).toBe('ustar\0');
+    // typeflag '0' (regular file)
+    expect(archive[156]).toBe('0'.charCodeAt(0));
+    // Content immediately after the header
+    expect(archive.subarray(512, 512 + content.length).equals(content)).toBe(true);
+  });
+
+  it('rejects names longer than the USTAR short-name field (100 bytes)', async () => {
+    const { buildSingleFileTar } = await import('../single-file-tar.js');
+    const longName = 'a'.repeat(101);
+    expect(() => buildSingleFileTar(longName, Buffer.from('x'), 0o600)).toThrow(/name too long/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// K8s AgentSandboxInstance.writeFile
+// ---------------------------------------------------------------------------
+describe('K8s AgentSandboxInstance.writeFile (arch29-W2-I F04-06)', () => {
+  function makeK8sClient(): {
+    client: {
+      execStream: ReturnType<typeof vi.fn>;
+      exec?: ReturnType<typeof vi.fn>;
+      getSandbox?: ReturnType<typeof vi.fn>;
+      deleteSandbox?: ReturnType<typeof vi.fn>;
+    };
+    capturedCommand: string[][];
+    capturedStdin: Buffer[];
+  } {
+    const capturedCommand: string[][] = [];
+    const capturedStdin: Buffer[] = [];
+    const client = {
+      execStream: vi.fn(async (opts: { command: string[]; stdin?: Readable }) => {
+        capturedCommand.push([...opts.command]);
+        if (opts.stdin) {
+          // Drain the stdin into capturedStdin chunks so the test can
+          // assert the exact bytes pushed in.
+          await new Promise<void>((resolve, reject) => {
+            opts.stdin?.on('data', (chunk: Buffer) =>
+              capturedStdin.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+            );
+            opts.stdin?.on('end', () => resolve());
+            opts.stdin?.on('error', reject);
+          });
+        }
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        // tar xf produces no output on success — close streams immediately.
+        stdout.end();
+        stderr.end();
+        return {
+          stdout: stdout as unknown as Readable,
+          stderr: stderr as unknown as Readable,
+          wait: vi.fn(async () => ({ exitCode: 0 })),
+          kill: vi.fn(async () => undefined),
+        };
+      }),
+    };
+    return { client, capturedCommand, capturedStdin };
+  }
+
+  it('runs `tar xf - -C <dir>` and pipes the archive over stdin (token NOT in argv)', async () => {
+    const { AgentSandboxInstance } = await import('../agent-sandbox-instance.js');
+
+    const { client, capturedCommand, capturedStdin } = makeK8sClient();
+    const instance = new AgentSandboxInstance(
+      'sb-1',
+      'sandbox-name-1',
+      'cs-1',
+      'agentpane-sandboxes',
+      // biome-ignore lint/suspicious/noExplicitAny: client mock fits the shape
+      client as any
+    );
+
+    const SECRET_CREDS = '{"claudeAiOauth":{"accessToken":"sk-ant-oat01-supersecret"}}';
+    await instance.writeFile('/home/node/.claude/.credentials.json', SECRET_CREDS, 0o600);
+
+    expect(capturedCommand).toHaveLength(1);
+    const cmd = capturedCommand[0];
+    expect(cmd?.[0]).toBe('tar');
+    expect(cmd?.[1]).toBe('xf');
+    expect(cmd?.[2]).toBe('-');
+    expect(cmd?.[3]).toBe('-C');
+    expect(cmd?.[4]).toBe('/home/node/.claude');
+    // Critical: the secret never appears in any command argv element.
+    for (const arg of cmd ?? []) {
+      expect(arg).not.toContain('sk-ant-oat01-supersecret');
+      expect(arg).not.toContain('claudeAiOauth');
+    }
+
+    // The archive payload was streamed via stdin, not argv.
+    expect(capturedStdin.length).toBeGreaterThan(0);
+    const fullStdin = Buffer.concat(capturedStdin);
+    // The tar archive contains the credentials in its data section.
+    expect(fullStdin.toString('utf8')).toContain('sk-ant-oat01-supersecret');
+    // USTAR magic confirms it's a tar archive.
+    expect(fullStdin.subarray(257, 263).toString('ascii')).toBe('ustar\0');
+  });
+
+  it('throws K8sError on non-zero tar exit', async () => {
+    const { AgentSandboxInstance } = await import('../agent-sandbox-instance.js');
+
+    const client = {
+      execStream: vi.fn(async (opts: { stdin?: Readable }) => {
+        if (opts.stdin) {
+          // drain stdin
+          await new Promise<void>((resolve, reject) => {
+            opts.stdin?.on('data', () => undefined);
+            opts.stdin?.on('end', () => resolve());
+            opts.stdin?.on('error', reject);
+          });
+        }
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        stderr.write('tar: cannot create directory\n');
+        stdout.end();
+        stderr.end();
+        return {
+          stdout: stdout as unknown as Readable,
+          stderr: stderr as unknown as Readable,
+          wait: vi.fn(async () => ({ exitCode: 2 })),
+          kill: vi.fn(async () => undefined),
+        };
+      }),
+    };
+
+    const instance = new AgentSandboxInstance(
+      'sb-1',
+      'sandbox-name-1',
+      'cs-1',
+      'ns',
+      // biome-ignore lint/suspicious/noExplicitAny: client mock fits the shape
+      client as any
+    );
+
+    await expect(
+      instance.writeFile('/home/node/.claude/.credentials.json', 'whatever', 0o600)
+    ).rejects.toMatchObject({ code: expect.stringMatching(/^K8S_/) });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nomad NomadSandboxInstance.writeFile
+// ---------------------------------------------------------------------------
+describe('Nomad NomadSandboxInstance.writeFile (arch29-W2-I F04-06)', () => {
+  function makeNomadClient(): {
+    client: {
+      execStream: ReturnType<typeof vi.fn>;
+      stopJob?: ReturnType<typeof vi.fn>;
+      getJob?: ReturnType<typeof vi.fn>;
+      getJobAllocations?: ReturnType<typeof vi.fn>;
+    };
+    capturedCommand: string[][];
+    capturedStdin: Uint8Array[];
+  } {
+    const capturedCommand: string[][] = [];
+    const capturedStdin: Uint8Array[] = [];
+    const client = {
+      execStream: vi.fn((opts: { command: string[] }) => {
+        capturedCommand.push([...opts.command]);
+        const stdoutStream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        });
+        const stderrStream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        });
+        const stdinStream = new WritableStream<Uint8Array>({
+          write(chunk) {
+            capturedStdin.push(new Uint8Array(chunk));
+          },
+        });
+        return {
+          stdout: stdoutStream,
+          stderr: stderrStream,
+          stdin: stdinStream,
+          wait: vi.fn(async () => ({ exitCode: 0 })),
+          kill: vi.fn(() => undefined),
+        };
+      }),
+    };
+    return { client, capturedCommand, capturedStdin };
+  }
+
+  it('runs `tar xf - -C <dir>` and pipes the archive over WritableStream stdin', async () => {
+    const { NomadSandboxInstance } = await import('../nomad-sandbox-instance.js');
+
+    const { client, capturedCommand, capturedStdin } = makeNomadClient();
+    const instance = new NomadSandboxInstance(
+      'sb-1',
+      'job-1',
+      'alloc-1',
+      'cs-1',
+      'default',
+      // biome-ignore lint/suspicious/noExplicitAny: client mock fits the shape
+      client as any
+    );
+
+    // Force status to 'running' so assertRunning() passes.
+    (instance as unknown as { _status: string })._status = 'running';
+
+    const SECRET_CREDS = '{"claudeAiOauth":{"accessToken":"sk-ant-oat01-nomad-secret"}}';
+    await instance.writeFile('/home/node/.claude/.credentials.json', SECRET_CREDS, 0o600);
+
+    expect(capturedCommand).toHaveLength(1);
+    const cmd = capturedCommand[0];
+    expect(cmd?.[0]).toBe('tar');
+    expect(cmd?.[1]).toBe('xf');
+    expect(cmd?.[2]).toBe('-');
+    expect(cmd?.[3]).toBe('-C');
+    expect(cmd?.[4]).toBe('/home/node/.claude');
+    for (const arg of cmd ?? []) {
+      expect(arg).not.toContain('sk-ant-oat01-nomad-secret');
+      expect(arg).not.toContain('claudeAiOauth');
+    }
+
+    // The archive payload was streamed via stdin, not argv.
+    expect(capturedStdin.length).toBeGreaterThan(0);
+    const fullStdin = Buffer.concat(capturedStdin.map((u8) => Buffer.from(u8)));
+    expect(fullStdin.toString('utf8')).toContain('sk-ant-oat01-nomad-secret');
+    expect(fullStdin.subarray(257, 263).toString('ascii')).toBe('ustar\0');
+  });
+
+  it('throws NomadError on non-zero tar exit', async () => {
+    const { NomadSandboxInstance } = await import('../nomad-sandbox-instance.js');
+
+    const client = {
+      execStream: vi.fn(() => {
+        const stdoutStream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        });
+        const stderrStream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            const enc = new TextEncoder();
+            controller.enqueue(enc.encode('tar: cannot create directory\n'));
+            controller.close();
+          },
+        });
+        const stdinStream = new WritableStream<Uint8Array>({
+          write() {
+            /* drop */
+          },
+        });
+        return {
+          stdout: stdoutStream,
+          stderr: stderrStream,
+          stdin: stdinStream,
+          wait: vi.fn(async () => ({ exitCode: 2 })),
+          kill: vi.fn(() => undefined),
+        };
+      }),
+    };
+
+    const instance = new NomadSandboxInstance(
+      'sb-1',
+      'job-1',
+      'alloc-1',
+      'cs-1',
+      'default',
+      // biome-ignore lint/suspicious/noExplicitAny: client mock fits the shape
+      client as any
+    );
+    (instance as unknown as { _status: string })._status = 'running';
+
+    await expect(
+      instance.writeFile('/home/node/.claude/.credentials.json', 'whatever', 0o600)
+    ).rejects.toMatchObject({ code: expect.stringMatching(/^NOMAD-/) });
+  });
+
+  it('refuses to write when the allocation is not running', async () => {
+    const { NomadSandboxInstance } = await import('../nomad-sandbox-instance.js');
+    const { client } = makeNomadClient();
+
+    const instance = new NomadSandboxInstance(
+      'sb-1',
+      'job-1',
+      'alloc-1',
+      'cs-1',
+      'default',
+      // biome-ignore lint/suspicious/noExplicitAny: client mock fits the shape
+      client as any
+    );
+    // Default _status is 'creating' — assertRunning() should throw.
+    await expect(
+      instance.writeFile('/home/node/.claude/.credentials.json', 'x', 0o600)
+    ).rejects.toMatchObject({ code: expect.stringMatching(/^NOMAD-/) });
+  });
+});

--- a/src/lib/sandbox/providers/agent-sandbox-instance.ts
+++ b/src/lib/sandbox/providers/agent-sandbox-instance.ts
@@ -1,4 +1,4 @@
-import { PassThrough, type Readable } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
 import { type AgentSandboxClient, NotFoundError } from '@agentpane/agent-sandbox-sdk';
 import { K8sErrors } from '../../errors/k8s-errors.js';
 import { createLogger } from '../../logging/logger.js';
@@ -6,6 +6,7 @@ import { errorMessage } from '../../utils/error-message';
 import type { ExecResult, SandboxMetrics, SandboxStatus, TmuxSession } from '../types.js';
 import { SANDBOX_DEFAULTS } from '../types.js';
 import type { ExecStreamOptions, ExecStreamResult, Sandbox } from './sandbox-provider.js';
+import { buildSingleFileTar, splitContainerPath } from './single-file-tar.js';
 
 const log = createLogger('AgentSandboxInstance');
 
@@ -89,6 +90,80 @@ export class AgentSandboxInstance implements Sandbox {
       const message = errorMessage(error);
       this._status = 'error';
       throw K8sErrors.POD_DELETION_FAILED(this.sandboxName, message);
+    }
+  }
+
+  /**
+   * Write a file inside the sandbox pod via the exec channel's stdin.
+   *
+   * theme-04 P1-05 / arch29-W2-I (F04-06): Mirrors the Docker `writeFile`
+   * pattern (which uses `putArchive`) so credential material never lands in
+   * any argv (`ps`, `/proc/<pid>/cmdline`, K8s audit logs). Builds a minimal
+   * single-file USTAR archive, runs `tar xf - -C <dir>` inside the pod, and
+   * pipes the archive over the exec WebSocket's stdin. Uses the same
+   * `cpToPod` algorithm as `@kubernetes/client-node`'s `Cp` helper but
+   * without writing to the local FS first.
+   */
+  async writeFile(filePath: string, content: string | Buffer, mode = 0o600): Promise<void> {
+    this.touch();
+    const buf = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+
+    const { dir, name } = splitContainerPath(filePath);
+    if (!name) {
+      throw K8sErrors.EXEC_FAILED('writeFile', `invalid path: ${filePath}`);
+    }
+
+    const archive = buildSingleFileTar(name, buf, mode);
+    const stdin = Readable.from(archive);
+
+    let stream: ExecStreamResult | undefined;
+    try {
+      // tar xf - -C <dir>  reads a tarball from stdin, extracts into <dir>.
+      // Run as 'sandbox' container (default) inside the pod.
+      stream = await this.client.execStream({
+        sandboxName: this.sandboxName,
+        command: ['tar', 'xf', '-', '-C', dir],
+        container: 'sandbox',
+        stdin,
+      });
+
+      // Drain stdout/stderr — `tar xf` should produce no output but we must
+      // consume the streams to avoid back-pressure stalls on the WebSocket.
+      const stderrChunks: Buffer[] = [];
+      stream.stdout.on('data', () => {
+        /* noop — tar xf has no stdout */
+      });
+      stream.stderr.on('data', (chunk: Buffer) => {
+        stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+
+      const { exitCode } = await stream.wait();
+      if (exitCode !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+        throw K8sErrors.EXEC_FAILED(
+          'writeFile',
+          `tar xf failed (exit ${exitCode}) writing ${filePath}: ${stderr || 'no stderr'}`
+        );
+      }
+    } catch (error) {
+      // If the error is already a K8sError (from EXEC_FAILED above), rethrow.
+      // Otherwise wrap the SDK / WebSocket error for consistent shape. K8sErrors
+      // emit codes prefixed with `K8S_` (see src/lib/errors/k8s-errors.ts).
+      const code = (error as { code?: string }).code;
+      if (typeof code === 'string' && code.startsWith('K8S_')) throw error;
+      throw K8sErrors.EXEC_FAILED(
+        'writeFile',
+        `failed to write ${filePath}: ${errorMessage(error)}`
+      );
+    } finally {
+      // Best-effort cleanup if the stream was created but not finalised.
+      if (stream) {
+        try {
+          await stream.kill();
+        } catch {
+          // kill() after wait() resolves is a no-op; ignore.
+        }
+      }
     }
   }
 

--- a/src/lib/sandbox/providers/docker-provider.ts
+++ b/src/lib/sandbox/providers/docker-provider.ts
@@ -22,65 +22,9 @@ import type {
   SandboxProviderEvent,
   SandboxProviderEventListener,
 } from './sandbox-provider.js';
+import { buildSingleFileTar, splitContainerPath } from './single-file-tar.js';
 
 const log = createLogger('DockerProvider');
-
-/**
- * Build a minimal POSIX USTAR archive containing a single regular file.
- *
- * theme-04 P1-05: Used by `DockerSandbox.writeFile` to upload files (notably
- * credentials) via `putArchive` instead of a shell exec, so the content never
- * lands in any argv.
- *
- * The USTAR format is fixed 512-byte blocks: 1 header + N data blocks (padded
- * with zeros) + 2 trailing zero blocks. See `man tar(5)` or
- * https://www.gnu.org/software/tar/manual/html_node/Standard.html.
- */
-function buildSingleFileTar(
-  name: string,
-  content: Buffer,
-  mode: number,
-  uid = 1000, // node user inside the agent-sandbox image
-  gid = 1000
-): Buffer {
-  const nameBytes = Buffer.byteLength(name, 'utf8');
-  if (nameBytes > 100) {
-    // USTAR short-name field is 100 bytes; we could split into name/prefix but
-    // no sandbox path needs it. Fail loud rather than silently truncating.
-    throw new Error(`writeFile: name too long for USTAR short-name (${nameBytes} bytes > 100)`);
-  }
-
-  const header = Buffer.alloc(512);
-  header.write(name, 0, 100, 'utf8');
-  header.write(`${mode.toString(8).padStart(7, '0')}\0`, 100, 8, 'ascii'); // mode
-  header.write(`${uid.toString(8).padStart(7, '0')}\0`, 108, 8, 'ascii'); // uid
-  header.write(`${gid.toString(8).padStart(7, '0')}\0`, 116, 8, 'ascii'); // gid
-  header.write(`${content.length.toString(8).padStart(11, '0')}\0`, 124, 12, 'ascii'); // size
-  header.write(
-    `${Math.floor(Date.now() / 1000)
-      .toString(8)
-      .padStart(11, '0')}\0`,
-    136,
-    12,
-    'ascii'
-  ); // mtime
-  header.write('        ', 148, 8, 'ascii'); // checksum placeholder (8 spaces)
-  header.write('0', 156, 1, 'ascii'); // typeflag = '0' (normal file)
-  header.write('ustar\0', 257, 6, 'ascii'); // magic
-  header.write('00', 263, 2, 'ascii'); // version
-
-  // Compute checksum: unsigned sum of all header bytes (with placeholder)
-  let checksum = 0;
-  for (let i = 0; i < 512; i++) checksum += header[i] ?? 0;
-  header.write(`${checksum.toString(8).padStart(6, '0')}\0 `, 148, 8, 'ascii');
-
-  // Data blocks, padded to 512-byte boundary
-  const padLen = (512 - (content.length % 512)) % 512;
-  const pad = Buffer.alloc(padLen);
-  const trailer = Buffer.alloc(1024); // two zero blocks
-
-  return Buffer.concat([header, content, pad, trailer]);
-}
 
 /**
  * Docker-based sandbox implementation
@@ -342,9 +286,7 @@ class DockerSandbox implements Sandbox {
 
     // Compute parent directory and filename. `putArchive` requires the target
     // directory to exist inside the container.
-    const lastSlash = filePath.lastIndexOf('/');
-    const dir = lastSlash >= 0 ? filePath.slice(0, lastSlash) : '.';
-    const name = lastSlash >= 0 ? filePath.slice(lastSlash + 1) : filePath;
+    const { dir, name } = splitContainerPath(filePath);
     if (!name) {
       throw SandboxErrors.EXEC_FAILED('writeFile', `invalid path: ${filePath}`);
     }

--- a/src/lib/sandbox/providers/nomad-sandbox-instance.ts
+++ b/src/lib/sandbox/providers/nomad-sandbox-instance.ts
@@ -14,6 +14,7 @@ import type { ExecResult, SandboxMetrics, SandboxStatus, TmuxSession } from '../
 import { SANDBOX_DEFAULTS } from '../types.js';
 import { mapNomadJobStatus } from './nomad-sandbox-provider.js';
 import type { ExecStreamOptions, ExecStreamResult, Sandbox } from './sandbox-provider.js';
+import { buildSingleFileTar, splitContainerPath } from './single-file-tar.js';
 
 const log = createLogger('NomadSandboxInstance');
 
@@ -126,6 +127,115 @@ export class NomadSandboxInstance implements Sandbox {
       const message = errorMessage(error);
       this._status = 'error';
       throw NomadErrors.JOB_STOP_FAILED(this.jobName, message);
+    }
+  }
+
+  /**
+   * Write a file inside the sandbox allocation via the exec channel's stdin.
+   *
+   * theme-04 P1-05 / arch29-W2-I (F04-06): Mirrors the Docker `writeFile`
+   * pattern (which uses `putArchive`) so credential material never lands in
+   * any argv (`ps`, `/proc/<pid>/cmdline`, Nomad audit logs). Builds a minimal
+   * single-file USTAR archive, runs `tar xf - -C <dir>` inside the allocation,
+   * and pipes the archive over the exec WebSocket's stdin.
+   *
+   * Implementation note: the SDK exposes `stdin` as a `WritableStream<Uint8Array>`
+   * (Web Streams API, not Node Streams). We write the entire archive in one
+   * chunk then close to signal EOF.
+   */
+  async writeFile(filePath: string, content: string | Buffer, mode = 0o600): Promise<void> {
+    this.assertRunning();
+    this.touch();
+
+    const buf = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+    const { dir, name } = splitContainerPath(filePath);
+    if (!name) {
+      throw NomadErrors.EXEC_FAILED('writeFile', `invalid path: ${filePath}`);
+    }
+
+    const archive = buildSingleFileTar(name, buf, mode);
+
+    // tar xf - -C <dir>  reads a tarball from stdin, extracts into <dir>.
+    const stream = this.client.execStream({
+      allocId: this.allocId,
+      task: 'sandbox',
+      command: ['tar', 'xf', '-', '-C', dir],
+    });
+
+    try {
+      // Drain stderr so the WebSocket back-pressure doesn't stall the process.
+      // We don't expect tar xf to write anything to stdout/stderr on success.
+      const stderrChunks: Uint8Array[] = [];
+      void (async () => {
+        const reader = stream.stderr.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) stderrChunks.push(value);
+          }
+        } catch {
+          // Stream errors surface via wait(); drain best-effort only.
+        }
+      })();
+      void (async () => {
+        const reader = stream.stdout.getReader();
+        try {
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        } catch {
+          // ignore
+        }
+      })();
+
+      // Write the entire archive then close stdin to signal EOF.
+      const writer = stream.stdin.getWriter();
+      try {
+        // Use a Uint8Array view over the same underlying buffer (Buffer is a
+        // Uint8Array subclass; the SDK requires a plain Uint8Array).
+        await writer.write(new Uint8Array(archive.buffer, archive.byteOffset, archive.byteLength));
+        await writer.close();
+      } finally {
+        try {
+          writer.releaseLock();
+        } catch {
+          // releaseLock after close is harmless.
+        }
+      }
+
+      const { exitCode } = await stream.wait();
+      if (exitCode !== 0) {
+        const stderrLen = stderrChunks.reduce((n, c) => n + c.byteLength, 0);
+        const stderrBuf = Buffer.alloc(stderrLen);
+        let off = 0;
+        for (const c of stderrChunks) {
+          stderrBuf.set(c, off);
+          off += c.byteLength;
+        }
+        const stderr = stderrBuf.toString('utf8').trim();
+        throw NomadErrors.EXEC_FAILED(
+          'writeFile',
+          `tar xf failed (exit ${exitCode}) writing ${filePath}: ${stderr || 'no stderr'}`
+        );
+      }
+    } catch (error) {
+      // If the error is already a NomadError shape, rethrow. NomadErrors
+      // emit codes like 'NOMAD-300' (see src/lib/errors/nomad-errors.ts).
+      const code = (error as { code?: string }).code;
+      if (typeof code === 'string' && code.startsWith('NOMAD-')) throw error;
+      throw NomadErrors.EXEC_FAILED(
+        'writeFile',
+        `failed to write ${filePath}: ${errorMessage(error)}`
+      );
+    } finally {
+      // Best-effort cleanup if the stream is still open.
+      try {
+        stream.kill();
+      } catch {
+        // kill() after wait() resolves is a no-op; ignore.
+      }
     }
   }
 

--- a/src/lib/sandbox/providers/single-file-tar.ts
+++ b/src/lib/sandbox/providers/single-file-tar.ts
@@ -1,0 +1,74 @@
+/**
+ * Build a minimal POSIX USTAR archive containing a single regular file.
+ *
+ * theme-04 P1-05 / arch29-W2-I (F04-06): Used by sandbox `writeFile` impls
+ * (Docker via `putArchive`, K8s/Nomad via `tar xf - -C dir` over exec stdin)
+ * to upload files (notably credentials) without going through an exec `sh -c`
+ * path that would put the encoded content in argv.
+ *
+ * The USTAR format is fixed 512-byte blocks: 1 header + N data blocks (padded
+ * with zeros) + 2 trailing zero blocks. See `man tar(5)` or
+ * https://www.gnu.org/software/tar/manual/html_node/Standard.html.
+ */
+export function buildSingleFileTar(
+  /** File name relative to the extraction directory (NOT the absolute path). */
+  name: string,
+  content: Buffer,
+  mode: number,
+  /** UID inside the container (1000 = `node` user in the agent-sandbox image). */
+  uid = 1000,
+  /** GID inside the container. */
+  gid = 1000
+): Buffer {
+  const nameBytes = Buffer.byteLength(name, 'utf8');
+  if (nameBytes > 100) {
+    // USTAR short-name field is 100 bytes; we could split into name/prefix but
+    // no sandbox path needs it. Fail loud rather than silently truncating.
+    throw new Error(`writeFile: name too long for USTAR short-name (${nameBytes} bytes > 100)`);
+  }
+
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, 'utf8');
+  header.write(`${mode.toString(8).padStart(7, '0')}\0`, 100, 8, 'ascii'); // mode
+  header.write(`${uid.toString(8).padStart(7, '0')}\0`, 108, 8, 'ascii'); // uid
+  header.write(`${gid.toString(8).padStart(7, '0')}\0`, 116, 8, 'ascii'); // gid
+  header.write(`${content.length.toString(8).padStart(11, '0')}\0`, 124, 12, 'ascii'); // size
+  header.write(
+    `${Math.floor(Date.now() / 1000)
+      .toString(8)
+      .padStart(11, '0')}\0`,
+    136,
+    12,
+    'ascii'
+  ); // mtime
+  header.write('        ', 148, 8, 'ascii'); // checksum placeholder (8 spaces)
+  header.write('0', 156, 1, 'ascii'); // typeflag = '0' (normal file)
+  header.write('ustar\0', 257, 6, 'ascii'); // magic
+  header.write('00', 263, 2, 'ascii'); // version
+
+  // Compute checksum: unsigned sum of all header bytes (with placeholder)
+  let checksum = 0;
+  for (let i = 0; i < 512; i++) checksum += header[i] ?? 0;
+  header.write(`${checksum.toString(8).padStart(6, '0')}\0 `, 148, 8, 'ascii');
+
+  // Data blocks, padded to 512-byte boundary
+  const padLen = (512 - (content.length % 512)) % 512;
+  const pad = Buffer.alloc(padLen);
+  const trailer = Buffer.alloc(1024); // two zero blocks
+
+  return Buffer.concat([header, content, pad, trailer]);
+}
+
+/**
+ * Split an absolute container file path into a (parent directory, file name) pair.
+ *
+ * theme-04 P1-05 / arch29-W2-I: shared by all three providers' `writeFile`
+ * implementations. The directory is needed for the `tar xf - -C dir` extraction
+ * target; the name goes into the USTAR header.
+ */
+export function splitContainerPath(filePath: string): { dir: string; name: string } {
+  const lastSlash = filePath.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? filePath.slice(0, lastSlash) : '.';
+  const name = lastSlash >= 0 ? filePath.slice(lastSlash + 1) : filePath;
+  return { dir, name };
+}

--- a/src/services/__tests__/container-agent-worktree.test.ts
+++ b/src/services/__tests__/container-agent-worktree.test.ts
@@ -64,6 +64,9 @@ function createProviderMock() {
       wait: vi.fn().mockResolvedValue({ exitCode: 0 }),
       kill: vi.fn(),
     }),
+    // arch29-W2-I (F04-06): every provider implements writeFile so credentials
+    // can be injected out-of-band (no token in argv).
+    writeFile: vi.fn().mockResolvedValue(undefined),
   };
   return {
     get: vi.fn().mockResolvedValue(sandbox),
@@ -128,6 +131,9 @@ function createK8sProviderMock() {
       wait: vi.fn().mockResolvedValue({ exitCode: 0 }),
       kill: vi.fn(),
     }),
+    // arch29-W2-I (F04-06): every provider implements writeFile so credentials
+    // can be injected out-of-band (no token in argv).
+    writeFile: vi.fn().mockResolvedValue(undefined),
   };
   return {
     name: 'kubernetes',

--- a/src/services/container-agent/container-exec.service.ts
+++ b/src/services/container-agent/container-exec.service.ts
@@ -110,6 +110,15 @@ export class ContainerExecService {
 
   /**
    * Build environment variables and create the container bridge for agent execution.
+   *
+   * arch29-W2-I (F04-07, F06-NEW-05): the OAuth access token is NOT passed via
+   * the container env. Credentials live exclusively in `~/.claude/.credentials.json`
+   * inside the sandbox, written by `CredentialsInjector.writeFile()` before
+   * the exec call. This keeps the token out of `/proc/<pid>/environ`,
+   * `printenv`, and any tool capturing the agent-runner's environment for
+   * diagnostics. `CLAUDE_OAUTH_EXPIRES_AT` and `CLAUDE_OAUTH_REFRESH_TOKEN`
+   * are similarly removed — they live in the credentials file alongside the
+   * access token.
    */
   private prepareContainerExec(params: {
     taskId: string;
@@ -121,11 +130,6 @@ export class ContainerExecService {
     agentConfig: AgentConfig;
     worktreePath: string;
     stopFilePath: string;
-    oauthToken: string;
-    /** theme-03 F11: real OAuth expiry ms since epoch (null when host has no record). */
-    oauthExpiresAtMs?: number | null;
-    /** theme-03 F11: OAuth refresh token when the host registry carries one. */
-    oauthRefreshToken?: string | null;
   }): { env: Record<string, string>; bridge: ContainerBridge } {
     const {
       taskId,
@@ -137,8 +141,6 @@ export class ContainerExecService {
       agentConfig,
       worktreePath,
       stopFilePath,
-      oauthExpiresAtMs,
-      oauthRefreshToken,
     } = params;
 
     // F10-03: propagate the spawning HTTP request id as the agent-runner's
@@ -147,7 +149,6 @@ export class ContainerExecService {
     const correlationId = getRequestId();
 
     const env: Record<string, string> = {
-      CLAUDE_OAUTH_TOKEN: '[REDACTED]',
       AGENT_TASK_ID: taskId,
       AGENT_SESSION_ID: sessionId,
       AGENT_PROMPT: prompt,
@@ -160,11 +161,6 @@ export class ContainerExecService {
       AGENT_STOP_FILE: stopFilePath,
       AGENT_PHASE: phase,
       ...(sdkSessionId ? { AGENT_SDK_SESSION_ID: sdkSessionId } : {}),
-      // theme-03 F11: pass real OAuth metadata through to the agent-runner when
-      // the host registry has it. Omitted entries leave the agent-runner to use
-      // its far-future sentinel rather than a fabricated 24h expiry.
-      ...(oauthExpiresAtMs ? { CLAUDE_OAUTH_EXPIRES_AT: String(oauthExpiresAtMs) } : {}),
-      ...(oauthRefreshToken ? { CLAUDE_OAUTH_REFRESH_TOKEN: oauthRefreshToken } : {}),
       ...(correlationId ? { CORRELATION_ID: correlationId } : {}),
     };
     log.debug('Env vars prepared', {
@@ -198,6 +194,83 @@ export class ContainerExecService {
     });
 
     return { env, bridge };
+  }
+
+  /**
+   * Refresh the in-sandbox credentials file in the SDK-compatible CLI shape
+   * (`{ claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes,
+   * subscriptionType } }`) immediately before the agent-runner is exec'd.
+   *
+   * arch29-W2-I (F04-07, F06-NEW-05): the OAuth access token, refresh token,
+   * and expiry MUST NOT be passed via container env vars (visible in
+   * `/proc/<pid>/environ`, `printenv`, crash dumps, etc.). They live
+   * exclusively in `~/.claude/.credentials.json` inside the sandbox.
+   *
+   * Uses `sandbox.writeFile` (out-of-band tar upload over the exec channel
+   * stdin for K8s/Nomad, `putArchive` for Docker) so the JSON content never
+   * appears in argv.
+   */
+  private async injectCredentialsBeforeExec(
+    sandbox: Sandbox,
+    oauthToken: string,
+    oauthRefreshToken: string | null,
+    oauthExpiresAtMs: number | null
+  ): Promise<Result<void, SandboxError>> {
+    const credentialsPath = `${SANDBOX_DEFAULTS.userHome}/.claude/.credentials.json`;
+
+    // Use a far-future sentinel when the host registry has no expiry; matches
+    // the agent-runner's previous fallback (theme-03 F11) so the SDK does not
+    // see a stale `expiresAt` and immediately try to refresh.
+    const expiresAt = oauthExpiresAtMs ?? 100_000_000_000_000;
+
+    const credentialsJson = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: oauthToken,
+        refreshToken: oauthRefreshToken,
+        expiresAt,
+        scopes: ['user:inference', 'user:profile', 'user:sessions:claude_code'],
+        subscriptionType: 'max',
+      },
+    });
+
+    // Ensure the .claude directory exists. mkdir -p is idempotent and the
+    // path is fixed (no user-supplied data) so this is safe.
+    try {
+      await sandbox.exec('mkdir', ['-p', `${SANDBOX_DEFAULTS.userHome}/.claude`]);
+    } catch (mkdirErr) {
+      return err(
+        SandboxErrors.CREDENTIALS_INJECTION_FAILED(
+          `Failed to ensure .claude directory: ${
+            mkdirErr instanceof Error ? mkdirErr.message : String(mkdirErr)
+          }`
+        )
+      );
+    }
+
+    if (typeof sandbox.writeFile !== 'function') {
+      // arch29-W2-I requires `writeFile` parity across Docker/K8s/Nomad. If a
+      // provider still lacks it, fail closed rather than fall through to a
+      // shell-exec path that puts the token in argv.
+      return err(
+        SandboxErrors.CREDENTIALS_INJECTION_FAILED(
+          'Sandbox provider does not implement writeFile — refusing to inject credentials via shell exec (would leak token via argv).'
+        )
+      );
+    }
+
+    try {
+      await sandbox.writeFile(credentialsPath, credentialsJson, 0o600);
+    } catch (writeErr) {
+      return err(
+        SandboxErrors.CREDENTIALS_INJECTION_FAILED(
+          `Failed to write credentials via writeFile: ${
+            writeErr instanceof Error ? writeErr.message : String(writeErr)
+          }`
+        )
+      );
+    }
+
+    return ok(undefined);
   }
 
   /**
@@ -731,7 +804,10 @@ export class ContainerExecService {
       });
     }
 
-    // Build env vars and create container bridge
+    // Build env vars and create container bridge.
+    // arch29-W2-I (F04-07, F06-NEW-05): no OAuth token / refresh / expiry flow
+    // through the env any more — those values live in the credentials file
+    // injected below via `injectCredentialsBeforeExec`.
     const { env, bridge } = this.prepareContainerExec({
       taskId,
       sessionId,
@@ -742,18 +818,39 @@ export class ContainerExecService {
       agentConfig,
       worktreePath,
       stopFilePath,
-      oauthToken,
-      oauthExpiresAtMs,
-      // F03-09 (arch29-W2-C): refresh token now flows from `api_keys.
-      // encrypted_refresh_token` through `ApiKeyService.getDecryptedRefreshToken`.
-      // Null when no refresh token is stored for this service (legacy rows or
-      // non-OAuth keys); the agent-runner falls back to its "no refresh" path.
-      oauthRefreshToken,
     });
 
+    // arch29-W2-I (F04-07, F06-NEW-05): refresh ~/.claude/.credentials.json
+    // inside the sandbox immediately before exec. The host already retrieved
+    // a fresh `oauthToken` (line ~526). For shared sandboxes the file may
+    // belong to a previous tenant; for per-project sandboxes a previous run
+    // may have stale rotation data. Either way, write the current token
+    // (and refresh token + real expiry when available) via `writeFile` so
+    // the credential never appears in argv. F03-09 keeps the refresh token
+    // in DB; we surface it through the file, not through env.
+    const credentialsRefreshResult = await this.injectCredentialsBeforeExec(
+      sandbox,
+      oauthToken,
+      oauthRefreshToken,
+      oauthExpiresAtMs
+    );
+    if (!credentialsRefreshResult.ok) {
+      log.error('Failed to refresh credentials file before agent exec', {
+        data: {
+          taskId,
+          sandboxId: sandbox.id,
+          error: credentialsRefreshResult.error.message,
+        },
+      });
+      if (worktreeId) {
+        await this.worktreeInit.cleanupWorktree(taskId, worktreeId);
+      }
+      return err(credentialsRefreshResult.error);
+    }
+
     // Merge project-level env vars (sandbox.env setting) into container env.
-    // Agent-specific vars (CLAUDE_OAUTH_TOKEN, AGENT_*, etc.) are already set
-    // in `env` by prepareContainerExec, so they take precedence on conflict.
+    // Agent-specific vars (AGENT_*, etc.) are already set in `env` by
+    // prepareContainerExec, so they take precedence on conflict.
     if (Object.keys(sandboxEnv).length > 0) {
       let applied = 0;
       for (const [key, value] of Object.entries(sandboxEnv)) {
@@ -819,12 +916,15 @@ export class ContainerExecService {
         }
       }
 
+      // arch29-W2-I (F04-07, F06-NEW-05): the OAuth token does NOT flow
+      // through env any more. The agent-runner reads
+      // `~/.claude/.credentials.json` (refreshed above by
+      // `injectCredentialsBeforeExec`) as its only authentication source.
       const execResult = await sandbox.execStream({
         cmd: 'node',
         args: ['/opt/agent-runner/dist/index.js'],
         env: {
           ...env,
-          CLAUDE_OAUTH_TOKEN: oauthToken,
           AGENT_PROMPT: prompt,
         },
         cwd: worktreePath,

--- a/tests/integration/agent-oauth-refresh.test.ts
+++ b/tests/integration/agent-oauth-refresh.test.ts
@@ -166,7 +166,7 @@ describe('Agent OAuth refresh token plumbing (F03-09 / arch29-W2-C)', () => {
     await clearTestDatabase();
   });
 
-  it('refresh token from api_keys flows into CLAUDE_OAUTH_REFRESH_TOKEN env var', async () => {
+  it('refresh token from api_keys flows into the credentials file (not env var)', async () => {
     // Seed: api_keys row with both access and refresh token.
     const REFRESH = 'rt_test_secret_value';
     const saveResult = await realApiKeyService.saveKey(
@@ -196,10 +196,33 @@ describe('Agent OAuth refresh token plumbing (F03-09 / arch29-W2-C)', () => {
 
     expect(result.ok, JSON.stringify(result)).toBe(true);
 
-    // The env passed to the agent-runner exec must contain the refresh token.
+    // arch29-W2-I (F04-07, F06-NEW-05): the refresh token flows through the
+    // credentials file, NOT through env vars. Verify:
+    //   1. env passed to agent-runner contains NO CLAUDE_OAUTH_* keys
+    //   2. sandbox.writeFile was called with credentials JSON containing the
+    //      refresh token in the SDK-compatible CLI shape.
     expect(execStreamSpy).toHaveBeenCalled();
     const execArgs = execStreamSpy.mock.calls[0][0] as { env: Record<string, string> };
-    expect(execArgs.env.CLAUDE_OAUTH_REFRESH_TOKEN).toBe(REFRESH);
+    const oauthKeys = Object.keys(execArgs.env).filter((k) => k.startsWith('CLAUDE_OAUTH'));
+    expect(oauthKeys).toEqual([]);
+
+    // Locate the writeFile call that wrote the credentials JSON.
+    const writeFileSpy = mockSandbox.writeFile as ReturnType<typeof vi.fn>;
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      expect.stringContaining('.credentials.json'),
+      expect.any(String),
+      0o600
+    );
+    const credCall = writeFileSpy.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('.credentials.json')
+    );
+    expect(credCall).toBeDefined();
+    const credContent = credCall?.[1] as string;
+    const parsed = JSON.parse(credContent) as {
+      claudeAiOauth?: { accessToken?: string; refreshToken?: string };
+    };
+    expect(parsed.claudeAiOauth?.refreshToken).toBe(REFRESH);
+    expect(parsed.claudeAiOauth?.accessToken).toBe('sk-ant-oat01-test-access');
   });
 
   it('absence of refresh token in api_keys leaves CLAUDE_OAUTH_REFRESH_TOKEN unset (no empty-string injection)', async () => {

--- a/tests/integration/k8s-git-clone-no-token-argv.test.ts
+++ b/tests/integration/k8s-git-clone-no-token-argv.test.ts
@@ -1,0 +1,164 @@
+/**
+ * arch29-W2-I (F04-12) — the K8s workspace initializer must not embed the
+ * GitHub token in the clone-URL argv. The previous form
+ * `https://x-access-token:${token}@github.com/...` is replaced with a
+ * token-free public URL plus a per-invocation `-c http.extraHeader=...`
+ * argument carrying the auth header (base64 of `x-access-token:TOKEN`).
+ *
+ * Red→green regression test:
+ *   - WITHOUT fix: `git remote add origin <url>` argv contains
+ *     `x-access-token:TOKEN_VALUE` substring.
+ *   - WITH fix: NO call to `sandbox.exec('git', [...])` should have an arg
+ *     containing the literal substring `x-access-token:` (and the token
+ *     itself must not appear unencoded). The remote URL stored in
+ *     `.git/config` MUST be the public form. The token may appear in the
+ *     `-c http.extraHeader` argv during the single fetch call as the
+ *     base64-encoded `Authorization: Basic <b64>` value.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/lib/logging/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+interface ExecCall {
+  cmd: string;
+  args: string[];
+}
+
+function makeMockSandbox(): {
+  sandbox: { exec: ReturnType<typeof vi.fn> };
+  calls: ExecCall[];
+} {
+  const calls: ExecCall[] = [];
+  const sandbox = {
+    exec: vi.fn(async (cmd: string, args: string[] = []) => {
+      calls.push({ cmd, args: [...args] });
+      // Mock the workspace-cloned check to return "not cloned"
+      if (cmd === 'test' && args.includes('-d') && args.some((a) => a.endsWith('/.git'))) {
+        return { exitCode: 1, stdout: '', stderr: '' };
+      }
+      // Default: success
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }),
+  };
+  return { sandbox, calls };
+}
+
+describe('arch29-W2-I (F04-12) — K8s git clone never puts token in URL argv', () => {
+  it('initializeK8sWorkspace runs no git command containing x-access-token: substring', async () => {
+    const { initializeK8sWorkspace } = await import(
+      '../../src/lib/sandbox/k8s-workspace-initializer.js'
+    );
+
+    const { sandbox, calls } = makeMockSandbox();
+    const SECRET_TOKEN = 'ghp_extremelysensitive_should_never_appear_in_argv_xxx';
+
+    await initializeK8sWorkspace({
+      sandbox,
+      gitToken: { token: SECRET_TOKEN, owner: 'agentdevsl', repo: 'agentpane' },
+      taskTitle: 'fix-the-thing',
+      taskId: 'task-abcd1234',
+      baseBranch: 'main',
+    });
+
+    // Pull every git invocation argv we've recorded.
+    const gitCalls = calls.filter((c) => c.cmd === 'git');
+    expect(gitCalls.length).toBeGreaterThan(0);
+
+    // Critical: NO argv element across every git call may contain
+    // `x-access-token:` (the URL form leaks the token via /proc/<pid>/cmdline,
+    // container audit logs, and any sibling tenant in shared-sandbox mode).
+    for (const call of gitCalls) {
+      for (const arg of call.args) {
+        expect(arg).not.toContain('x-access-token:');
+      }
+    }
+
+    // Critical: the raw token never appears literally either. The auth header
+    // arg is base64-encoded so the plaintext token must not be present in argv.
+    for (const call of gitCalls) {
+      for (const arg of call.args) {
+        expect(arg).not.toContain(SECRET_TOKEN);
+      }
+    }
+
+    // The `git remote add origin <url>` call MUST use the token-free public
+    // URL — that's what `git remote -v` will surface to any later command
+    // (and any tenant in shared-sandbox mode).
+    const remoteAddCall = gitCalls.find(
+      (c) => c.args.includes('remote') && c.args.includes('add') && c.args.includes('origin')
+    );
+    expect(remoteAddCall).toBeDefined();
+    const url = remoteAddCall?.args[remoteAddCall.args.length - 1];
+    expect(url).toBe('https://github.com/agentdevsl/agentpane.git');
+
+    // The `set-url origin` call (when present, used to overwrite a stale
+    // tokenized URL from a prior run) MUST also use the token-free form.
+    const setUrlCall = gitCalls.find(
+      (c) => c.args.includes('remote') && c.args.includes('set-url') && c.args.includes('origin')
+    );
+    if (setUrlCall) {
+      const setUrlArg = setUrlCall.args[setUrlCall.args.length - 1];
+      expect(setUrlArg).toBe('https://github.com/agentdevsl/agentpane.git');
+      expect(setUrlArg).not.toContain('x-access-token');
+    }
+  });
+
+  it('the fetch call carries -c http.extraHeader with base64 auth header (token NOT in plaintext)', async () => {
+    const { initializeK8sWorkspace } = await import(
+      '../../src/lib/sandbox/k8s-workspace-initializer.js'
+    );
+
+    const { sandbox, calls } = makeMockSandbox();
+    const SECRET_TOKEN = 'ghp_secret_pat_value_for_test_purposes';
+
+    await initializeK8sWorkspace({
+      sandbox,
+      gitToken: { token: SECRET_TOKEN, owner: 'agentdevsl', repo: 'agentpane' },
+      taskTitle: 'feature-x',
+      taskId: 'task-efgh5678',
+      baseBranch: 'main',
+    });
+
+    // Find the fetch call(s).
+    const gitCalls = calls.filter((c) => c.cmd === 'git');
+    const fetchCalls = gitCalls.filter((c) => c.args.includes('fetch'));
+    expect(fetchCalls.length).toBeGreaterThan(0);
+
+    // Each fetch must carry `-c <extraHeader>` for auth.
+    for (const fetchCall of fetchCalls) {
+      const dashCIdx = fetchCall.args.indexOf('-c');
+      expect(dashCIdx).toBeGreaterThanOrEqual(0);
+      const cVal = fetchCall.args[dashCIdx + 1] ?? '';
+      expect(cVal).toMatch(/^http\.extraHeader=Authorization:\s+Basic\s+/);
+      // The plaintext token must NOT appear; only the b64-encoded form may.
+      expect(cVal).not.toContain(SECRET_TOKEN);
+      expect(cVal).not.toContain('x-access-token:');
+    }
+  });
+
+  it('buildGitAuthHeaderArg encodes the token with x-access-token: prefix', async () => {
+    const { buildGitAuthHeaderArg } = await import(
+      '../../src/lib/sandbox/k8s-workspace-initializer.js'
+    );
+    const arg = buildGitAuthHeaderArg('ghp_test_token');
+    // Expect the form `http.extraHeader=Authorization: Basic <b64>`.
+    expect(arg).toMatch(/^http\.extraHeader=Authorization: Basic [A-Za-z0-9+/=]+$/);
+    // Decode and check it's `x-access-token:ghp_test_token`.
+    const b64 = arg.replace(/^http\.extraHeader=Authorization: Basic /, '');
+    const decoded = Buffer.from(b64, 'base64').toString('utf8');
+    expect(decoded).toBe('x-access-token:ghp_test_token');
+    // The plaintext token IS in the b64-decoded value (that's the whole
+    // point of the auth header) — but it is NOT visible as a literal
+    // substring in the b64-encoded argv element.
+    expect(arg).not.toContain('ghp_test_token');
+    expect(arg).not.toContain('x-access-token:');
+  });
+});

--- a/tests/integration/sandbox-credentials-no-env.test.ts
+++ b/tests/integration/sandbox-credentials-no-env.test.ts
@@ -1,0 +1,268 @@
+/**
+ * arch29-W2-I (F04-07, F06-NEW-05) — sandbox credential injection drops the
+ * `CLAUDE_OAUTH_TOKEN` env var entirely. The host writes
+ * `~/.claude/.credentials.json` via `sandbox.writeFile()` (out-of-band) and
+ * the agent-runner is expected to read that file directly.
+ *
+ * Red→green regression test:
+ *   - WITHOUT fix: container exec env contains `CLAUDE_OAUTH_TOKEN: '<real token>'`
+ *   - WITH fix: container exec env contains NO key matching /CLAUDE_OAUTH/
+ *     and `sandbox.writeFile` is invoked with the SDK-compatible CLI shape.
+ *
+ * Strategy: instantiate `ContainerExecService` with mocked deps. The service's
+ * `injectCredentialsBeforeExec` private method writes via `sandbox.writeFile`,
+ * and `prepareContainerExec` builds the env. The env passed to `execStream`
+ * must be free of any `CLAUDE_OAUTH_*` keys.
+ */
+
+import type { Readable, Writable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/lib/logging/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+interface ExecStreamCall {
+  cmd: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+interface WriteFileCall {
+  path: string;
+  content: string;
+  mode?: number;
+}
+
+function buildMockSandbox(): {
+  sandbox: {
+    id: string;
+    codespaceId: string;
+    containerId: string;
+    status: 'running';
+    exec: ReturnType<typeof vi.fn>;
+    execStream: ReturnType<typeof vi.fn>;
+    writeFile: ReturnType<typeof vi.fn>;
+    refreshStatus?: () => Promise<void>;
+    [k: string]: unknown;
+  };
+  execStreamCalls: ExecStreamCall[];
+  writeFileCalls: WriteFileCall[];
+} {
+  const execStreamCalls: ExecStreamCall[] = [];
+  const writeFileCalls: WriteFileCall[] = [];
+  const sandbox = {
+    id: 'sb-1',
+    codespaceId: 'cs-1',
+    containerId: 'docker-c1',
+    status: 'running' as const,
+    exec: vi.fn(async () => ({ exitCode: 0, stdout: 'ready', stderr: '' })),
+    execStream: vi.fn(async (opts: ExecStreamCall) => {
+      execStreamCalls.push({
+        cmd: opts.cmd,
+        args: opts.args,
+        env: opts.env ? { ...opts.env } : undefined,
+        cwd: opts.cwd,
+      });
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      // Don't emit data; tests assert on env, not on output.
+      return {
+        stdout: stdout as unknown as Readable,
+        stderr: stderr as unknown as Readable,
+        wait: vi.fn(async () => ({ exitCode: 0 })),
+        kill: vi.fn(async () => {
+          stdout.end();
+          stderr.end();
+        }),
+        // For agent-runner emulation: don't force-close so handlers can attach.
+        stdin: undefined as unknown as Writable | undefined,
+      };
+    }),
+    writeFile: vi.fn(async (path: string, content: string | Buffer, mode?: number) => {
+      writeFileCalls.push({
+        path,
+        content: typeof content === 'string' ? content : content.toString('utf8'),
+        mode,
+      });
+    }),
+    refreshStatus: async () => {
+      /* noop */
+    },
+    touch: vi.fn(),
+    getLastActivity: vi.fn(() => new Date()),
+    getMetrics: vi.fn(),
+    stop: vi.fn(),
+    execAsRoot: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+    createTmuxSession: vi.fn(),
+    listTmuxSessions: vi.fn(),
+    killTmuxSession: vi.fn(),
+    sendKeysToTmux: vi.fn(),
+    captureTmuxPane: vi.fn(),
+  };
+  return { sandbox, execStreamCalls, writeFileCalls };
+}
+
+describe('arch29-W2-I — credentials never flow via env var; only via writeFile', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('injectCredentialsBeforeExec writes ~/.claude/.credentials.json via writeFile in CLI shape', async () => {
+    const { ContainerExecService } = await import(
+      '../../src/services/container-agent/container-exec.service.js'
+    );
+
+    const { sandbox, writeFileCalls } = buildMockSandbox();
+
+    // Construct a near-empty service instance just to exercise the private
+    // injection method via the public path. We use a typed cast to reach the
+    // private method without re-implementing the full startAgent path.
+    const svc = new ContainerExecService(
+      // deps stub — only `streams` is touched by the private method indirectly
+      {
+        db: {} as never,
+        provider: {} as never,
+        streams: { publish: vi.fn(async () => undefined) } as never,
+        apiKeyService: {} as never,
+      } as never,
+      {} as never, // SandboxStateManager
+      {} as never, // WorktreeInitService
+      vi.fn() as never, // onPlanReady
+      vi.fn() as never // onAgentCompleteCallback
+    );
+
+    // Reach the private method via the unknown cast so we can target it
+    // without round-tripping through startAgent (which needs DB fixtures).
+    const result = await (
+      svc as unknown as {
+        injectCredentialsBeforeExec: (
+          sandbox: unknown,
+          oauthToken: string,
+          oauthRefreshToken: string | null,
+          oauthExpiresAtMs: number | null
+        ) => Promise<{ ok: boolean; error?: { code: string; message: string } }>;
+      }
+    ).injectCredentialsBeforeExec(
+      sandbox,
+      'sk-ant-oat01-secret-token-xyz',
+      'rt-deadbeef',
+      Date.now() + 60_000
+    );
+
+    expect(result.ok).toBe(true);
+    expect(writeFileCalls).toHaveLength(1);
+    const call = writeFileCalls[0];
+    expect(call?.path).toBe('/home/node/.claude/.credentials.json');
+    expect(call?.mode).toBe(0o600);
+    const parsed = JSON.parse(call?.content ?? '{}') as {
+      claudeAiOauth?: { accessToken?: string; refreshToken?: string };
+    };
+    expect(parsed.claudeAiOauth?.accessToken).toBe('sk-ant-oat01-secret-token-xyz');
+    expect(parsed.claudeAiOauth?.refreshToken).toBe('rt-deadbeef');
+  });
+
+  it('injectCredentialsBeforeExec FAILS CLOSED when sandbox lacks writeFile (no shell-exec fallback)', async () => {
+    const { ContainerExecService } = await import(
+      '../../src/services/container-agent/container-exec.service.js'
+    );
+
+    const { sandbox } = buildMockSandbox();
+    // Strip writeFile to simulate a provider that hasn't been ported.
+    (sandbox as Record<string, unknown>).writeFile = undefined;
+
+    const svc = new ContainerExecService(
+      {
+        db: {} as never,
+        provider: {} as never,
+        streams: { publish: vi.fn(async () => undefined) } as never,
+        apiKeyService: {} as never,
+      } as never,
+      {} as never,
+      {} as never,
+      vi.fn() as never,
+      vi.fn() as never
+    );
+
+    const result = await (
+      svc as unknown as {
+        injectCredentialsBeforeExec: (
+          sandbox: unknown,
+          oauthToken: string,
+          oauthRefreshToken: string | null,
+          oauthExpiresAtMs: number | null
+        ) => Promise<{ ok: boolean; error?: { code: string; message: string } }>;
+      }
+    ).injectCredentialsBeforeExec(sandbox, 'sk-ant-oat01-token', null, null);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Refuses to fall through to a shell-exec path that would put the
+      // token in argv (the whole point of arch29-W2-I).
+      expect(result.error?.code).toContain('CREDENTIALS_INJECTION_FAILED');
+      expect(result.error?.message).toMatch(/writeFile/i);
+    }
+  });
+
+  it('prepareContainerExec env carries NO CLAUDE_OAUTH_* keys', async () => {
+    const { ContainerExecService } = await import(
+      '../../src/services/container-agent/container-exec.service.js'
+    );
+
+    const svc = new ContainerExecService(
+      {
+        db: {} as never,
+        provider: {} as never,
+        streams: { publish: vi.fn(async () => undefined) } as never,
+        apiKeyService: {} as never,
+      } as never,
+      {} as never,
+      {} as never,
+      vi.fn() as never,
+      vi.fn() as never
+    );
+
+    const { env } = (
+      svc as unknown as {
+        prepareContainerExec: (params: {
+          taskId: string;
+          sessionId: string;
+          codespaceId: string;
+          phase: 'plan' | 'execute';
+          sdkSessionId?: string;
+          prompt: string;
+          agentConfig: { model: string; maxTurns: number; allowedTools: string[] };
+          worktreePath: string;
+          stopFilePath: string;
+        }) => { env: Record<string, string> };
+      }
+    ).prepareContainerExec({
+      taskId: 'task-1',
+      sessionId: 'sess-1',
+      codespaceId: 'cs-1',
+      phase: 'plan',
+      prompt: 'do the thing',
+      agentConfig: { model: 'claude-opus-4-5-20251101', maxTurns: 50, allowedTools: ['Bash'] },
+      worktreePath: '/workspace',
+      stopFilePath: '/tmp/.stop-task-1',
+    });
+
+    // Assert the env is free of every CLAUDE_OAUTH_* leak vector.
+    const oauthKeys = Object.keys(env).filter((k) => k.startsWith('CLAUDE_OAUTH'));
+    expect(oauthKeys).toEqual([]);
+    // Sanity: the AGENT_* vars are still there.
+    expect(env.AGENT_TASK_ID).toBe('task-1');
+    expect(env.AGENT_PHASE).toBe('plan');
+  });
+});

--- a/tests/mocks/mock-sandbox.ts
+++ b/tests/mocks/mock-sandbox.ts
@@ -123,6 +123,9 @@ export function createMockSandbox(overrides: Partial<Sandbox> = {}): Sandbox {
     touch: vi.fn(),
     getLastActivity: vi.fn().mockReturnValue(new Date()),
     execStream: vi.fn().mockResolvedValue(createMockExecStreamResult()),
+    // arch29-W2-I (F04-06): every provider implements writeFile so credentials
+    // can be injected out-of-band (no token in argv).
+    writeFile: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/tests/mocks/mock-services.ts
+++ b/tests/mocks/mock-services.ts
@@ -465,6 +465,9 @@ export function createMockSandbox(overrides?: Partial<Sandbox>): Sandbox {
     touch: vi.fn(),
     getLastActivity: vi.fn().mockReturnValue(new Date()),
     execStream: vi.fn().mockResolvedValue(defaultExecStreamResult),
+    // arch29-W2-I (F04-06): every provider implements writeFile so credentials
+    // can be injected out-of-band (no token in argv).
+    writeFile: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/tests/services/container-agent.service.test.ts
+++ b/tests/services/container-agent.service.test.ts
@@ -142,6 +142,9 @@ function createMockSandbox(overrides: Record<string, unknown> = {}) {
     killTmuxSession: vi.fn(),
     sendKeysToTmux: vi.fn(),
     captureTmuxPane: vi.fn(),
+    // arch29-W2-I (F04-06): all providers implement writeFile so credentials
+    // can be injected out-of-band (no token in argv).
+    writeFile: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -2110,7 +2113,7 @@ describe('ContainerAgentService', () => {
       );
     });
 
-    it('includes CLAUDE_OAUTH_TOKEN in env vars', async () => {
+    it('arch29-W2-I (F04-07, F06-NEW-05): does NOT pass CLAUDE_OAUTH_TOKEN via env', async () => {
       const project = await createTestProject();
       const task = await createTestTask(project.id, { title: 'Token test' });
 
@@ -2121,12 +2124,26 @@ describe('ContainerAgentService', () => {
         prompt: 'Do something',
       });
 
-      expect(sandbox.execStream).toHaveBeenCalledWith(
-        expect.objectContaining({
-          env: expect.objectContaining({
-            CLAUDE_OAUTH_TOKEN: 'sk-ant-oat01-test-token',
-          }),
-        })
+      // The OAuth access token MUST NOT appear in the agent-runner's env.
+      // It lives only in `~/.claude/.credentials.json` written by the host
+      // via `sandbox.writeFile()` (out-of-band) before exec.
+      const calls = (sandbox.execStream as ReturnType<typeof vi.fn>).mock.calls as Array<
+        [{ env?: Record<string, string> }]
+      >;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const [opts] of calls) {
+        const envKeys = Object.keys(opts.env ?? {});
+        const oauthKeys = envKeys.filter((k) => k.startsWith('CLAUDE_OAUTH'));
+        expect(oauthKeys).toEqual([]);
+      }
+
+      // The credentials file IS written via the sandbox's writeFile, with the
+      // token in the body. The body should be the SDK-compatible CLI shape
+      // (`{ claudeAiOauth: { accessToken, ... } }`).
+      expect(sandbox.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('.credentials.json'),
+        expect.stringContaining('sk-ant-oat01-test-token'),
+        0o600
       );
     });
 


### PR DESCRIPTION
## Summary

- **F04-06 (P1)** — port the Docker `writeFile` pattern (USTAR tarball over the exec channel) to K8s `AgentSandboxInstance` and Nomad `NomadSandboxInstance`. Both now stream the credentials file via `tar xf - -C <dir>` with the archive piped over stdin — the credential content never appears in argv (`ps`, `/proc/<pid>/cmdline`, container audit logs).
- **F04-07 / F06-NEW-05 (P1)** — drop `CLAUDE_OAUTH_TOKEN`, `CLAUDE_OAUTH_REFRESH_TOKEN`, and `CLAUDE_OAUTH_EXPIRES_AT` from the agent-runner's container env entirely. Credentials live exclusively in `~/.claude/.credentials.json` injected via `sandbox.writeFile()` immediately before exec. New private `ContainerExecService.injectCredentialsBeforeExec()` writes the SDK-compatible CLI shape (`{ claudeAiOauth: { ... } }`) and **fails closed** when the provider lacks `writeFile` (no shell-exec fallback that would put the encoded blob in argv).
- **F04-12 (P1)** — stop embedding the GitHub token in the clone-URL argv. The remote URL is now the public token-free form (`https://github.com/owner/repo.git`); auth is supplied per-fetch via `git -c http.extraHeader=Authorization: Basic <b64>`. After clone, `git remote -v` shows only the public URL, so no sibling tenant in shared-sandbox mode can recover the token from `.git/config`.
- **Agent-runner change** — `validateConfig()` no longer requires `CLAUDE_OAUTH_TOKEN`. `writeCredentialsFile()` first checks for the host-injected file and uses it when valid; only writes from env vars if the file is missing (local-dev fallback only).
- **Code organisation** — shared `buildSingleFileTar` helper extracted to `src/lib/sandbox/providers/single-file-tar.ts` and reused by Docker / K8s / Nomad providers.

## Findings closed

| ID | Title | Status |
|---|---|---|
| F04-06 | Credentials injection landed `writeFile` on Docker only; K8s and Nomad still use the legacy `sh -c 'echo "<base64>" | base64 -d > path'` exec path | **closed** |
| F04-07 | `CLAUDE_OAUTH_TOKEN` is still passed via the container environment | **closed** |
| F04-12 | GitHub token still flows through argv in K8s workspace initialization | **closed** |
| F06-NEW-05 | OAuth token still passed as container env var | **closed** (same fix as F04-07) |

## Test bar (red→green)

**Before:** `tests/services/container-agent.service.test.ts > includes CLAUDE_OAUTH_TOKEN in env vars` PASSED on `arch-review-april29` — proving the leak. `tests/integration/agent-oauth-refresh.test.ts > refresh token from api_keys flows into CLAUDE_OAUTH_REFRESH_TOKEN env var` likewise required the env var to leak the refresh token.

**After:**
- `tests/services/container-agent.service.test.ts > arch29-W2-I (F04-07, F06-NEW-05): does NOT pass CLAUDE_OAUTH_TOKEN via env` — asserts NO `CLAUDE_OAUTH_*` env keys, asserts `sandbox.writeFile` called with credentials JSON containing the token (PASS).
- `tests/integration/agent-oauth-refresh.test.ts > refresh token from api_keys flows into the credentials file (not env var)` — asserts the refresh token surfaces in the `.credentials.json` body, not env (PASS).
- New `tests/integration/sandbox-credentials-no-env.test.ts` (3 tests) — verifies env stays clean, `injectCredentialsBeforeExec` writes via `writeFile` in the SDK CLI shape, and fails closed when `writeFile` is missing.
- New `tests/integration/k8s-git-clone-no-token-argv.test.ts` (3 tests) — verifies no git argv contains `x-access-token:` or the raw token, the remote URL is the public form, and the fetch call carries `-c http.extraHeader=Authorization: Basic <b64>`.
- New `src/lib/sandbox/providers/__tests__/sandbox-writefile-parity.test.ts` (7 tests) — verifies USTAR tar layout, K8s `writeFile` runs `tar xf - -C dir` with archive over stdin, Nomad `writeFile` does the same via the WritableStream stdin, both throw typed errors on non-zero exit, Nomad refuses when allocation is not running.

## Status vs April 29 review

- F04-06 (P1): closed — `writeFile` parity across Docker/K8s/Nomad. Shared USTAR tar builder.
- F04-07 (P1): closed — `CLAUDE_OAUTH_TOKEN` dropped from container env. The credentials file is now the only path.
- F04-12 (P1): closed — token-in-URL form deleted; `git remote -v` is clean. Token appears only as base64 inside `-c http.extraHeader=Authorization: Basic <b64>` argv during the single fetch (acceptable trade-off given K8s buffered exec has no env support; the persistent `.git/config` is clean).
- F06-NEW-05 (P1): closed — same fix as F04-07.

## Test plan

- [x] Biome `check --write --max-diagnostics=500 --diagnostic-level=error src/ tests/ agent-runner/src/` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` (full suite): 9481 pass, 9 skip; 2 pre-existing W2-H api-keys regressions on `arch-review-april29` unrelated to this PR
- [x] `npx vitest run --project functional`: 90 pass
- [x] `npx vitest run tests/integration/*schema-drift*`: 62 pass
- [x] `cd agent-runner && bun test`: 25 pass
- [x] Pre-commit hooks (biome, tsc, semgrep, secrets, EOF, large files): all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
