### PR TITLE
fix(arch29-W3-B): Helm sandbox image + backup CronJob (F11-20, F11-21)

### DIFF
--- a/charts/agentpane/Chart.yaml
+++ b/charts/agentpane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentpane
 description: AgentPane - AI agent orchestration platform with Kubernetes-native agent execution
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.0.0"
 kubeVersion: ">=1.28.0-0"
 keywords:

--- a/charts/agentpane/templates/_helpers.tpl
+++ b/charts/agentpane/templates/_helpers.tpl
@@ -165,9 +165,8 @@ Container image reference
 {{- end }}
 
 {{/*
-Sandbox container image reference
+F11-20: a `agentpane.sandbox.image` helper used to live here; it was unused
+by every template and the chart `sandbox.image` value was never read by the
+runtime (the DB `sandbox.defaults.image` setting is the source of truth).
+Both have been removed to eliminate operator confusion.
 */}}
-{{- define "agentpane.sandbox.image" -}}
-{{- $tag := .Values.sandbox.image.tag | default .Chart.AppVersion }}
-{{- printf "%s:%s" .Values.sandbox.image.repository $tag }}
-{{- end }}

--- a/charts/agentpane/templates/cronjob-backup.yaml
+++ b/charts/agentpane/templates/cronjob-backup.yaml
@@ -1,0 +1,136 @@
+{{- if .Values.backup.enabled }}
+{{- /*
+F11-21 (arch29 review): Periodic database backup CronJob.
+
+The April 29 review flagged that `scripts/backup-db-pg.sh` and
+`scripts/backup-db.sh` exist but are never invoked — there is no
+CronJob, no documented restore drill, and a fresh `helm install`
+produces a deployment with zero backups. This template fixes that:
+
+  * Default OFF (`backup.enabled: false`) so a fresh install does
+    not silently provision a PVC the operator did not ask for.
+  * Default schedule is `0 3 * * *` (daily 03:00 UTC) — quiet
+    enough to avoid contending with the Helm `pre-upgrade`
+    migration hook (F11-05) which is operator-triggered.
+  * The Job runs inside the main app image (`agentpane.image`),
+    so `pg_dump` (Postgres) and `sqlite3` (SQLite) plus the
+    backup scripts are already present — no separate image
+    needed.
+  * Backups are written to a dedicated PVC mounted at `/backups`.
+    The backup script keeps the most recent `retentionDays`
+    artefacts and cleans the rest.
+  * `restartPolicy: OnFailure` so transient pg_dump errors retry
+    inside the same Pod.
+  * The restore drill is documented in
+    `specs/application/operations/backup-restore.md`.
+*/ -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "agentpane.fullname" . }}-backup
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  {{- with .Values.backup.timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy | default "Forbid" }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit | default 3 }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "agentpane.labels" . | nindent 8 }}
+        app.kubernetes.io/component: backup
+    spec:
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds | default 1800 }}
+      backoffLimit: {{ .Values.backup.backoffLimit | default 2 }}
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            {{- include "agentpane.labels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "agentpane.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.backup.podSecurityContext | nindent 12 }}
+          containers:
+            - name: backup
+              image: {{ if .Values.backup.image.repository }}{{ printf "%s:%s" .Values.backup.image.repository (.Values.backup.image.tag | default .Chart.AppVersion) }}{{ else }}{{ include "agentpane.image" . }}{{ end }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy | default "IfNotPresent" }}
+              securityContext:
+                {{- toYaml .Values.backup.securityContext | nindent 16 }}
+              command: ["/bin/sh", "-c"]
+              {{- if eq .Values.database.mode "postgres" }}
+              args:
+                - |
+                  set -euo pipefail
+                  echo "[backup] AgentPane Postgres backup starting at $(date -u +%FT%TZ)"
+                  exec /app/scripts/backup-db-pg.sh /backups
+              {{- else }}
+              args:
+                - |
+                  set -euo pipefail
+                  echo "[backup] AgentPane SQLite backup starting at $(date -u +%FT%TZ)"
+                  exec /app/scripts/backup-db.sh /backups
+              {{- end }}
+              envFrom:
+                - configMapRef:
+                    name: {{ include "agentpane.fullname" . }}
+              env:
+                - name: MAX_BACKUPS
+                  value: {{ .Values.backup.retentionDays | quote }}
+                {{- if and .Values.database.external.enabled .Values.database.external.existingSecret }}
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.database.external.existingSecret }}
+                      key: {{ .Values.database.external.secretKeys.urlKey | default "DATABASE_URL" }}
+                {{- else if eq .Values.database.mode "postgres" }}
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "agentpane.database.secretName" . }}
+                      key: {{ include "agentpane.database.passwordKey" . }}
+                - name: DATABASE_URL
+                  value: {{ include "agentpane.database.url" . | quote }}
+                {{- end }}
+                {{- with .Values.backup.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+                - name: tmp
+                  mountPath: /tmp
+                {{- if and (ne .Values.database.mode "postgres") .Values.persistence.enabled }}
+                - name: data
+                  mountPath: /app/data
+                  readOnly: true
+                {{- end }}
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: {{ include "agentpane.fullname" . }}-backup
+            - name: tmp
+              emptyDir: {}
+            {{- if and (ne .Values.database.mode "postgres") .Values.persistence.enabled }}
+            - name: data
+              persistentVolumeClaim:
+                claimName: {{ include "agentpane.fullname" . }}-data
+            {{- end }}
+          {{- with .Values.backup.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backup.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/agentpane/templates/pvc-backup.yaml
+++ b/charts/agentpane/templates/pvc-backup.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.backup.enabled .Values.backup.pvc.create }}
+{{- /*
+F11-21: PVC for the backup CronJob (cronjob-backup.yaml). Only rendered when
+both `backup.enabled` and `backup.pvc.create` are true. Operators who manage
+their own backup volume (e.g. via a CSI snapshot pipeline) should set
+`backup.pvc.create: false` and pre-create a PVC named
+`<release>-agentpane-backup`.
+*/ -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agentpane.fullname" . }}-backup
+  labels:
+    {{- include "agentpane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+  {{- with .Values.backup.pvc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.backup.pvc.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.pvc.size | default "5Gi" | quote }}
+  {{- if .Values.backup.pvc.storageClass }}
+  storageClassName: {{ .Values.backup.pvc.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/agentpane/values.yaml
+++ b/charts/agentpane/values.yaml
@@ -248,6 +248,119 @@ deploymentStrategy:
   maxUnavailable: 0
 
 # -----------------------------------------------------------------------------
+# Backup CronJob (F11-21)
+# -----------------------------------------------------------------------------
+# Periodic database backups via `scripts/backup-db-pg.sh` (Postgres) or
+# `scripts/backup-db.sh` (SQLite). Disabled by default so a fresh `helm
+# install` does not require a backup PVC; operators must opt in by setting
+# `backup.enabled: true` and provisioning a PVC of size `backup.pvc.size`.
+#
+# The CronJob runs the backup script (already in the app image at
+# `/app/scripts/backup-db-pg.sh`) and writes timestamped artefacts to a
+# dedicated `backup` PVC mounted at `/backups`. Old backups beyond
+# `backup.retentionDays` are cleaned up by the script itself.
+#
+# The restore drill is documented in `specs/application/operations/backup-restore.md`.
+backup:
+  # -- Create a CronJob that runs database backups on a schedule. Default
+  # disabled — opt-in to avoid surprise PVC provisioning on a fresh install.
+  enabled: false
+
+  # -- Cron schedule expression (default: daily at 03:00 UTC). All times are
+  # interpreted in the cluster's `kube-controller-manager` timezone (usually
+  # UTC). Pin a specific timezone with `backup.timeZone` if your cluster
+  # supports `CronJob.spec.timeZone` (Kubernetes >= 1.27).
+  schedule: "0 3 * * *"
+
+  # -- Optional IANA timezone for the CronJob (Kubernetes >= 1.27). Leave
+  # blank to use the controller's default (typically UTC).
+  timeZone: ""
+
+  # -- Number of backup artefacts to keep on the PVC. The backup script's
+  # MAX_BACKUPS env var maps directly. Older artefacts are removed by the
+  # script after each successful run.
+  retentionDays: 7
+
+  # -- ConcurrencyPolicy: Forbid prevents overlapping runs if a backup runs
+  # long; Allow runs in parallel; Replace cancels the running one.
+  concurrencyPolicy: Forbid
+
+  # -- Number of successful job histories to retain
+  successfulJobsHistoryLimit: 3
+
+  # -- Number of failed job histories to retain (helps post-mortem)
+  failedJobsHistoryLimit: 3
+
+  # -- activeDeadlineSeconds for each backup Job (default: 30 minutes)
+  activeDeadlineSeconds: 1800
+
+  # -- Number of retries on Job failure
+  backoffLimit: 2
+
+  # -- PodSecurityContext for the backup Pod. Backups run as the same
+  # non-root user as the main app container.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- securityContext for the backup container
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  pvc:
+    # -- Create a dedicated PVC to hold backup artefacts. If false you must
+    # pre-create a PVC named `<release>-agentpane-backup` and mount it.
+    create: true
+    # -- Storage class (empty = cluster default)
+    storageClass: ""
+    # -- PVC access mode. Backups are typically `ReadWriteOnce` since only
+    # one CronJob Pod writes at a time.
+    accessMode: ReadWriteOnce
+    # -- PVC size — sized for ~30 daily snapshots of a small AgentPane DB.
+    size: 5Gi
+    # -- Additional annotations for the backup PVC
+    annotations: {}
+
+  # -- Image used by the backup Job. Defaults to the main app image so
+  # `scripts/backup-db-pg.sh` and the `pg_dump`/`sqlite3` binaries are
+  # available with no extra build. To use a separate image with only the
+  # backup tooling, override `image.repository` / `image.tag`.
+  image:
+    # -- Image repository; empty string means "use the main app image"
+    repository: ""
+    # -- Image tag override; empty string means "use the main image's tag"
+    tag: ""
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+
+  # -- Resource requests/limits for the backup Pod (small, one-shot)
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # -- Optional node selector for the backup Pod (e.g. pin to a node label
+  # like `kubernetes.io/role: backup`).
+  nodeSelector: {}
+
+  # -- Optional tolerations for the backup Pod
+  tolerations: []
+
+  # -- Additional environment variables passed to the backup script
+  extraEnv: []
+
+# -----------------------------------------------------------------------------
 # Pre-upgrade Migration Hook (F11-05)
 # -----------------------------------------------------------------------------
 # A Helm pre-upgrade/pre-install Job applies migrations once before the
@@ -363,8 +476,21 @@ topologySpreadConstraints: []
 # Prerequisites:
 #   1. Install Agent Sandbox CRDs: kubectl apply -f k8s/manifests/crds.yaml
 #   2. Deploy the agent-sandbox controller to the cluster
-# Sandbox provider settings are stored in the database (sandbox.defaults,
-# sandbox.kubernetes keys) and can be managed via the Settings UI.
+#
+# Sandbox provider settings (provider type, image digest, resource limits,
+# network mode, etc.) are stored in the application database under the
+# `sandbox.defaults` and `sandbox.kubernetes` setting keys. They are NOT
+# rendered into Kubernetes manifests by this chart — the runtime sandbox
+# provider reads them from the DB at agent-start time, and they are managed
+# via the Settings UI or `PUT /api/settings`.
+#
+# F11-20 (arch29 review): an earlier version of this chart exposed
+# `sandbox.image.repository`/`tag` here, but those values were never read at
+# runtime — the DB was the source of truth all along. To prevent operator
+# confusion we deleted the decorative block; to override the sandbox image,
+# update the `sandbox.defaults.image` setting via the API or UI. The default
+# (`SANDBOX_DEFAULTS.image` in `src/lib/sandbox/types.ts`) is digest-pinned
+# and theme-04 P0-01 enforces digest pinning on any override.
 # -----------------------------------------------------------------------------
 sandbox:
   # -- Enable agent sandbox pod management and RBAC
@@ -374,14 +500,6 @@ sandbox:
   # the app will use the Agent Sandbox CRD provider; "docker" uses local Docker.
   # This is the default provider written to the database on first startup.
   provider: kubernetes
-
-  image:
-    # -- Agent sandbox container image repository
-    repository: agentpane/agent-sandbox
-    # -- Image pull policy for sandbox pods
-    pullPolicy: IfNotPresent
-    # -- Overrides the sandbox image tag
-    tag: ""
 
   # -- Namespace for agent sandbox pods
   namespace: agentpane-sandboxes

--- a/specs/application/operations/backup-restore.md
+++ b/specs/application/operations/backup-restore.md
@@ -1,0 +1,255 @@
+# Backup and Restore
+
+This document covers the AgentPane database backup and restore drill. It is
+the operational runbook referenced from the architecture review (theme 11
+finding F11-21) and from the rollback runbook (F11-29). It assumes the
+operator has cluster access for Kubernetes deployments and host shell access
+for Docker / bare-metal deployments.
+
+> **Status:** the `scripts/backup-db-pg.sh` and `scripts/backup-db.sh` scripts
+> are checked into the repo; the Helm chart `charts/agentpane/templates/cronjob-backup.yaml`
+> wires them to a `CronJob` (default disabled — opt-in via
+> `backup.enabled: true`). For Docker Compose / bare-metal you are
+> responsible for scheduling the script (cron, systemd timers, etc.).
+
+## 1. Quick reference
+
+| Mode       | Backup script               | Output filename                | Restore command                                    |
+|------------|-----------------------------|--------------------------------|-----------------------------------------------------|
+| PostgreSQL | `scripts/backup-db-pg.sh`   | `agentpane_pg_<ts>.dump`        | `pg_restore --clean --if-exists --dbname=$URL ...` |
+| SQLite     | `scripts/backup-db.sh`      | `agentpane_<ts>.db`             | `cp <file> ./data/agentpane.db`                    |
+
+Both scripts:
+
+* run with `set -euo pipefail` so any error aborts the run;
+* `umask 077` (PG) so files are owner-only readable;
+* trap on `ERR` to remove partial artefacts (PG);
+* keep the most recent `MAX_BACKUPS` (default `7`) artefacts and prune older ones;
+* write to `./data/backups/` by default — pass an alternative directory as `$1`.
+
+## 2. Helm CronJob (Kubernetes)
+
+### 2.1 Enable the CronJob
+
+```bash
+helm upgrade agentpane charts/agentpane \
+  --reuse-values \
+  --set backup.enabled=true \
+  --set backup.schedule="0 3 * * *" \
+  --set backup.retentionDays=7 \
+  --set backup.pvc.size=5Gi
+```
+
+What this renders:
+
+* `cronjob-backup.yaml` — `kind: CronJob` named `<release>-agentpane-backup`,
+  schedule `0 3 * * *` (daily 03:00 UTC), `concurrencyPolicy: Forbid`,
+  `restartPolicy: OnFailure`, `activeDeadlineSeconds: 1800`.
+* `pvc-backup.yaml` — `kind: PersistentVolumeClaim` named
+  `<release>-agentpane-backup`, `5Gi`, `ReadWriteOnce`. Mounted at `/backups`
+  inside the backup Pod. Suppress this if you bring your own PVC: set
+  `backup.pvc.create: false`.
+* The Job uses the **main app image** (`agentpane.image`) so `pg_dump` /
+  `sqlite3` and the backup scripts are already present — no separate image
+  build is required.
+
+### 2.2 Verify the CronJob is healthy
+
+```bash
+# Confirm the CronJob is registered
+kubectl get cronjob -l app.kubernetes.io/component=backup
+
+# Wait for the next scheduled run, or trigger a one-shot backup now:
+kubectl create job --from=cronjob/agentpane-backup agentpane-backup-manual-$(date +%s)
+kubectl get jobs -l app.kubernetes.io/component=backup -w
+
+# Inspect the backup PVC contents
+kubectl run --rm -it backup-inspect \
+  --image=busybox:1.36 \
+  --overrides='{"spec":{"containers":[{"name":"backup-inspect","image":"busybox:1.36","command":["sh"],"stdin":true,"tty":true,"volumeMounts":[{"mountPath":"/backups","name":"backups"}]}],"volumes":[{"name":"backups","persistentVolumeClaim":{"claimName":"agentpane-backup"}}]}}' \
+  -- ls -lh /backups
+```
+
+You should see `agentpane_pg_YYYYMMDD_HHMMSS.dump` files (or
+`agentpane_YYYYMMDD_HHMMSS.db` in SQLite mode) sized roughly proportional to
+the live DB.
+
+### 2.3 Pre-upgrade snapshot (optional but recommended)
+
+The Helm `pre-upgrade` migration Job runs DDL atomically, but a multi-table
+migration that fails halfway leaves the operator without a pre-migration
+snapshot. To capture one before the migration hook fires, trigger a manual
+backup:
+
+```bash
+kubectl create job --from=cronjob/agentpane-backup agentpane-backup-pre-upgrade
+kubectl wait --for=condition=complete job/agentpane-backup-pre-upgrade --timeout=20m
+kubectl logs job/agentpane-backup-pre-upgrade
+helm upgrade agentpane charts/agentpane --reuse-values  # proceed with upgrade
+```
+
+If the upgrade fails, the most recent backup is the recovery target
+(see §3 below).
+
+## 3. Restore drill — step by step
+
+The restore drill assumes you have a recent backup artefact and need to
+restore it onto a target cluster (either to roll back a bad migration or to
+recover from data loss). The drill is **destructive** — it overwrites the
+current database — so always confirm the artefact integrity before running it
+against a production cluster.
+
+### 3.1 PostgreSQL restore (Kubernetes)
+
+```bash
+# 0. Establish a maintenance window. Stop the AgentPane Deployment.
+kubectl scale deployment agentpane --replicas=0
+
+# 1. Pick a backup artefact. Backups are sorted by timestamp; pick the last
+#    known-good one before the incident.
+BACKUP="/backups/agentpane_pg_20260429_030000.dump"
+
+# 2. Verify the backup is readable by pg_restore. This catches truncation
+#    and corruption before you touch the live DB.
+kubectl run --rm -it backup-verify \
+  --image=ghcr.io/agentdevsl/agentpane:1.0.0 \
+  --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"backup-verify","image":"ghcr.io/agentdevsl/agentpane:1.0.0","command":["pg_restore","--list","'"$BACKUP"'"],"volumeMounts":[{"mountPath":"/backups","name":"backups"}]}],"volumes":[{"name":"backups","persistentVolumeClaim":{"claimName":"agentpane-backup"}}]}}'
+
+# 3. Drop and recreate the database from a maintenance Pod. The backup Pod
+#    image already has psql + pg_restore.
+kubectl run --rm -it db-restore \
+  --image=ghcr.io/agentdevsl/agentpane:1.0.0 \
+  --restart=Never \
+  --env="DATABASE_URL=$(kubectl get secret agentpane-postgresql -o jsonpath='{.data.password}' | base64 -d | xargs -I{} printf 'postgresql://agentpane:{}@agentpane-postgresql:5432/agentpane?sslmode=disable')" \
+  --overrides='{"spec":{"containers":[{"name":"db-restore","image":"ghcr.io/agentdevsl/agentpane:1.0.0","command":["sh","-c","pg_restore --clean --if-exists --no-owner --no-privileges --dbname=\"$DATABASE_URL\" /backups/agentpane_pg_20260429_030000.dump"],"volumeMounts":[{"mountPath":"/backups","name":"backups"}]}],"volumes":[{"name":"backups","persistentVolumeClaim":{"claimName":"agentpane-backup"}}]}}'
+
+# 4. Verify the restored DB. The `schema_migrations` table should reflect
+#    the migrations the restored snapshot was taken against — NOT necessarily
+#    the latest. Confirm before scaling back up.
+kubectl run --rm -it db-verify \
+  --image=ghcr.io/agentdevsl/agentpane:1.0.0 \
+  --restart=Never \
+  --env="DATABASE_URL=$(kubectl get secret agentpane-postgresql -o jsonpath='{.data.password}' | base64 -d | xargs -I{} printf 'postgresql://agentpane:{}@agentpane-postgresql:5432/agentpane?sslmode=disable')" \
+  --command -- psql "$DATABASE_URL" -c "select count(*) as migrations from schema_migrations;"
+
+# 5. If the restore brings the DB back to a state that pre-dates the current
+#    chart's migrations, run `bun run migrate:run-only` ONCE to bring it up to
+#    speed. The Helm pre-upgrade Job is the canonical way to do this in
+#    production:
+helm upgrade agentpane charts/agentpane --reuse-values --recreate-pods=false
+
+# 6. Scale back up. App pods will run migrate-check-only as an init container
+#    (F11-17) and refuse to start if the schema is still behind.
+kubectl scale deployment agentpane --replicas=1
+kubectl rollout status deployment/agentpane
+kubectl logs deployment/agentpane | grep -i 'migrate\|schema'
+```
+
+### 3.2 PostgreSQL restore (Docker Compose / bare-metal)
+
+```bash
+# 1. Stop the app
+docker compose down agentpane
+
+# 2. Verify the backup
+pg_restore --list ./data/backups/agentpane_pg_20260429_030000.dump | head
+
+# 3. Restore (pg_restore --clean drops existing schema first)
+DATABASE_URL='postgresql://agentpane:agentpane_dev@localhost:5432/agentpane' \
+  pg_restore --clean --if-exists --no-owner --no-privileges \
+  --dbname="$DATABASE_URL" \
+  ./data/backups/agentpane_pg_20260429_030000.dump
+
+# 4. Verify
+psql "$DATABASE_URL" -c "select count(*) from schema_migrations;"
+
+# 5. Apply any newer migrations and start
+bun run migrate:run-only
+docker compose up agentpane
+```
+
+### 3.3 SQLite restore (Docker Compose / bare-metal)
+
+```bash
+# 1. Stop the app
+docker compose down agentpane
+
+# 2. Pick the backup artefact and verify integrity
+BACKUP=./data/backups/agentpane_20260429_030000.db
+sqlite3 "$BACKUP" "PRAGMA integrity_check;"
+# Expected output: ok
+
+# 3. Capture a checksum so the restore is auditable
+sha256sum "$BACKUP" > "$BACKUP.sha256"
+
+# 4. Remove WAL/SHM sidecar files (otherwise they will be replayed on top
+#    of the restored DB and corrupt it). The backup script already issued a
+#    PRAGMA wal_checkpoint(TRUNCATE) before copying, so the artefact is a
+#    point-in-time snapshot with no outstanding WAL.
+rm -f ./data/agentpane.db-wal ./data/agentpane.db-shm
+
+# 5. Atomic move: restore the DB file
+cp "$BACKUP" ./data/agentpane.db.new
+mv ./data/agentpane.db.new ./data/agentpane.db
+
+# 6. Verify the restored DB
+sqlite3 ./data/agentpane.db "PRAGMA integrity_check;"
+sqlite3 ./data/agentpane.db "select count(*) from schema_migrations;"
+
+# 7. Apply any newer migrations and start. The migration runner is
+#    idempotent: migrations whose journal entry already exists are skipped.
+bun run migrate:run-only
+docker compose up agentpane
+```
+
+## 4. Rehearsal cadence
+
+Backups that have never been restored aren't backups; they are write-only
+files. The recommended cadence is:
+
+| Cadence    | Activity                                                                                          |
+|------------|---------------------------------------------------------------------------------------------------|
+| Weekly     | Cron-driven smoke test — restore the most recent backup into a throwaway namespace and run `bun run migrate:check-only` against it. Pass = the migration ledger and schema match what the binary expects. |
+| Monthly    | End-to-end drill — restore into a parallel cluster, point a non-production app instance at it, and exercise a representative workflow (create codespace, start agent, approve plan). |
+| Per-incident | Whenever the migration Job fails or the rollback runbook (F11-29) is invoked. Capture timing data and update this doc if a step needs tightening. |
+
+## 5. Troubleshooting
+
+### "pg_restore: error: could not open input file"
+
+The backup PVC was unmounted or the path is wrong. Confirm the file exists
+inside the backup Pod (`kubectl exec` into a fresh Pod that mounts the same
+PVC). If the PVC is empty, the CronJob hasn't run yet — trigger a manual run
+(see §2.2).
+
+### "ERROR: role agentpane does not exist"
+
+The restore image's `pg_restore` is trying to assign ownership to a role
+that doesn't exist on the target. Always use `--no-owner --no-privileges`
+in the restore command (see §3.1 step 3).
+
+### SQLite "database disk image is malformed"
+
+Either the backup was truncated mid-write or the WAL/SHM files were not
+removed before `cp`. Re-run `PRAGMA integrity_check` against the backup
+artefact to determine which. If the backup is corrupt, fall back to the
+prior artefact (the script keeps `MAX_BACKUPS` of them).
+
+### Backup PVC fills up
+
+Reduce `backup.retentionDays`, increase `backup.pvc.size`, or migrate to an
+external object store (CSI snapshot pipeline, S3 sidecar). The script's
+default of 7 daily backups at, e.g., 50MB each consumes well under 1GB; if
+you see runaway growth, audit the DB for unbounded tables (see
+`specs/arch_review_april/02-data-layer.md`).
+
+## 6. Cross-references
+
+* `scripts/backup-db-pg.sh` — Postgres backup script (canonical implementation).
+* `scripts/backup-db.sh` — SQLite backup script (canonical implementation).
+* `charts/agentpane/templates/cronjob-backup.yaml` — Helm CronJob wrapper.
+* `charts/agentpane/templates/pvc-backup.yaml` — Helm PVC for backup artefacts.
+* `specs/application/operations/deployment.md` §4.3 — high-level backup story.
+* `specs/arch_review_april29/11-operations-deployment.md` F11-21 — review finding addressed by this doc.
+* `specs/arch_review_april29/11-operations-deployment.md` F11-29 — rollback runbook that consumes the artefacts produced here.

--- a/specs/application/operations/deployment.md
+++ b/specs/application/operations/deployment.md
@@ -1033,86 +1033,57 @@ src/db/
 
 ### 4.3 Backup and Restore Procedures
 
-#### Backup Script
+The canonical backup scripts are checked into the repository:
+
+| Mode       | Script                       | Output                          |
+|------------|------------------------------|----------------------------------|
+| PostgreSQL | `scripts/backup-db-pg.sh`    | `agentpane_pg_<ts>.dump` (custom format, `--compress=6`, verified by `pg_restore --list`) |
+| SQLite     | `scripts/backup-db.sh`       | `agentpane_<ts>.db` (cold copy after `PRAGMA wal_checkpoint(TRUNCATE)`) |
+
+Both scripts run with `set -euo pipefail`, cap the artefact count at
+`MAX_BACKUPS` (default `7`), and write to `./data/backups/` unless overridden
+by the first positional argument. The Postgres script additionally uses
+`umask 077` and a `trap 'rm -f "$BACKUP_FILE"' ERR` to remove partial
+artefacts.
+
+#### Scheduling on Kubernetes
+
+The Helm chart ships a `CronJob` template at
+`charts/agentpane/templates/cronjob-backup.yaml`. It is **disabled by
+default** (so a fresh `helm install` doesn't surprise-provision a PVC) and
+opted into by setting `backup.enabled: true`:
 
 ```bash
-#!/bin/bash
-# scripts/backup-database.sh
-
-set -euo pipefail
-
-# Configuration
-DATA_DIR="${DATA_DIR:-./data}"
-BACKUP_DIR="${BACKUP_DIR:-./backups}"
-DB_FILE="agentpane.db"
-RETENTION_DAYS="${RETENTION_DAYS:-7}"
-
-# Create backup directory
-mkdir -p "$BACKUP_DIR"
-
-# Generate timestamp
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_FILE="$BACKUP_DIR/agentpane_${TIMESTAMP}.db"
-
-echo "[Backup] Starting database backup..."
-
-# Checkpoint WAL before backup (ensures consistency)
-if [ -f "$DATA_DIR/$DB_FILE" ]; then
-  sqlite3 "$DATA_DIR/$DB_FILE" "PRAGMA wal_checkpoint(TRUNCATE);"
-fi
-
-# Copy database file
-cp "$DATA_DIR/$DB_FILE" "$BACKUP_FILE"
-
-# Compress backup
-gzip "$BACKUP_FILE"
-BACKUP_FILE="${BACKUP_FILE}.gz"
-
-echo "[Backup] Created: $BACKUP_FILE"
-
-# Calculate size
-SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
-echo "[Backup] Size: $SIZE"
-
-# Clean up old backups
-echo "[Backup] Cleaning backups older than $RETENTION_DAYS days..."
-find "$BACKUP_DIR" -name "agentpane_*.db.gz" -mtime +$RETENTION_DAYS -delete
-
-echo "[Backup] Complete"
+helm upgrade agentpane charts/agentpane --reuse-values \
+  --set backup.enabled=true \
+  --set backup.schedule="0 3 * * *" \
+  --set backup.retentionDays=7 \
+  --set backup.pvc.size=5Gi
 ```
 
-#### Restore Script
+The CronJob runs the matching backup script (Postgres if `database.mode=postgres`,
+SQLite otherwise), writes to a `<release>-agentpane-backup` PVC at `/backups`,
+and cleans up older artefacts.
+
+#### Scheduling on Docker Compose / bare-metal
 
 ```bash
-#!/bin/bash
-# scripts/restore-database.sh
-
-set -euo pipefail
-
-DATA_DIR="${DATA_DIR:-./data}"
-BACKUP_DIR="${BACKUP_DIR:-./backups}"
-DB_FILE="agentpane.db"
-
-if [ $# -eq 0 ]; then
-  echo "Usage: $0 <backup-file>"
-  echo ""
-  echo "Available backups:"
-  ls -lh "$BACKUP_DIR"/*.gz 2>/dev/null || echo "  No backups found"
-  exit 1
-fi
-
-BACKUP_FILE="$1"
-
-# Stop AgentPane first
-# Remove WAL files
-rm -f "$DATA_DIR/$DB_FILE-wal" "$DATA_DIR/$DB_FILE-shm"
-
-# Restore from backup
-gunzip -c "$BACKUP_FILE" > "$DATA_DIR/$DB_FILE"
-
-# Verify restored database
-sqlite3 "$DATA_DIR/$DB_FILE" "PRAGMA integrity_check;"
+# crontab -e
+0 3 * * *  /opt/agentpane/scripts/backup-db-pg.sh /var/agentpane/backups
 ```
+
+#### Restore drill
+
+The full step-by-step restore drill — including how to verify a backup
+artefact, drop & recreate the database, run `migrate-check-only` after
+restore, and bring the app back online — lives in
+[`specs/application/operations/backup-restore.md`](./backup-restore.md). It
+covers Kubernetes (Helm + `kubectl run`), Docker Compose, and bare-metal
+flows for both PostgreSQL and SQLite.
+
+> **Operational requirement:** restore drills must be rehearsed weekly
+> (smoke test) and end-to-end monthly. A backup that has never been
+> restored is not a backup. See `backup-restore.md` §4 for the cadence.
 
 ---
 
@@ -1279,16 +1250,26 @@ kubectl rollout status deployment/agentpane
 
 #### Database Rollback
 
+The full restore drill — including verification, schema integrity checks,
+and the post-restore migration step — lives in
+[`backup-restore.md`](./backup-restore.md). The minimal flow:
+
 ```bash
 # If a migration caused issues:
 # 1. Stop the application
-docker stop agentpane
+docker compose down agentpane         # or: kubectl scale deploy agentpane --replicas=0
 
-# 2. Restore from pre-migration backup
-./scripts/restore-database.sh ./backups/agentpane_pre_migrate.db.gz
+# 2. PostgreSQL: pg_restore from the pre-migration snapshot
+pg_restore --clean --if-exists --no-owner --no-privileges \
+  --dbname="$DATABASE_URL" \
+  ./data/backups/agentpane_pg_<pre-upgrade-timestamp>.dump
 
-# 3. Deploy previous application version
-docker run ... agentpane:<previous-version>
+# 2. (alt) SQLite: cold copy
+rm -f ./data/agentpane.db-wal ./data/agentpane.db-shm
+cp ./data/backups/agentpane_<pre-upgrade-timestamp>.db ./data/agentpane.db
+
+# 3. Deploy previous application version (image digest pinned)
+docker run ... agentpane@sha256:<previous-digest>
 ```
 
 ---

--- a/tests/integration/helm-chart-template.test.ts
+++ b/tests/integration/helm-chart-template.test.ts
@@ -8,7 +8,7 @@
  * meaningful locally and in release preparation.
  */
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parseAllDocuments } from 'yaml';
@@ -25,13 +25,22 @@ function hasHelm(): boolean {
 }
 
 function renderChart(values: string[] = []): Array<Record<string, unknown>> {
+  // Use spawnSync with positional argv (no shell interpolation) so values
+  // containing characters like `*` (cron schedules) survive verbatim. This
+  // also avoids the F06-NEW-01 / W1-D shell-injection class of bug in test
+  // helpers — the same defence we apply in production.
   const args = ['template', 'test-release', CHART_PATH, ...values];
-  const output = execSync(`helm ${args.join(' ')}`, {
+  const result = spawnSync('helm', args, {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     maxBuffer: 16 * 1024 * 1024,
   });
-  const docs = parseAllDocuments(output)
+  if (result.status !== 0) {
+    throw new Error(
+      `helm template failed (status=${result.status}): ${result.stderr ?? ''}\n--- stdout ---\n${result.stdout ?? ''}`
+    );
+  }
+  const docs = parseAllDocuments(result.stdout)
     .map((d) => d.toJS() as Record<string, unknown> | null)
     .filter((d): d is Record<string, unknown> => d != null);
   return docs;
@@ -197,5 +206,184 @@ describeIfHelm('Helm chart template shape', () => {
       deployment?.spec as { template: { spec: { terminationGracePeriodSeconds?: number } } }
     )?.template.spec.terminationGracePeriodSeconds;
     expect(gracePeriod).toBeGreaterThanOrEqual(30);
+  });
+
+  // ---------------------------------------------------------------------------
+  // F11-20: chart-side `sandbox.image` was decorative — runtime reads the
+  // sandbox image from the DB `sandbox.defaults` setting, never from the chart.
+  // The fix deletes the value so operators can no longer be misled into
+  // thinking they can set the sandbox image via Helm. The runtime default
+  // (digest-pinned) lives in `src/lib/sandbox/types.ts` and is overridable
+  // via `PUT /api/settings`.
+  // ---------------------------------------------------------------------------
+  it('F11-20: chart values no longer expose sandbox.image (DB is the source of truth)', () => {
+    // Render with the new keys we DO ship for the sandbox block — provider
+    // type, namespace, etc. — but assert that no manifest references the
+    // removed `sandbox.image` shape. We also assert that overriding
+    // `sandbox.image.repository` is silently ignored (no template consumes it).
+    const docsDefault = renderChart();
+    const docsOverride = renderChart([
+      '--set',
+      'sandbox.image.repository=evil-attacker/sandbox',
+      '--set',
+      'sandbox.image.tag=latest',
+    ]);
+
+    // The two renders must be identical wrt manifests — confirming the
+    // sandbox.image override changes nothing.
+    const grepImage = (docs: Array<Record<string, unknown>>) =>
+      JSON.stringify(docs).match(/evil-attacker/g) ?? [];
+    expect(grepImage(docsDefault)).toHaveLength(0);
+    expect(grepImage(docsOverride)).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // F11-21: backup CronJob renders only when `backup.enabled=true`, otherwise
+  // a fresh `helm install` produces zero backups and the operator has no
+  // pre-migration snapshot to roll back to. The default is OFF so we don't
+  // surprise-provision a PVC on every install — operators opt in.
+  // ---------------------------------------------------------------------------
+  it('F11-21: default render produces no backup CronJob and no backup PVC', () => {
+    const docs = renderChart();
+    const cron = docs.find(
+      (d) =>
+        d.kind === 'CronJob' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    expect(cron).toBeUndefined();
+
+    const backupPvc = docs.find(
+      (d) =>
+        d.kind === 'PersistentVolumeClaim' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    expect(backupPvc).toBeUndefined();
+  });
+
+  it('F11-21: backup.enabled=true renders a CronJob and the matching PVC', () => {
+    const docs = renderChart(['--set', 'backup.enabled=true']);
+    const cron = docs.find(
+      (d) =>
+        d.kind === 'CronJob' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    expect(cron).toBeDefined();
+
+    const cronSpec = cron?.spec as {
+      schedule: string;
+      concurrencyPolicy: string;
+      jobTemplate: {
+        spec: {
+          template: {
+            spec: {
+              restartPolicy: string;
+              containers: Array<{ args: string[]; command: string[] }>;
+            };
+          };
+        };
+      };
+    };
+    expect(cronSpec.schedule).toBe('0 3 * * *');
+    expect(cronSpec.concurrencyPolicy).toBe('Forbid');
+
+    const podSpec = cronSpec.jobTemplate.spec.template.spec;
+    expect(podSpec.restartPolicy).toBe('OnFailure');
+
+    const container = podSpec.containers[0];
+    expect(container?.command).toEqual(['/bin/sh', '-c']);
+    // Postgres mode (default) should invoke the PG backup script.
+    expect(container?.args.join('\n')).toContain('/app/scripts/backup-db-pg.sh /backups');
+
+    const backupPvc = docs.find(
+      (d) =>
+        d.kind === 'PersistentVolumeClaim' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    expect(backupPvc).toBeDefined();
+    const pvcSpec = backupPvc?.spec as {
+      accessModes: string[];
+      resources: { requests: { storage: string } };
+    };
+    expect(pvcSpec.accessModes).toContain('ReadWriteOnce');
+    expect(pvcSpec.resources.requests.storage).toBe('5Gi');
+  });
+
+  it('F11-21: SQLite mode invokes scripts/backup-db.sh, not the Postgres script', () => {
+    const docs = renderChart([
+      '--set',
+      'backup.enabled=true',
+      '--set',
+      'database.mode=sqlite',
+      '--set',
+      'database.internal.enabled=false',
+      '--set',
+      'persistence.enabled=true',
+    ]);
+    const cron = docs.find(
+      (d) =>
+        d.kind === 'CronJob' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    const args =
+      (
+        cron?.spec as {
+          jobTemplate: {
+            spec: {
+              template: { spec: { containers: Array<{ args: string[] }> } };
+            };
+          };
+        }
+      ).jobTemplate.spec.template.spec.containers[0]?.args.join('\n') ?? '';
+    expect(args).toContain('/app/scripts/backup-db.sh /backups');
+    expect(args).not.toContain('/app/scripts/backup-db-pg.sh');
+  });
+
+  it('F11-21: backup.pvc.create=false suppresses the chart-managed PVC (operator manages volume)', () => {
+    const docs = renderChart(['--set', 'backup.enabled=true', '--set', 'backup.pvc.create=false']);
+    const cron = docs.find(
+      (d) =>
+        d.kind === 'CronJob' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    expect(cron).toBeDefined();
+
+    const backupPvc = docs.find(
+      (d) =>
+        d.kind === 'PersistentVolumeClaim' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    expect(backupPvc).toBeUndefined();
+  });
+
+  it('F11-21: backup.schedule and retentionDays propagate to the CronJob', () => {
+    // `renderChart` now uses argv (no shell interpolation), so `*` in a cron
+    // schedule survives verbatim.
+    const docs = renderChart([
+      '--set-string',
+      'backup.schedule=*/15 * * * *',
+      '--set',
+      'backup.enabled=true',
+      '--set',
+      'backup.retentionDays=14',
+    ]);
+    const cron = docs.find(
+      (d) =>
+        d.kind === 'CronJob' &&
+        (d.metadata as { name?: string })?.name === 'test-release-agentpane-backup'
+    );
+    const cronSpec = cron?.spec as {
+      schedule: string;
+      jobTemplate: {
+        spec: {
+          template: {
+            spec: { containers: Array<{ env: Array<{ name: string; value: string }> }> };
+          };
+        };
+      };
+    };
+    expect(cronSpec.schedule).toBe('*/15 * * * *');
+    const env = cronSpec.jobTemplate.spec.template.spec.containers[0]?.env ?? [];
+    const max = env.find((e) => e.name === 'MAX_BACKUPS');
+    expect(max?.value).toBe('14');
   });
 });


### PR DESCRIPTION
## Summary

Closes two P1 ops/deployment findings from `specs/arch_review_april29/11-operations-deployment.md`:

- **F11-20** — `helm/values.yaml`'s `sandbox.image` block was decorative: the runtime reads the sandbox image from the DB `sandbox.defaults` setting, never from the chart, so any operator override silently did nothing. Removed the value, removed the unused `agentpane.sandbox.image` helper, and updated the comment block to point operators at the Settings UI / `PUT /api/settings` and the digest-pinned default in `src/lib/sandbox/types.ts`.
- **F11-21** — `scripts/backup-db-pg.sh` / `scripts/backup-db.sh` exist but were never invoked; no Helm CronJob, no documented restore drill. Added a default-disabled `backup` value block, a `templates/cronjob-backup.yaml` (wraps the existing scripts), and a `templates/pvc-backup.yaml` for the artefact volume. Wrote `specs/application/operations/backup-restore.md` covering Kubernetes, Docker Compose, and bare-metal restore flows for both Postgres and SQLite.

Chart version bump: `0.1.0` → `0.1.1`.

### Design choices

- **F11-20**: chose option (b) from the review — delete the value and document — over option (a) (post-install Job that writes the DB setting). Reason: option (a) adds new infrastructure (Job + writer code path) for what is fundamentally a config that already lives in the DB and is managed via the Settings UI; the Helm chart reads it would have to dual-write, creating yet another source-of-truth split. Option (b) is atomic and aligns with "no half-finished implementations".
- **F11-21**: default `backup.enabled: false`. A fresh `helm install` should not silently provision a PVC; operators must opt in. The CronJob uses the **main app image** (so `pg_dump` / `sqlite3` and the backup scripts are already present — no separate image build needed) and writes to a dedicated `<release>-agentpane-backup` PVC mounted at `/backups`.
- **Drive-by hardening**: `renderChart()` in the integration test now uses `spawnSync` with positional argv (no shell interpolation). Without this, `--set 'backup.schedule=*/15 * * * *'` had its asterisks expanded by the shell, breaking the test. Same pattern as W1-D shell-injection hardening.

### Test bar (red → green)

- **before**: `tests/integration/helm-chart-template.test.ts` had no coverage for sandbox.image removal or the backup CronJob. Adding the new tests against `main` would error (missing template, helper still defined). Status: **FAIL**.
- **after**: 6 new tests covering F11-20 (chart override is silently ignored — no template references it) and F11-21 (default-disabled produces no CronJob/PVC, `enabled=true` renders both, Postgres vs SQLite picks the right script, schedule + `retentionDays` propagate, `backup.pvc.create=false` skips the chart-managed PVC). All 14 tests pass:
  ```
  Test Files  1 passed (1)
  Tests       14 passed (14)
  ```

### Status vs April 29 review

- F11-20 (P1) — **closed**. Decorative value removed; runtime DB-side path remains the single source of truth and is digest-validated by `SandboxConfigService` per theme-04 P0-01.
- F11-21 (P1) — **closed**. CronJob + PVC + restore drill in place.

## Test plan

- [x] `helm lint charts/agentpane/` — clean
- [x] `helm template test-release charts/agentpane/` — 23 docs, 0 yaml errors
- [x] `helm template test-release charts/agentpane/ --set backup.enabled=true` — 25 docs, 0 yaml errors
- [x] `npx vitest run tests/integration/helm-chart-template.test.ts --no-coverage` — 14/14 tests pass
- [x] `npx tsc --noEmit` — no new errors introduced
- [x] `npx @biomejs/biome check --diagnostic-level=error tests/integration/helm-chart-template.test.ts` — clean
- [ ] Manual: `helm install agentpane charts/agentpane --set backup.enabled=true` on a kind cluster, wait for the CronJob to fire, confirm artefact lands on the PVC.
- [ ] Manual: walk through `specs/application/operations/backup-restore.md` §3.1 against a non-prod Postgres restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
