### PR TITLE
fix(arch29-W3-A): close 3 critical Dependabot advisories (F06-NEW-12)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.30.0
+        # Pinned to commit SHA for v0.35.0 (immutable, post-supply-chain-incident, GHSA-69fq-xp46-6x23).
+        # Tag 0.35.0 published 2026-03-04 with GitHub immutable releases — see advisory at
+        # https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23.
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
           format: table

--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
   },
   "overrides": {
     "@types/node": "^25.6.0",
+    "protobufjs": "^7.5.5",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -618,7 +619,7 @@
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
 
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
 
     "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
 
@@ -626,13 +627,13 @@
 
     "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
 
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.1", "", {}, "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="],
 
     "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
 
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1770,7 +1771,7 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+    "protobufjs": ["protobufjs@7.5.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -2163,6 +2164,8 @@
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@protobufjs/fetch/@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -26,6 +26,10 @@ require (
 	github.com/posener/complete v1.1.1 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
-	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
-	golang.org/x/sys v0.25.0 // indirect
+	// Pinned to v0.31.0+ to address GHSA-v778-237x-gjrc (critical: ServerConfig.PublicKeyCallback
+	// authorization bypass) plus four high-severity SSH vulnerabilities. The `cli/` directory
+	// only uses sprig (templating) which transitively pulls x/crypto for blowfish/scrypt; SSH
+	// surface is unused but the bump removes the advisory.
+	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -62,8 +62,9 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -74,8 +75,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/coverage-v8": "4.1.5",
         "agent-browser": "0.26.0",
         "drizzle-kit": "^0.31.10",
         "fast-check": "^4.7.0",
@@ -1952,6 +1952,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1963,6 +1964,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2422,6 +2424,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,6 +2441,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2454,6 +2458,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2470,6 +2475,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2486,6 +2492,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2502,6 +2509,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,6 +2526,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2534,6 +2543,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2550,6 +2560,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,6 +2577,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2582,6 +2594,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,6 +2611,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,6 +2628,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2630,6 +2645,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2646,6 +2662,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2662,6 +2679,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2678,6 +2696,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2694,6 +2713,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2710,6 +2730,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2726,6 +2747,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2742,6 +2764,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2758,6 +2781,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2774,6 +2798,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2790,6 +2815,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2806,6 +2832,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2822,6 +2849,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4782,9 +4810,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -4810,9 +4838,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -4828,9 +4856,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
@@ -7777,27 +7805,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -7877,14 +7884,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.160",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
@@ -7895,7 +7894,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8068,6 +8067,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8077,7 +8077,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8153,14 +8153,14 @@
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -8174,13 +8174,41 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8436,20 +8464,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ansis": {
@@ -9430,6 +9444,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -9736,14 +9751,6 @@
       "engines": {
         "node": ">= 8.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -10590,7 +10597,7 @@
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -11254,7 +11261,7 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -12446,17 +12453,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -13946,22 +13942,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -13999,22 +13979,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -14162,14 +14142,6 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -14398,7 +14370,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -15367,7 +15339,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -15481,6 +15453,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,10 @@
     "zod": "4.3.6"
   },
   "overrides": {
-    "@types/node": "^25.6.0"
+    "@types/node": "^25.6.0",
+    "protobufjs": "^7.5.5"
+  },
+  "resolutions": {
+    "protobufjs": "^7.5.5"
   }
 }

--- a/specs/arch_review_april29/06-security.md
+++ b/specs/arch_review_april29/06-security.md
@@ -317,6 +317,27 @@ Counts as of April 29:
 
 Cross-ref: F06-01 (April).
 
+### Resolution status (PR W3-A, 2026-04-29)
+
+The 3 critical advisories were closed in PR W3-A (`fix(arch29-W3-A): close 3 critical Dependabot advisories (F06-NEW-12)`):
+
+| Advisory | Resolution | Verification |
+|---|---|---|
+| `GHSA-xq3m-2v4x-88gg` (protobufjs RCE, < 7.5.5) | Added `protobufjs: ^7.5.5` to `overrides` and `resolutions` in root `package.json`. `bun install` and `npm install --package-lock-only --legacy-peer-deps` regenerated lockfiles to resolve protobufjs@7.5.6. The override propagates through the transitive path `dockerode → @grpc/proto-loader → protobufjs`. | `tests/integration/dependency-advisories.test.ts` parses both `bun.lock` and `package-lock.json` and asserts the resolved version is ≥ 7.5.5. |
+| `GHSA-69fq-xp46-6x23` (aquasecurity/trivy-action ≤ 0.34.2) | Workflow `aquasecurity/trivy-action@0.30.0` replaced with SHA pin `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0` in `.github/workflows/release.yml`. v0.35.0 is protected by GitHub immutable releases (enabled March 4, 2026, before the v0.35.0 cut), so the tag itself can't be force-pushed. SHA pin is defence-in-depth per the advisory's recommendation. | `tests/integration/release-workflows.test.ts` rejects any `aquasecurity/trivy-action@0.X.Y` reference where `X` is in `[10..34]` (the original-tag forever-tainted range) and requires either a 40-char SHA pin or a `v0.35.0+`/`v1.x.y+` tag. |
+| `GHSA-v778-237x-gjrc` (golang.org/x/crypto < 0.31.0) | `cli/go.mod` bumped from pseudo-version `v0.0.0-20200820211705-5c72a883971a` to `v0.31.0`. Required co-bump of `golang.org/x/sys` to `v0.28.0`. `go mod tidy` regenerated `cli/go.sum` with the patched checksums. | `tests/integration/dependency-advisories.test.ts` parses the require line in `cli/go.mod` and the matching go.sum checksum row. Pseudo-versions (`v0.0.0-...`) and any < 0.31.0 cause the test to fail. |
+
+After the bump, `gh api repos/agentdevsl/agentpane/dependabot/alerts --paginate | jq '[.[] | select(.state == "open" and .security_vulnerability.severity == "critical")] | length'` should drop from 3 to 0 once Dependabot re-scans the merged PR.
+
+**Test bar (red→green)**:
+- Without the fix: `npx vitest run tests/integration/dependency-advisories.test.ts tests/integration/release-workflows.test.ts` → **6 failures** (3 protobufjs + 2 golang/x/crypto + 1 trivy-action SHA pin).
+- With the fix: same command → **all 15 tests pass**.
+
+**Out of scope for W3-A** (deferred to a follow-up PR):
+- 4 `high` and 4 `medium` `golang.org/x/crypto` advisories: these are auto-resolved by the same v0.31.0 bump (the patched range covers all five SSH-related advisories simultaneously). Verify with a re-scan after merge.
+- 1 `medium` `uuid` (bounds check, GHSA-w5hq-g745-h8pq, < 14.0.0). Comes via `dockerode` → `uuid@10.0.0`. Bump scheduled for a separate PR; the bounds-check issue is dev-time only (no untrusted UUID parsing surface in production).
+- 1 `medium` `esbuild` dev-server CORS (GHSA-67mh-4wv8-2f99). Affects only the `vite dev` server in local dev. Mitigated by Vite's localhost binding default; the upstream esbuild bump is in the `vite@8.0.8` chain.
+
 ---
 
 ## F06-NEW-13 — P2 — Session cookie `Secure` flag still keyed on `NODE_ENV === 'production'`, asymmetric with `oauth_state`

--- a/tests/integration/dependency-advisories.test.ts
+++ b/tests/integration/dependency-advisories.test.ts
@@ -1,0 +1,131 @@
+/**
+ * F06-NEW-12 — Critical Dependabot advisory regression guards.
+ *
+ * Each test below pins a specific GHSA identifier and asserts the resolved version
+ * in our lockfiles is no longer in the vulnerable range. The tests fail on `main`
+ * (which still ships the vulnerable transitive resolutions) and pass with the
+ * fix that lands in PR W3-A.
+ *
+ * Why we test the lockfile, not just package.json:
+ *   - protobufjs is a transitive dep via dockerode → @grpc/proto-loader → protobufjs.
+ *     A direct `dependencies` bump would not work; only an `overrides`/`resolutions`
+ *     entry forces every node_modules entry to the patched version. Reading the
+ *     lockfile is the only way to verify that override actually took effect.
+ *   - aquasecurity/trivy-action is referenced in a workflow file, not a lockfile.
+ *     The release-workflows.test.ts file covers that.
+ *   - golang.org/x/crypto is a Go module — verified separately by go.mod parsing.
+ *
+ * Precedent: this is the same pattern used for schema drift suites
+ * (`tests/integration/*-schema-drift.test.ts`) — read the on-disk artifact and
+ * assert on its content, no service wiring needed.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../..');
+
+/**
+ * Parses semver-ish strings ("7.5.4", "v0.31.0", "0.0.0-20200820211705-...") into a
+ * comparable numeric tuple. Pre-release identifiers and Go pseudo-versions sort
+ * lower than any real semver release. Returns -Infinity if the input is unparseable
+ * so we can fail loudly rather than silently passing.
+ */
+function parseVersionTuple(raw: string): [number, number, number, string] {
+  const stripped = raw.trim().replace(/^v/, '');
+  // Go pseudo-version like 0.0.0-20200820211705-5c72a883971a → [0, 0, 0, 'pre']
+  const semverMatch = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+](.*))?$/);
+  if (!semverMatch) return [-Infinity, -Infinity, -Infinity, ''];
+  const [, major, minor, patch, suffix] = semverMatch;
+  return [Number(major), Number(minor), Number(patch), suffix ?? ''];
+}
+
+function compareVersions(a: string, b: string): number {
+  const [aMaj, aMin, aPatch, aSuffix] = parseVersionTuple(a);
+  const [bMaj, bMin, bPatch, bSuffix] = parseVersionTuple(b);
+  if (aMaj !== bMaj) return aMaj - bMaj;
+  if (aMin !== bMin) return aMin - bMin;
+  if (aPatch !== bPatch) return aPatch - bPatch;
+  // A non-empty suffix sorts lower than an empty one (e.g. 0.0.0-pre < 0.0.0).
+  if (aSuffix === '' && bSuffix !== '') return 1;
+  if (aSuffix !== '' && bSuffix === '') return -1;
+  return aSuffix.localeCompare(bSuffix);
+}
+
+describe('F06-NEW-12: critical Dependabot advisory regression guards', () => {
+  describe('GHSA-xq3m-2v4x-88gg — protobufjs RCE', () => {
+    // Vulnerable range: < 7.5.5. Patched: 7.5.5+. Comes in transitively via
+    // dockerode → @grpc/proto-loader → protobufjs.
+    const PATCHED = '7.5.5';
+
+    it('package.json has an overrides entry forcing protobufjs to the patched range', () => {
+      const pkg = JSON.parse(readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8')) as {
+        overrides?: Record<string, string>;
+        resolutions?: Record<string, string>;
+      };
+      // Either npm-style `overrides` or yarn-style `resolutions` is acceptable; the
+      // bun and npm lockfiles both honour these. Without one, transitive resolutions
+      // pick the highest 7.x satisfying the consumer's `^7.3.2` constraint, which on
+      // April 29, 2026 was still 7.5.4 (vulnerable).
+      const override = pkg.overrides?.protobufjs ?? pkg.resolutions?.protobufjs;
+      expect(override, 'package.json must declare an override for protobufjs').toBeTruthy();
+      // The override must demand at least the patched version.
+      const overrideMin = (override ?? '').replace(/^[~^>=<]+/, '').trim();
+      expect(compareVersions(overrideMin, PATCHED)).toBeGreaterThanOrEqual(0);
+    });
+
+    it('bun.lock resolves protobufjs to >= 7.5.5', () => {
+      const lock = readFileSync(resolve(REPO_ROOT, 'bun.lock'), 'utf8');
+      // Bun lockfile entry shape: `"protobufjs": ["protobufjs@<version>", ...`
+      const match = lock.match(/^\s*"protobufjs":\s*\["protobufjs@([\d.]+)"/m);
+      expect(match, 'bun.lock must contain a top-level protobufjs entry').toBeTruthy();
+      if (!match) return;
+      const resolved = match[1];
+      expect(compareVersions(resolved, PATCHED)).toBeGreaterThanOrEqual(0);
+    });
+
+    it('package-lock.json resolves protobufjs to >= 7.5.5', () => {
+      const lock = readFileSync(resolve(REPO_ROOT, 'package-lock.json'), 'utf8');
+      // package-lock.json shape: `"node_modules/protobufjs": { "version": "<v>", ...`
+      const idx = lock.indexOf('"node_modules/protobufjs"');
+      expect(idx).toBeGreaterThan(0);
+      const slice = lock.slice(idx, idx + 400);
+      const versionMatch = slice.match(/"version":\s*"([\d.]+)"/);
+      expect(versionMatch, 'package-lock.json protobufjs entry must have a version').toBeTruthy();
+      if (!versionMatch) return;
+      expect(compareVersions(versionMatch[1], PATCHED)).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('GHSA-v778-237x-gjrc — golang.org/x/crypto authorization bypass', () => {
+    // Vulnerable range: < 0.31.0. Patched: 0.31.0+. The cli/ Go module pulls x/crypto
+    // transitively via Masterminds/sprig (used for templating). The SSH surface is
+    // not exercised by our CLI but the advisory still requires a bump because Go's
+    // module graph elevates the highest pinned version per build.
+    const PATCHED = '0.31.0';
+
+    it('cli/go.mod requires golang.org/x/crypto >= 0.31.0', () => {
+      const goMod = readFileSync(resolve(REPO_ROOT, 'cli/go.mod'), 'utf8');
+      // Match: `golang.org/x/crypto v<version>` (with optional `// indirect` suffix).
+      // Also reject pseudo-versions like `v0.0.0-<timestamp>-<sha>` — those map to
+      // pre-release < any real release and are usually pre-0.31.0.
+      const match = goMod.match(/^\s*golang\.org\/x\/crypto\s+v([\d.]+)(?:-[a-f0-9]+)?/m);
+      expect(match, 'cli/go.mod must contain a golang.org/x/crypto require line').toBeTruthy();
+      if (!match) return;
+      const requested = match[1];
+      // Reject Go pseudo-versions explicitly — they're 0.0.0 with a date stamp and
+      // always represent a pre-0.31.0 commit.
+      expect(requested).not.toBe('0.0.0');
+      expect(compareVersions(requested, PATCHED)).toBeGreaterThanOrEqual(0);
+    });
+
+    it('cli/go.sum has a checksum entry for the patched version', () => {
+      const goSum = readFileSync(resolve(REPO_ROOT, 'cli/go.sum'), 'utf8');
+      // Look for the exact patched-version line; if `go mod tidy` was skipped after
+      // editing go.mod, the build would fail at compile time but this test catches
+      // the inconsistency earlier.
+      expect(goSum).toMatch(new RegExp(`golang\\.org/x/crypto v${PATCHED.replace(/\./g, '\\.')}`));
+    });
+  });
+});

--- a/tests/integration/release-workflows.test.ts
+++ b/tests/integration/release-workflows.test.ts
@@ -55,6 +55,28 @@ describe('F11-01: release.yml workflow', () => {
     expect(yaml).toContain("exit-code: '1'");
   });
 
+  // F06-NEW-12: Critical Dependabot advisory GHSA-69fq-xp46-6x23 (Trivy supply chain compromise).
+  // The trivy-action repo had 76 of 77 version tags force-pushed to malicious commits during
+  // the March 19-22, 2026 incident. Only v0.35.0 onward (protected by GitHub immutable releases)
+  // is safe; tags 0.0.1 - 0.34.2 are forever compromised. We pin to a SHA for defense-in-depth
+  // because the safe tags themselves remain mutable in principle. Failing on `main` (which uses
+  // `@0.30.0` tag — vulnerable) and passing here proves the regression test bar.
+  it('pins trivy-action to a SHA for v0.35.0+ (GHSA-69fq-xp46-6x23)', () => {
+    const yaml = readFileSync(resolve(WORKFLOWS, 'release.yml'), 'utf8');
+    // Reject any vulnerable tag form (anything ≤ 0.34.x without v-prefix; bare `@0.x.y` form).
+    // The safe forms are: `@<40-char SHA>` or `@v0.35.0+` (v-prefix) or `@v0.34.x` (re-pinned).
+    expect(yaml).not.toMatch(/aquasecurity\/trivy-action@0\.(?:[12]\d|3[0-4])\.\d+/);
+    // Require either a 40-char SHA pin OR an explicit v0.35.0+ tag.
+    const trivyPin = yaml.match(/aquasecurity\/trivy-action@([\w.-]+)/);
+    expect(trivyPin).toBeTruthy();
+    if (!trivyPin) return;
+    const ref = trivyPin[1];
+    // Either a full SHA (40 hex chars) or a v0.35+ tag.
+    const sha40 = /^[a-f0-9]{40}$/.test(ref);
+    const safeTag = /^v0\.(3[5-9]|[4-9]\d)\.\d+$/.test(ref) || /^v[1-9]\d*\.\d+\.\d+$/.test(ref);
+    expect(sha40 || safeTag).toBe(true);
+  });
+
   it('packages the Helm chart via helm package', () => {
     const yaml = readFileSync(resolve(WORKFLOWS, 'release.yml'), 'utf8');
     expect(yaml).toContain('helm package charts/agentpane');


### PR DESCRIPTION
## Summary

Triages and closes the 3 critical Dependabot advisories on `agentdevsl/agentpane`, addressing finding **F06-NEW-12** in `specs/arch_review_april29/06-security.md`.

| Advisory | Severity | Resolution |
|---|---|---|
| [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) — protobufjs RCE (< 7.5.5) | Critical | `overrides`/`resolutions` entry in `package.json` forces transitive resolution to 7.5.6 (was 7.5.4). |
| [GHSA-69fq-xp46-6x23](https://github.com/advisories/GHSA-69fq-xp46-6x23) — aquasecurity/trivy-action supply-chain compromise (≤ 0.34.2) | Critical | `release.yml`: `@0.30.0` (vulnerable) → SHA-pinned `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0, immutable release). |
| [GHSA-v778-237x-gjrc](https://github.com/advisories/GHSA-v778-237x-gjrc) — golang.org/x/crypto auth bypass (< 0.31.0) | Critical | `cli/go.mod`: `v0.0.0-20200820211705` → `v0.31.0`. Side-benefit: same bump auto-closes 4 high + 4 medium x/crypto SSH advisories. |

After merge, `gh api repos/agentdevsl/agentpane/dependabot/alerts | jq '[.[] | select(.state == \"open\" and .security_vulnerability.severity == \"critical\")] | length'` should drop from 3 → 0 once Dependabot re-scans.

## Test plan

**Test bar (red→green)**: 6 tests fail on `main`, all 15 pass with the fix.

```
npx vitest run tests/integration/dependency-advisories.test.ts tests/integration/release-workflows.test.ts
```

- [x] `tests/integration/dependency-advisories.test.ts` (new): parses `package.json`, `bun.lock`, `package-lock.json`, `cli/go.mod`, `cli/go.sum` and asserts the resolved versions are no longer in the vulnerable range. **5 tests** (3 protobufjs + 2 golang/x/crypto), all passing.
- [x] `tests/integration/release-workflows.test.ts` (extended): added `pins trivy-action to a SHA for v0.35.0+ (GHSA-69fq-xp46-6x23)` test. Rejects any `aquasecurity/trivy-action@0.{10..34}.x` reference; requires either a 40-char SHA or `v0.35.0+` tag. **+1 test**, passing.
- [x] `npx tsc --noEmit` — clean
- [x] `npx @biomejs/biome check --max-diagnostics=500 --diagnostic-level=error` — clean
- [x] `cd cli && go build ./... && go mod verify` — clean
- [x] Pre-commit hooks — all pass (Biome, TSC, secrets, YAML, etc.)
- [x] Lockfiles regenerated and committed (`bun.lock`, `package-lock.json`, `cli/go.sum`)

## Status vs April 29 review

- **F06-NEW-12** — `06-security.md` updated with a "Resolution status (PR W3-A)" subsection documenting which advisory each commit closes, the regression test that proves it, and the deferred follow-ups (medium-severity uuid + esbuild advisories).

## Hard constraints honoured

- No new infrastructure (only lockfile + workflow + Go module bumps).
- No raw SQL / Drizzle changes (no DB schema impact).
- Lockfiles committed (`bun.lock` for bun CI `--frozen-lockfile`, `package-lock.json` for npm consumers, `cli/go.sum` for Go).
- Title format `fix(arch29-W3-A):` per plan convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
