### PR TITLE
fix(arch29-W3-D): complete project→codespace API rename (F12-06, F07-04)

### DIFF
--- a/specs/application/api/endpoints.md
+++ b/specs/application/api/endpoints.md
@@ -2,11 +2,13 @@
 
 ## Overview
 
-Complete REST API specification for AgentPane. The API is built on **Hono** (`hono` v4.11.5), a lightweight web framework. Each domain area is implemented as a Hono sub-application in a dedicated route file under `src/server/routes/`, then mounted onto the main router via `app.route()` in `src/server/router.ts`.
+Complete REST API specification for AgentPane. The API is built on **Hono** (`hono` v4.x), a lightweight web framework. Each domain area is implemented as a Hono sub-application in a dedicated route file under `src/server/routes/`, then mounted onto the main router via `app.route()` in `src/server/router.ts`.
 
 All endpoints are prefixed with `/api/` and return JSON with a consistent `ok/error` response structure.
 
-**Route files:** 33 files producing 120+ endpoints across 20 domain groups.
+**Route files:** 40+ files producing 240+ endpoints across the documented domain groups.
+
+> **arch29-W3-D (F12-06)** — the project→codespace rename has been completed at the API surface. The previous `/api/projects/*`, `/api/project-folders/*`, `/api/project-members/*`, and `/api/team-projects/*` paths have been renamed to `/api/codespaces/*`, `/api/codespace-folders/*`, `/api/codespaces/:id/members`, and `/api/teams/:id/project-folders` respectively. For one release the server emits a 308 Permanent Redirect from `/api/project-folders/*` → `/api/codespace-folders/*` so existing API clients continue to work; the redirect will be removed in the next release. All other old paths have been replaced (no redirect was added because there was no production API consumer using them when the rename landed).
 
 ---
 
@@ -24,35 +26,43 @@ src/server/
     ├── api-keys.ts
     ├── auth.ts
     ├── cli-monitor.ts
+    ├── codespace-folders.ts   # arch29-W3-D: renamed from project-folders.ts
+    ├── codespace-members.ts   # arch29-W3-D: renamed from project-members.ts
+    ├── codespaces.ts          # was projects.ts
     ├── events.ts
     ├── filesystem.ts
     ├── git.ts
     ├── github.ts
+    ├── github-app.ts
+    ├── github-app-webhooks.ts
     ├── health.ts
     ├── invitation-accept.ts
     ├── marketplaces.ts
     ├── me.ts
-    ├── project-members.ts
-    ├── projects.ts
+    ├── memory.ts
+    ├── metrics.ts
+    ├── admin-metrics.ts
     ├── rbac-tokens.ts
-    ├── sandbox.ts          # 3 exported factories: sandbox configs, K8s, Nomad
+    ├── sandbox.ts             # legacy factories
+    ├── sandbox-configs.ts
+    ├── sandbox-k8s.ts
+    ├── sandbox-nomad.ts
     ├── sandbox-status.ts
     ├── sessions.ts
     ├── settings.ts
-    ├── tags.ts             # 3 exported factories: tags, project-tags, task-tags
+    ├── tags.ts                # 3 exported factories: tags, codespace-tags, task-tags
     ├── task-creation.ts
     ├── tasks.ts
     ├── team-github-token.ts
     ├── team-invitations.ts
     ├── team-members.ts
-    ├── team-projects.ts
+    ├── team-project-folders.ts  # was team-projects.ts
     ├── teams.ts
     ├── templates.ts
     ├── terraform.ts
     ├── webhooks.ts
     ├── workflow-designer.ts
-    ├── workflows.ts
-    └── worktrees.ts
+    └── workflows.ts
 ```
 
 ### Route Factory Pattern
@@ -63,11 +73,11 @@ Each route file exports a factory function that receives service dependencies an
 import { Hono } from 'hono';
 import { json } from '../shared.js';
 
-interface ProjectsDeps {
+interface CodespacesDeps {
   db: Database;
 }
 
-export function createProjectsRoutes({ db }: ProjectsDeps) {
+export function createCodespacesRoutes({ db }: CodespacesDeps) {
   const app = new Hono();
 
   app.get('/', async (c) => {
@@ -82,7 +92,7 @@ export function createProjectsRoutes({ db }: ProjectsDeps) {
 The main router mounts it:
 
 ```typescript
-app.route('/api/projects', createProjectsRoutes({ db }));
+app.route('/api/codespaces', createCodespacesRoutes({ db }));
 ```
 
 ### Response Format
@@ -130,12 +140,12 @@ All `/api/*` routes pass through a middleware chain defined in `router.ts`:
 | `/api/webhooks` | `admin` |
 | `/api/tasks/create-with-ai` | `agent_operator` |
 | `/api/git` | `agent_operator` |
-| `/api/projects`, `/api/tasks`, `/api/agents`, `/api/sessions`, `/api/worktrees` | `viewer` |
+| `/api/codespaces`, `/api/codespace-folders`, `/api/tasks`, `/api/agents`, `/api/sessions` | `viewer` |
 | `/api/github`, `/api/workflows`, `/api/templates`, `/api/workflow-designer` | `viewer` |
 | `/api/marketplaces`, `/api/terraform`, `/api/cli-monitor`, `/api/events` | `viewer` |
 | `/api/sandbox/status` | `viewer` |
 
-Some route handlers perform additional fine-grained role checks (e.g., `requireTeamRole`, `requireProjectRole`) internally.
+Some route handlers perform additional fine-grained role checks (e.g., `requireTeamRole`, `requireCodespaceRole`) internally.
 
 ### Validation Pattern
 
@@ -143,7 +153,7 @@ Routes use either inline Zod validation or the shared `parseBody` / `parseJsonBo
 
 ```typescript
 // Inline pattern
-const parsed = createProjectSchema.safeParse(body);
+const parsed = createCodespaceSchema.safeParse(body);
 if (!parsed.success) {
   return json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '...' } }, 400);
 }
@@ -197,48 +207,76 @@ if (!parsed.ok) return parsed.response;
 
 ---
 
-## Projects
+## Codespaces
 
-**File:** `projects.ts` | **Mount:** `/api/projects`
+**File:** `codespaces.ts` | **Mount:** `/api/codespaces`
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/projects` | List all projects (ordered by `updatedAt` desc) |
-| `POST` | `/api/projects` | Create a new project (validates unique path) |
-| `GET` | `/api/projects/summaries` | List projects with task counts, running agents, status |
-| `GET` | `/api/projects/:id` | Get project by ID |
-| `PATCH` | `/api/projects/:id` | Update project (name, description, config, maxConcurrentAgents) |
-| `DELETE` | `/api/projects/:id` | Delete project (optionally delete files with `?deleteFiles=true`) |
+| `GET` | `/api/codespaces` | List all codespaces (ordered by `updatedAt` desc) |
+| `POST` | `/api/codespaces` | Create a new codespace (validates unique path) |
+| `GET` | `/api/codespaces/summaries` | List codespaces with task counts, running agents, status |
+| `GET` | `/api/codespaces/:id` | Get codespace by ID |
+| `PATCH` | `/api/codespaces/:id` | Update codespace (name, description, config, maxConcurrentAgents) |
+| `DELETE` | `/api/codespaces/:id` | Delete codespace (optionally delete files with `?deleteFiles=true`) |
 
-**Validation (inline Zod):**
+**Validation (`src/server/validation.ts`):**
 
 ```typescript
-const createProjectSchema = z.object({
-  name: z.string().min(1),
-  path: z.string().min(1),
-  description: z.string().optional(),
+export const createCodespaceSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200),
+  path: z.string().min(1, 'Path is required').max(2048),
+  description: z.string().max(2000).optional(),
+  projectFolderId: idSchema,
 });
 
-const updateProjectSchema = z.object({
-  name: z.string().min(1).optional(),
-  description: z.string().optional(),
+export const updateCodespaceSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).optional(),
   maxConcurrentAgents: z.number().int().positive().optional(),
   config: z.record(z.string(), z.unknown()).optional(),
+  projectFolderId: idSchema.optional(),
+  githubOwner: z.string().min(1).max(200).optional(),
+  githubRepo: z.string().min(1).max(200).optional(),
 });
 ```
 
 ---
 
-## Project Members
+## Codespace Folders
 
-**File:** `project-members.ts` | **Mount:** `/api/projects/:id/members`
+**File:** `codespace-folders.ts` | **Mount:** `/api/codespace-folders`
+
+> arch29-W3-D: previously mounted at `/api/project-folders`. Old path emits 308 redirect.
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/projects/:id/members` | List project members with effective roles |
-| `POST` | `/api/projects/:id/members` | Add project member override (requires `admin` role) |
-| `PATCH` | `/api/projects/:id/members/:uid` | Update member role (requires `admin` role) |
-| `DELETE` | `/api/projects/:id/members/:uid` | Remove project member override (requires `admin` role) |
+| `GET` | `/api/codespace-folders` | List all codespace folders (optional `teamId` filter) |
+| `POST` | `/api/codespace-folders` | Create a new folder (auto-generates slug if not provided) |
+| `GET` | `/api/codespace-folders/:id` | Get folder by ID |
+| `PATCH` | `/api/codespace-folders/:id` | Update folder (name, slug, description, icon, color) |
+| `DELETE` | `/api/codespace-folders/:id` | Delete folder (refuses if it contains codespaces) |
+| `GET` | `/api/codespace-folders/:id/codespaces` | List codespaces in this folder |
+| `GET` | `/api/codespace-folders/:id/summary` | Get folder summary (counts, running agents, etc.) |
+
+> The DB table and service are still named `projectFolders` / `ProjectFolderService` because the entity is a "folder of codespaces" — distinct from a single codespace. The rename is scoped to the public API path and route file.
+
+---
+
+## Codespace Members
+
+**File:** `codespace-members.ts` | **Mount:** `/api/codespaces/:id/members`
+
+> arch29-W3-D: route file renamed from `project-members.ts`. The mount path was already `/api/codespaces/:id/members`. Internal symbols renamed (`createCodespaceMembersRoutes`, `addCodespaceMemberSchema`, `updateCodespaceMemberSchema`).
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/codespaces/:id/members` | List codespace members with effective roles |
+| `POST` | `/api/codespaces/:id/members` | Add codespace member override (requires `admin` role) |
+| `PATCH` | `/api/codespaces/:id/members/:uid` | Update member role (requires `admin` role) |
+| `DELETE` | `/api/codespaces/:id/members/:uid` | Remove codespace member override (requires `admin` role) |
+
+Each list item includes `codespaceRole` and (deprecated) `projectRole` mirror plus `effectiveRole` resolved from RBAC.
 
 ---
 
@@ -248,7 +286,7 @@ const updateProjectSchema = z.object({
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/tasks` | List tasks for a project (requires `projectId` query param) |
+| `GET` | `/api/tasks` | List tasks for a codespace (requires `codespaceId` query param) |
 | `POST` | `/api/tasks` | Create a new task |
 | `GET` | `/api/tasks/:id` | Get task by ID |
 | `PUT` | `/api/tasks/:id` | Update a task (title, description, labels, priority) |
@@ -308,7 +346,7 @@ The SSE stream emits events: `connected`, `task-creation:token`, `task-creation:
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/agents` | List agents for a project (requires `projectId` query param) |
+| `GET` | `/api/agents` | List agents for a codespace (requires `codespaceId` query param) |
 | `POST` | `/api/agents` | Create a new agent |
 | `GET` | `/api/agents/:id` | Get agent by ID |
 | `PATCH` | `/api/agents/:id` | Update agent configuration |
@@ -327,7 +365,7 @@ The SSE stream emits events: `connected`, `task-creation:token`, `task-creation:
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/sessions` | List sessions (optional `projectId`, `status`, `agentId`, `search`, `dateFrom`, `dateTo` filters) |
+| `GET` | `/api/sessions` | List sessions (optional `codespaceId`, `status`, `agentId`, `search`, `dateFrom`, `dateTo` filters) |
 | `POST` | `/api/sessions` | Create a new session |
 | `GET` | `/api/sessions/:id` | Get session by ID |
 | `DELETE` | `/api/sessions/:id` | Delete a session |
@@ -345,9 +383,9 @@ Note: The SSE streaming endpoint has been removed. Clients subscribe to Caddy du
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/worktrees` | List worktrees for a project (requires `projectId` query param) |
+| `GET` | `/api/worktrees` | List worktrees for a codespace (requires `codespaceId` query param) |
 | `POST` | `/api/worktrees` | Create a new worktree |
-| `POST` | `/api/worktrees/prune` | Prune stale worktrees for a project |
+| `POST` | `/api/worktrees/prune` | Prune stale worktrees for a codespace |
 | `GET` | `/api/worktrees/:id` | Get worktree status |
 | `DELETE` | `/api/worktrees/:id` | Remove a worktree (`?force=true` to force) |
 | `GET` | `/api/worktrees/:id/diff` | Get diff for a worktree |
@@ -362,7 +400,7 @@ Note: The SSE streaming endpoint has been removed. Clients subscribe to Caddy du
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/git/status` | Get git status for a project (requires `projectId` query param) |
+| `GET` | `/api/git/status` | Get git status for a codespace (requires `codespaceId` query param) |
 | `GET` | `/api/git/branches` | List local branches for a project |
 | `GET` | `/api/git/commits` | List commits (optional `branch` and `limit` query params) |
 | `GET` | `/api/git/remote-branches` | List remote branches (fetches from remote first) |
@@ -415,14 +453,16 @@ Note: The SSE streaming endpoint has been removed. Clients subscribe to Caddy du
 
 ---
 
-## Team Projects
+## Team Project Folders
 
-**File:** `team-projects.ts` | **Mount:** `/api/teams/:id/projects`
+**File:** `team-project-folders.ts` | **Mount:** `/api/teams/:id/project-folders`
+
+> arch29-W3-D: previously named "team-projects". Now scopes folders (each folder contains many codespaces) onto a team.
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/teams/:id/projects` | Assign a project to the team (requires `admin` role) |
-| `DELETE` | `/api/teams/:id/projects/:projectId` | Remove a project from the team (requires `admin` role) |
+| `POST` | `/api/teams/:id/project-folders` | Assign a folder to the team (requires `admin` role) |
+| `DELETE` | `/api/teams/:id/project-folders/:folderId` | Remove a folder from the team (requires `admin` role) |
 
 ---
 
@@ -476,14 +516,16 @@ Validates token hash, checks email match against GitHub OAuth email, and adds us
 
 ---
 
-## Project Tags
+## Codespace Tags
 
-**File:** `tags.ts` (exported as `createProjectTagRoutes`) | **Mount:** `/api/projects/:id/tags`
+**File:** `tags.ts` (exported as `createProjectTagRoutes`) | **Mount:** `/api/codespaces/:id/tags`
+
+> arch29-W3-D: mounted at `/api/codespaces/:id/tags`. The exported factory name `createProjectTagRoutes` is a legacy holdover and not user-visible.
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/projects/:id/tags` | Assign a tag to a project (requires `agent_operator` on project) |
-| `DELETE` | `/api/projects/:id/tags/:tagId` | Remove a tag from a project |
+| `POST` | `/api/codespaces/:id/tags` | Assign a tag to a codespace (requires `agent_operator` on codespace) |
+| `DELETE` | `/api/codespaces/:id/tags/:tagId` | Remove a tag from a codespace |
 
 ---
 
@@ -535,7 +577,7 @@ Sensitive fields (`sandbox.nomad.token`, `sandbox.agentcore.secretAccessKey`) ar
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/templates` | List templates (optional `scope`, `projectId`, `limit` filters) |
+| `GET` | `/api/templates` | List templates (optional `scope`, `codespaceId`, `limit` filters) |
 | `POST` | `/api/templates` | Create a template (requires `name`, `scope`, `githubUrl`) |
 | `GET` | `/api/templates/:id` | Get template by ID |
 | `PATCH` | `/api/templates/:id` | Update a template |
@@ -659,7 +701,7 @@ The SSE stream sends an initial `cli-monitor:snapshot` event, then relays live e
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/events/subscriptions` | List subscriptions (optional `sourceId`, `projectId` filters) |
+| `GET` | `/api/events/subscriptions` | List subscriptions (optional `sourceId`, `codespaceId` filters) |
 | `GET` | `/api/events/subscriptions/:id` | Get subscription by ID |
 | `POST` | `/api/events/subscriptions` | Create a subscription |
 | `PATCH` | `/api/events/subscriptions/:id` | Update a subscription |
@@ -700,8 +742,8 @@ The SSE stream sends an initial `cli-monitor:snapshot` event, then relays live e
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/sandbox/status/:projectId` | Get sandbox mode, container status, and provider health (Docker, K8s, Nomad) |
-| `POST` | `/api/sandbox/status/:projectId/restart` | Restart the sandbox container |
+| `GET` | `/api/sandbox/status/:codespaceId` | Get sandbox mode, container status, and provider health (Docker, K8s, Nomad) |
+| `POST` | `/api/sandbox/status/:codespaceId/restart` | Restart the sandbox container |
 
 Includes self-healing: auto-creates the default sandbox when Docker/K8s is available but no container exists.
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -394,11 +394,16 @@ export const apiClient = {
     return this.projects;
   },
 
+  // arch29-W3-D (F12-06): the public mount path is now `/api/codespace-folders`.
+  // The client field name `projectFolders` is preserved to avoid a breaking
+  // rename of every call site at this same time; the property name only
+  // surfaces inside the wrapper. The server still serves
+  // `/api/project-folders/*` via a 308 redirect for one release.
   projectFolders: {
-    list: () => apiServerFetch<{ items: ProjectFolderItem[] }>('/api/project-folders'),
+    list: () => apiServerFetch<{ items: ProjectFolderItem[] }>('/api/codespace-folders'),
 
     get: (id: string) =>
-      apiServerFetch<ProjectFolderItem>(`/api/project-folders/${encodeURIComponent(id)}`),
+      apiServerFetch<ProjectFolderItem>(`/api/codespace-folders/${encodeURIComponent(id)}`),
 
     create: (data: {
       name: string;
@@ -406,7 +411,8 @@ export const apiClient = {
       icon?: string;
       color?: string;
       description?: string;
-    }) => apiServerFetch<ProjectFolderItem>('/api/project-folders', { method: 'POST', body: data }),
+    }) =>
+      apiServerFetch<ProjectFolderItem>('/api/codespace-folders', { method: 'POST', body: data }),
 
     update: (
       id: string,
@@ -418,21 +424,25 @@ export const apiClient = {
         description: string;
       }>
     ) =>
-      apiServerFetch<ProjectFolderItem>(`/api/project-folders/${encodeURIComponent(id)}`, {
+      apiServerFetch<ProjectFolderItem>(`/api/codespace-folders/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         body: data,
       }),
 
     delete: (id: string) =>
-      apiServerFetch<null>(`/api/project-folders/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+      apiServerFetch<null>(`/api/codespace-folders/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      }),
 
     listCodespaces: (folderId: string) =>
       apiServerFetch<{ items: CodespaceListItem[] }>(
-        `/api/project-folders/${encodeURIComponent(folderId)}/codespaces`
+        `/api/codespace-folders/${encodeURIComponent(folderId)}/codespaces`
       ),
 
     getSummary: (folderId: string) =>
-      apiServerFetch<FolderSummary>(`/api/project-folders/${encodeURIComponent(folderId)}/summary`),
+      apiServerFetch<FolderSummary>(
+        `/api/codespace-folders/${encodeURIComponent(folderId)}/summary`
+      ),
   },
 
   tasks: {

--- a/src/lib/config/__tests__/config.test.ts
+++ b/src/lib/config/__tests__/config.test.ts
@@ -24,7 +24,7 @@ describe('config system', () => {
   });
 
   it('loads project config from defaults when missing', async () => {
-    const result = await loadCodespaceConfigFrom({ projectPath: '/tmp/missing' });
+    const result = await loadCodespaceConfigFrom({ codespacePath: '/tmp/missing' });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -37,7 +37,7 @@ describe('config system', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     process.env.AGENTPANE_MAX_TURNS = '12';
 
-    const result = await loadCodespaceConfig({ projectPath: '/tmp/missing' });
+    const result = await loadCodespaceConfig({ codespacePath: '/tmp/missing' });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -58,7 +58,7 @@ describe('config system', () => {
     const previousKey = process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
 
-    const result = await loadCodespaceConfig({ projectPath: '/tmp/missing' });
+    const result = await loadCodespaceConfig({ codespacePath: '/tmp/missing' });
 
     expect(result.ok).toBe(true);
 

--- a/src/lib/config/config-service.ts
+++ b/src/lib/config/config-service.ts
@@ -14,15 +14,22 @@ export type LoadedConfig = {
   codespace: CodespaceConfig;
 };
 
+/**
+ * Load the per-codespace `.claude/settings.json` from the given codespace path.
+ *
+ * arch29-W3-D (F12-06): the parameter was named `projectPath` after the
+ * project→codespace rename was incomplete. Renamed to `codespacePath` to
+ * match the function name and the rest of the API surface.
+ */
 export const loadCodespaceConfigFrom = async ({
-  projectPath,
+  codespacePath,
 }: {
-  projectPath: string;
+  codespacePath: string;
 }): Promise<CodespaceConfigResult> => {
-  const projectConfigPath = path.join(projectPath, '.claude', 'settings.json');
+  const codespaceConfigPath = path.join(codespacePath, '.claude', 'settings.json');
 
   try {
-    const content = await fs.readFile(projectConfigPath, 'utf-8');
+    const content = await fs.readFile(codespaceConfigPath, 'utf-8');
     const parsed = JSON.parse(content) as Record<string, unknown>;
     const validated = codespaceConfigSchema.parse(parsed);
 
@@ -52,16 +59,21 @@ const parseEnvNumber = (value: string | undefined, fallback: number): number => 
   return Number.isNaN(parsed) ? fallback : parsed;
 };
 
+/**
+ * Load the codespace config from disk and merge env overrides.
+ *
+ * arch29-W3-D (F12-06): parameter renamed `projectPath` → `codespacePath`.
+ */
 export const loadCodespaceConfig = async ({
-  projectPath,
+  codespacePath,
 }: {
-  projectPath: string;
+  codespacePath: string;
 }): Promise<Result<LoadedConfig, ReturnType<typeof createError>>> => {
   // CB-013: ANTHROPIC_API_KEY is no longer checked at config loading time.
   // Non-agent operations (codespace listing, settings, etc.) do not require an API key.
   // The key is validated at agent execution time instead (see api.ts key resolution).
 
-  const baseConfigResult = await loadCodespaceConfigFrom({ projectPath });
+  const baseConfigResult = await loadCodespaceConfigFrom({ codespacePath });
   if (!baseConfigResult.ok) {
     return baseConfigResult;
   }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -54,6 +54,10 @@ import { createAgentsRoutes } from './routes/agents.js';
 import { createApiKeysRoutes } from './routes/api-keys.js';
 import { createAuthRoutes } from './routes/auth.js';
 import { createCliMonitorRoutes } from './routes/cli-monitor.js';
+// arch29-W3-D (F12-06): renamed from `project-folders.ts` / `project-members.ts`.
+// Old paths `/api/project-folders/*` issue 308 redirects below for one release.
+import { createCodespaceFoldersRoutes } from './routes/codespace-folders.js';
+import { createCodespaceMembersRoutes } from './routes/codespace-members.js';
 import { createCodespacesRoutes } from './routes/codespaces.js';
 import { createEventsRoutes } from './routes/events.js';
 import { createFilesystemRoutes } from './routes/filesystem.js';
@@ -67,8 +71,6 @@ import { createMarketplacesRoutes } from './routes/marketplaces.js';
 import { createMeRoutes } from './routes/me.js';
 import { createMemoryRoutes } from './routes/memory.js';
 import { createMetricsRoutes } from './routes/metrics.js';
-import { createProjectFoldersRoutes } from './routes/project-folders.js';
-import { createProjectMembersRoutes } from './routes/project-members.js';
 import { createRbacTokensRoutes } from './routes/rbac-tokens.js';
 import { createSandboxConfigRoutes } from './routes/sandbox-configs.js';
 import { createK8sRoutes } from './routes/sandbox-k8s.js';
@@ -370,6 +372,25 @@ export function createRouter(deps: RouterDependencies) {
   app.use('*', securityHeaders);
   // F10-01: record per-request counters for /api/metrics.
   app.use('*', metricsMiddleware);
+
+  // arch29-W3-D (F12-06): one-release backward-compat redirect from the old
+  // `/api/project-folders` mount path to the new `/api/codespace-folders`. We
+  // emit a 308 (Permanent Redirect) to preserve the request method (GET/POST/
+  // PATCH/DELETE) on the rewritten target. The matcher must run *before* the
+  // auth middleware so unauthenticated probes still see the redirect, and
+  // *before* the body-size middleware so a POST/PATCH with a body is not
+  // double-buffered. The query string is preserved.
+  app.use('/api/project-folders/*', async (c) => {
+    const url = new URL(c.req.url);
+    const newPath = url.pathname.replace(/^\/api\/project-folders/, '/api/codespace-folders');
+    const location = `${newPath}${url.search}`;
+    return c.redirect(location, 308);
+  });
+  app.use('/api/project-folders', async (c) => {
+    const url = new URL(c.req.url);
+    return c.redirect(`/api/codespace-folders${url.search}`, 308);
+  });
+
   // F06-NEW-09: cap incoming body size on the public-facing surfaces.
   // Default is 5MB (matches the prior cli-monitor cap). Applied early so
   // webhook handlers that call `c.req.text()` and route handlers that call
@@ -470,8 +491,10 @@ export function createRouter(deps: RouterDependencies) {
   useRoleGuard(app, '/api/memory', 'viewer', rbacService);
   // biome-ignore lint/correctness/useHookAtTopLevel: useRoleGuard is a Hono middleware helper, not a React hook
   useRoleGuard(app, '/api/codespaces', 'viewer', rbacService);
+  // arch29-W3-D (F12-06): renamed from `/api/project-folders`. Role guard is
+  // applied to the new path; redirects from the old path are registered below.
   // biome-ignore lint/correctness/useHookAtTopLevel: useRoleGuard is a Hono middleware helper, not a React hook
-  useRoleGuard(app, '/api/project-folders', 'viewer', rbacService);
+  useRoleGuard(app, '/api/codespace-folders', 'viewer', rbacService);
   // biome-ignore lint/correctness/useHookAtTopLevel: useRoleGuard is a Hono middleware helper, not a React hook
   useRoleGuard(app, '/api/tasks', 'viewer', rbacService);
   // biome-ignore lint/correctness/useHookAtTopLevel: useRoleGuard is a Hono middleware helper, not a React hook
@@ -565,8 +588,8 @@ export function createRouter(deps: RouterDependencies) {
     })
   );
   app.route(
-    '/api/project-folders',
-    createProjectFoldersRoutes({ projectFolderService: deps.projectFolderService })
+    '/api/codespace-folders',
+    createCodespaceFoldersRoutes({ projectFolderService: deps.projectFolderService })
   );
   app.route('/api/agents', createAgentsRoutes({ agentService: deps.agentService, db: deps.db }));
   app.route(
@@ -688,7 +711,7 @@ export function createRouter(deps: RouterDependencies) {
   app.route('/api/invitations', createInvitationAcceptRoutes({ db: deps.db }));
   app.route(
     '/api/codespaces/:id/members',
-    createProjectMembersRoutes({ db: deps.db, rbacService })
+    createCodespaceMembersRoutes({ db: deps.db, rbacService })
   );
   app.route('/api/tokens', createRbacTokensRoutes({ db: deps.db, rbacService }));
   app.route('/api/tags', createTagsRoutes({ db: deps.db, rbacService }));

--- a/src/server/routes/__tests__/codespace-members.test.ts
+++ b/src/server/routes/__tests__/codespace-members.test.ts
@@ -1,14 +1,14 @@
 import { Hono } from 'hono';
 import { describe, expect, it, vi } from 'vitest';
 import type { AuthContext } from '../../../lib/api/auth-middleware.js';
-import { createProjectMembersRoutes } from '../project-members.js';
+import { createCodespaceMembersRoutes } from '../codespace-members.js';
 
 // ── Mock Database ──
 
 function createMockDb() {
   return {
     query: {
-      projectMembers: {
+      codespaceMembers: {
         findMany: vi.fn(),
       },
     },
@@ -49,7 +49,7 @@ function sessionAuth(userId = 'user-1'): AuthContext {
 function createTestApp(auth = devAuth()) {
   const db = createMockDb();
   const rbacService = createMockRbacService();
-  const routes = createProjectMembersRoutes({
+  const routes = createCodespaceMembersRoutes({
     db: db as never,
     rbacService: rbacService as never,
   });
@@ -81,7 +81,7 @@ async function request(app: Hono, method: string, path: string, body?: unknown) 
 
 // ── Tests ──
 
-describe('Project Members API Routes', () => {
+describe('Codespace Members API Routes', () => {
   // ── POST /api/codespaces/:id/members ──
 
   describe('POST /api/codespaces/:id/members', () => {

--- a/src/server/routes/codespace-folders.ts
+++ b/src/server/routes/codespace-folders.ts
@@ -1,7 +1,15 @@
 /**
- * Project Folder routes
+ * Codespace Folder routes
  *
  * Thin route handlers that delegate to ProjectFolderService.
+ *
+ * arch29-W3-D (F12-06): renamed from `project-folders.ts` to align the API
+ * surface with the codespace naming used in CLAUDE.md. The DB schema and
+ * service still carry the `projectFolder` name (the entity is a
+ * "folder of codespaces" — distinct from a single codespace) so the rename
+ * is scoped to the public API mount path and route file. The 308 redirect
+ * from `/api/project-folders/*` is registered in `router.ts` for one-release
+ * backward compatibility.
  */
 
 import { Hono } from 'hono';
@@ -12,8 +20,8 @@ import type { ProjectFolderService } from '../../services/project-folder.service
 import { json, validateIdParam } from '../shared.js';
 import { parseJsonBody } from '../validation.js';
 
-// Validation schemas
-const createProjectFolderSchema = z.object({
+// Validation schemas — internal to this route module.
+const createCodespaceFolderSchema = z.object({
   name: z.string().min(1, 'Name is required').max(200),
   slug: z.string().min(1).max(200).optional(),
   description: z.string().max(1000).optional(),
@@ -21,7 +29,7 @@ const createProjectFolderSchema = z.object({
   color: z.string().max(50).optional(),
 });
 
-const updateProjectFolderSchema = z
+const updateCodespaceFolderSchema = z
   .object({
     name: z.string().min(1).max(200).optional(),
     slug: z.string().min(1).max(200).optional(),
@@ -33,14 +41,14 @@ const updateProjectFolderSchema = z
     message: 'At least one field must be provided',
   });
 
-interface ProjectFoldersDeps {
+interface CodespaceFoldersDeps {
   projectFolderService: ProjectFolderService;
 }
 
-export function createProjectFoldersRoutes({ projectFolderService }: ProjectFoldersDeps) {
+export function createCodespaceFoldersRoutes({ projectFolderService }: CodespaceFoldersDeps) {
   const app = new Hono<{ Variables: { auth: AuthContext } }>();
 
-  // GET /api/project-folders
+  // GET /api/codespace-folders
   app.get('/', async (c) => {
     const teamId = c.req.query('teamId') ?? undefined;
 
@@ -62,9 +70,9 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
     });
   });
 
-  // POST /api/project-folders
+  // POST /api/codespace-folders
   app.post('/', async (c) => {
-    const parsed = await parseJsonBody(c, createProjectFolderSchema);
+    const parsed = await parseJsonBody(c, createCodespaceFolderSchema);
     if (!parsed.ok) return parsed.response;
 
     const slug = parsed.data.slug ?? slugify(parsed.data.name, 200);
@@ -87,7 +95,7 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
     return json({ ok: true, data: result.value }, 201);
   });
 
-  // GET /api/project-folders/:id
+  // GET /api/codespace-folders/:id
   app.get('/:id', async (c) => {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
@@ -96,7 +104,7 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
 
     if (!result.ok) {
       return json(
-        { ok: false, error: { code: 'NOT_FOUND', message: 'Project folder not found' } },
+        { ok: false, error: { code: 'NOT_FOUND', message: 'Codespace folder not found' } },
         404
       );
     }
@@ -104,12 +112,12 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
     return json({ ok: true, data: result.value });
   });
 
-  // PATCH /api/project-folders/:id
+  // PATCH /api/codespace-folders/:id
   app.patch('/:id', async (c) => {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
 
-    const parsed = await parseJsonBody(c, updateProjectFolderSchema);
+    const parsed = await parseJsonBody(c, updateCodespaceFolderSchema);
     if (!parsed.ok) return parsed.response;
 
     const result = await projectFolderService.update(id, parsed.data);
@@ -124,7 +132,7 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
     return json({ ok: true, data: result.value });
   });
 
-  // DELETE /api/project-folders/:id
+  // DELETE /api/codespace-folders/:id
   app.delete('/:id', async (c) => {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
@@ -141,7 +149,7 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
     return json({ ok: true, data: { deleted: true } });
   });
 
-  // GET /api/project-folders/:id/codespaces
+  // GET /api/codespace-folders/:id/codespaces
   app.get('/:id/codespaces', async (c) => {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;
@@ -164,7 +172,7 @@ export function createProjectFoldersRoutes({ projectFolderService }: ProjectFold
     });
   });
 
-  // GET /api/project-folders/:id/summary
+  // GET /api/codespace-folders/:id/summary
   app.get('/:id/summary', async (c) => {
     const { id, error } = validateIdParam(c, 'id');
     if (error) return error;

--- a/src/server/routes/codespace-members.ts
+++ b/src/server/routes/codespace-members.ts
@@ -1,5 +1,9 @@
 /**
- * Project member routes
+ * Codespace member routes
+ *
+ * arch29-W3-D (F12-06): renamed from `project-members.ts`. Codespace members
+ * are tracked in the `codespaceMembers` table and the route is mounted at
+ * `/api/codespaces/:id/members`. Symbol names match.
  */
 
 import { and, eq } from 'drizzle-orm';
@@ -10,14 +14,18 @@ import type { AuthContext } from '../../lib/api/auth-middleware';
 import type { RbacService } from '../../services/rbac.service';
 import type { Database } from '../../types/database';
 import { json, requireCodespaceRole, validateIdParam } from '../shared';
-import { addProjectMemberSchema, parseJsonBody, updateProjectMemberSchema } from '../validation';
+import {
+  addCodespaceMemberSchema,
+  parseJsonBody,
+  updateCodespaceMemberSchema,
+} from '../validation';
 
-interface ProjectMembersDeps {
+interface CodespaceMembersDeps {
   db: Database;
   rbacService: RbacService;
 }
 
-export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDeps) {
+export function createCodespaceMembersRoutes({ db, rbacService }: CodespaceMembersDeps) {
   const app = new Hono<{ Variables: { auth: AuthContext } }>();
 
   // POST / - Add codespace member override
@@ -29,7 +37,7 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
     const denied = await requireCodespaceRole(auth, rbacService, codespaceId, 'admin');
     if (denied) return denied;
 
-    const parsed = await parseJsonBody(c, addProjectMemberSchema);
+    const parsed = await parseJsonBody(c, addCodespaceMemberSchema);
     if (!parsed.ok) return parsed.response;
 
     const result = await db.transaction(async (tx) => {
@@ -60,6 +68,8 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
     });
 
     if (result === 'DUPLICATE') {
+      // arch29-W3-D: error code preserved for API stability. Renaming the route
+      // file/symbols is internal; clients keying on `code` would break.
       return json(
         { ok: false, error: { code: 'PROJECT_MEMBER_EXISTS', message: 'Member already exists' } },
         409
@@ -113,6 +123,8 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
       .where(eq(codespaceMembers.codespaceId, codespaceId));
 
     // H4: Enrich with effectiveRole and source
+    // arch29-W3-D (F12-06): emit both `codespaceRole` (new canonical name) and
+    // `projectRole` (deprecated alias) for one release of backward compatibility.
     const enrichedMembers = await Promise.all(
       members.map(async (m) => {
         const effectiveRole = m.userId
@@ -120,6 +132,8 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
           : null;
         return {
           ...m,
+          codespaceRole: m.role,
+          /** @deprecated use `codespaceRole`. Removed in next release. */
           projectRole: m.role,
           effectiveRole: effectiveRole ?? m.role,
           source: 'direct' as const,
@@ -151,7 +165,7 @@ export function createProjectMembersRoutes({ db, rbacService }: ProjectMembersDe
     const adminDenied = await requireCodespaceRole(auth, rbacService, codespaceId, 'admin');
     if (adminDenied) return adminDenied;
 
-    const parsed = await parseJsonBody(c, updateProjectMemberSchema);
+    const parsed = await parseJsonBody(c, updateCodespaceMemberSchema);
     if (!parsed.ok) return parsed.response;
 
     const result = await db

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -208,13 +208,19 @@ export const createInvitationSchema = z.object({
   role: assignableRoleSchema,
 });
 
-export const addProjectMemberSchema = z.object({
+/**
+ * arch29-W3-D (F12-06): renamed from `addProjectMemberSchema` /
+ * `updateProjectMemberSchema`. Codespace members are tracked in the
+ * `codespaceMembers` table and the route is mounted under
+ * `/api/codespaces/:id/members`, so the schema names should match.
+ */
+export const addCodespaceMemberSchema = z.object({
   userId: idSchema,
   role: assignableRoleSchema,
   teamId: idSchema.optional(),
 });
 
-export const updateProjectMemberSchema = z.object({
+export const updateCodespaceMemberSchema = z.object({
   role: assignableRoleSchema,
 });
 

--- a/tests/integration/codespace-rename-redirect.test.ts
+++ b/tests/integration/codespace-rename-redirect.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment node
+ *
+ * arch29-W3-D (F12-06): regression test for the one-release backward-compat
+ * redirect from `/api/project-folders/*` to `/api/codespace-folders/*`.
+ *
+ * The rename was applied at the route file (`project-folders.ts` →
+ * `codespace-folders.ts`), the route factory (`createProjectFoldersRoutes` →
+ * `createCodespaceFoldersRoutes`) and the public mount path. To avoid breaking
+ * external integrations during the deprecation window, the router emits a
+ * 308 Permanent Redirect from the old path to the new one. 308 (rather than
+ * 301/302) preserves the request method and body, so a `POST /api/project-folders`
+ * with a JSON body lands on the new endpoint with the same body.
+ *
+ * Test bar (red→green):
+ *   before fix → no redirect, request hits an unmatched route, returns 401
+ *                (auth middleware applies because the path is unknown to the
+ *                redirect handler) — FAIL
+ *   after fix  → 308 with Location: /api/codespace-folders/...               — PASS
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createRouter, type RouterDependencies } from '@/server/router';
+
+// ---------------------------------------------------------------------------
+// Minimal mocks (mirrors tests/server/router.test.ts)
+// ---------------------------------------------------------------------------
+
+function stubDb(): RouterDependencies['db'] {
+  return {
+    query: {
+      codespaces: { findFirst: vi.fn().mockResolvedValue({ id: 'p1' }) },
+      userSessions: { findFirst: vi.fn().mockResolvedValue(null) },
+      apiTokens: { findFirst: vi.fn().mockResolvedValue(null) },
+      users: { findFirst: vi.fn().mockResolvedValue(null) },
+    },
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+  } as unknown as RouterDependencies['db'];
+}
+
+function stubService(overrides: Record<string, unknown> = {}): any {
+  return new Proxy(overrides, {
+    get(target, prop) {
+      if (prop in target) return target[prop as string];
+      return vi.fn().mockResolvedValue({ ok: true, data: {} });
+    },
+  });
+}
+
+function createMinimalDeps(): RouterDependencies {
+  return {
+    db: stubDb(),
+    githubService: stubService(),
+    apiKeyService: stubService(),
+    templateService: stubService(),
+    sandboxConfigService: stubService(),
+    taskService: stubService(),
+    sessionService: stubService(),
+    taskCreationService: stubService(),
+    marketplaceService: stubService(),
+    agentService: stubService(),
+  } as RouterDependencies;
+}
+
+async function appFetch(
+  app: ReturnType<typeof createRouter>,
+  path: string,
+  init: RequestInit = {}
+) {
+  // Redirects are handled by the caller (browser/curl). The Hono `c.redirect`
+  // method returns a Response with `status: 308` and a `Location` header — we
+  // do NOT follow it, we assert on the Response itself.
+  const url = `http://localhost${path}`;
+  const req = new Request(url, init);
+  return app.fetch(req);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('arch29-W3-D: project-folders → codespace-folders 308 redirect (F12-06)', () => {
+  it('GET /api/project-folders/123 returns 308 with Location: /api/codespace-folders/123', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders/123');
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders/123');
+  });
+
+  it('GET /api/project-folders (root) returns 308 with Location: /api/codespace-folders', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders');
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders');
+  });
+
+  it('preserves the query string on redirect', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders/123?foo=bar&baz=qux');
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders/123?foo=bar&baz=qux');
+  });
+
+  it('preserves the query string on root redirect', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders?teamId=abc-123');
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders?teamId=abc-123');
+  });
+
+  it('redirects nested sub-paths (codespaces, summary)', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res1 = await appFetch(app, '/api/project-folders/abc/codespaces');
+    expect(res1.status).toBe(308);
+    expect(res1.headers.get('Location')).toBe('/api/codespace-folders/abc/codespaces');
+
+    const res2 = await appFetch(app, '/api/project-folders/abc/summary');
+    expect(res2.status).toBe(308);
+    expect(res2.headers.get('Location')).toBe('/api/codespace-folders/abc/summary');
+  });
+
+  it('preserves the request method on POST (308 keeps method + body)', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'redirected', slug: 'redirected' }),
+    });
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders');
+  });
+
+  it('preserves the request method on PATCH', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders/xyz', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'renamed' }),
+    });
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders/xyz');
+  });
+
+  it('preserves the request method on DELETE', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/project-folders/xyz', { method: 'DELETE' });
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/api/codespace-folders/xyz');
+  });
+
+  // The new path must NOT redirect — it is the canonical target.
+  it('GET /api/codespace-folders does NOT redirect (it is the canonical path)', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/codespace-folders');
+
+    // Whether 200/401/etc., the key invariant is "no 308 self-loop".
+    expect(res.status).not.toBe(308);
+  });
+
+  it('GET /api/codespace-folders/123 does NOT redirect', async () => {
+    const app = createRouter(createMinimalDeps());
+
+    const res = await appFetch(app, '/api/codespace-folders/123');
+
+    expect(res.status).not.toBe(308);
+  });
+});

--- a/tests/integration/route-codespace-folders.test.ts
+++ b/tests/integration/route-codespace-folders.test.ts
@@ -1,14 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createProjectFoldersRoutes } from '../../src/server/routes/project-folders';
+import { createCodespaceFoldersRoutes } from '../../src/server/routes/codespace-folders';
 import { ProjectFolderService } from '../../src/services/project-folder.service';
 import { createTestProject } from '../factories/project.factory';
 import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
 
 /**
- * Integration tests for project-folders API routes.
+ * Integration tests for codespace-folders (formerly project-folders) API
+ * routes. arch29-W3-D (F12-06): the public mount path is now
+ * `/api/codespace-folders` and the route factory is
+ * `createCodespaceFoldersRoutes`. The 308 redirect from the old path is
+ * covered separately in `tests/integration/codespace-rename-redirect.test.ts`.
  *
- * Creates a real Hono app with the project-folders routes mounted,
- * backed by a real SQLite database via ProjectFolderService.
+ * Creates a real Hono app with the codespace-folders routes mounted,
+ * backed by a real SQLite database via ProjectFolderService (the underlying
+ * service still uses the project-folder name because the entity is a
+ * "folder of codespaces", a distinct concept).
  */
 
 const jsonRequest = (url: string, body: unknown, init?: RequestInit): Request =>
@@ -19,8 +25,8 @@ const jsonRequest = (url: string, body: unknown, init?: RequestInit): Request =>
     body: JSON.stringify(body),
   });
 
-describe('Project Folder Routes (IT-500)', () => {
-  let app: ReturnType<typeof createProjectFoldersRoutes>;
+describe('Codespace Folder Routes (IT-500)', () => {
+  let app: ReturnType<typeof createCodespaceFoldersRoutes>;
   let service: ProjectFolderService;
   let db: ReturnType<typeof getTestDb>;
 
@@ -28,14 +34,14 @@ describe('Project Folder Routes (IT-500)', () => {
     await setupTestDatabase();
     db = getTestDb();
     service = new ProjectFolderService(db as any);
-    app = createProjectFoldersRoutes({ projectFolderService: service });
+    app = createCodespaceFoldersRoutes({ projectFolderService: service });
   });
 
   afterEach(async () => {
     await clearTestDatabase();
   });
 
-  // ─── GET /api/project-folders ───────────────────────
+  // ─── GET /api/codespace-folders ───────────────────────
 
   it('IT-501: GET / returns empty list when no folders exist (besides default)', async () => {
     // clearTestDatabase re-seeds default-folder, so we expect at least that
@@ -60,7 +66,7 @@ describe('Project Folder Routes (IT-500)', () => {
     expect(body.data.totalCount).toBeGreaterThanOrEqual(3);
   });
 
-  // ─── POST /api/project-folders ──────────────────────
+  // ─── POST /api/codespace-folders ──────────────────────
 
   it('IT-503: POST / creates a new folder', async () => {
     const response = await app.request(
@@ -141,7 +147,7 @@ describe('Project Folder Routes (IT-500)', () => {
     expect(body.ok).toBe(false);
   });
 
-  // ─── GET /api/project-folders/:id ───────────────────
+  // ─── GET /api/codespace-folders/:id ───────────────────
 
   it('IT-509: GET /:id returns a folder by ID', async () => {
     const createResult = await service.create({ name: 'FindMe', slug: 'find-me' });
@@ -172,7 +178,7 @@ describe('Project Folder Routes (IT-500)', () => {
     expect(body.error.code).toBe('INVALID_ID');
   });
 
-  // ─── PATCH /api/project-folders/:id ─────────────────
+  // ─── PATCH /api/codespace-folders/:id ─────────────────
 
   it('IT-512: PATCH /:id updates a folder', async () => {
     const createResult = await service.create({ name: 'Old Name', slug: 'old-name' });
@@ -214,7 +220,7 @@ describe('Project Folder Routes (IT-500)', () => {
     expect(body.ok).toBe(false);
   });
 
-  // ─── DELETE /api/project-folders/:id ────────────────
+  // ─── DELETE /api/codespace-folders/:id ────────────────
 
   it('IT-515: DELETE /:id removes an empty folder', async () => {
     const createResult = await service.create({ name: 'ToDelete', slug: 'to-delete' });
@@ -253,7 +259,7 @@ describe('Project Folder Routes (IT-500)', () => {
     expect(body.error.code).toBe('PROJECT_FOLDER_HAS_CODESPACES');
   });
 
-  // ─── GET /api/project-folders/:id/codespaces ───────
+  // ─── GET /api/codespace-folders/:id/codespaces ───────
 
   it('IT-518: GET /:id/codespaces returns codespaces in folder', async () => {
     const createResult = await service.create({ name: 'WithCS', slug: 'with-cs' });
@@ -278,7 +284,7 @@ describe('Project Folder Routes (IT-500)', () => {
     expect(body.ok).toBe(false);
   });
 
-  // ─── GET /api/project-folders/:id/summary ──────────
+  // ─── GET /api/codespace-folders/:id/summary ──────────
 
   it('IT-520: GET /:id/summary returns folder summary', async () => {
     const createResult = await service.create({ name: 'Summary', slug: 'summary-test' });

--- a/tests/integration/route-codespace-members.test.ts
+++ b/tests/integration/route-codespace-members.test.ts
@@ -3,13 +3,15 @@ import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { codespaceMembers, users } from '../../src/db/schema';
 import type { AuthContext } from '../../src/lib/api/auth-middleware';
-import { createProjectMembersRoutes } from '../../src/server/routes/project-members';
+import { createCodespaceMembersRoutes } from '../../src/server/routes/codespace-members';
 import { RbacService } from '../../src/services/rbac.service';
 import { createTestProject } from '../factories/project.factory';
 import { clearTestDatabase, getTestDb, setupTestDatabase } from '../helpers/database';
 
 /**
- * Integration tests for project-members (codespace members) API routes.
+ * Integration tests for codespace-members (formerly project-members) API
+ * routes. arch29-W3-D (F12-06) completed the rename: routes file is now
+ * `codespace-members.ts` with `createCodespaceMembersRoutes`.
  *
  * The routes are mounted under /api/codespaces/:id/members, so the :id param
  * is read from the parent route. We simulate this by mounting the sub-routes
@@ -29,7 +31,7 @@ const jsonRequest = (url: string, body: unknown, init?: RequestInit): Request =>
     body: JSON.stringify(body),
   });
 
-describe('Project Members Routes (IT-460)', () => {
+describe('Codespace Members Routes (IT-460)', () => {
   let outerApp: Hono;
   let db: ReturnType<typeof getTestDb>;
   let rbacService: RbacService;
@@ -66,7 +68,7 @@ describe('Project Members Routes (IT-460)', () => {
     codespaceId = codespace.id;
 
     // Create the routes with auth context injected via middleware
-    const memberRoutes = createProjectMembersRoutes({ db: db as any, rbacService });
+    const memberRoutes = createCodespaceMembersRoutes({ db: db as any, rbacService });
 
     outerApp = new Hono();
     outerApp.use('/*', async (c, next) => {
@@ -144,6 +146,10 @@ describe('Project Members Routes (IT-460)', () => {
     expect(body.data.items[0].userId).toBe(memberUserId);
     expect(body.data.items[0].name).toBe('Member User');
     expect(body.data.items[0].email).toBe('member@example.com');
+    // arch29-W3-D (F12-06): both fields are emitted during the deprecation
+    // window so existing clients continue to work while new code can read
+    // `codespaceRole`. Both must always agree.
+    expect(body.data.items[0].codespaceRole).toBe('viewer');
     expect(body.data.items[0].projectRole).toBe('viewer');
     expect(body.data.items[0].source).toBe('direct');
   });

--- a/tests/lib/config/config.test.ts
+++ b/tests/lib/config/config.test.ts
@@ -40,7 +40,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue(JSON.stringify(fileConfig));
 
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfigFrom({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/test/project' });
 
       expect(mockedFs.readFile).toHaveBeenCalledWith(
         path.join('/test/project', '.claude', 'settings.json'),
@@ -61,7 +61,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -75,7 +75,7 @@ describe('Configuration Module', () => {
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
       const { DEFAULT_CODESPACE_CONFIG } = await import('@/lib/config/types');
 
-      const result = await loadCodespaceConfigFrom({ projectPath: '/nonexistent/path' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/nonexistent/path' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -95,7 +95,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue(JSON.stringify(partialConfig));
 
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfigFrom({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -117,7 +117,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue(JSON.stringify(invalidConfig));
 
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfigFrom({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -140,7 +140,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue(jsonConfig);
 
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfigFrom({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -153,7 +153,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue('{ invalid json }');
 
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfigFrom({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -168,7 +168,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -184,7 +184,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -197,7 +197,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue('{}');
 
       const { loadCodespaceConfigFrom } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfigFrom({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfigFrom({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -215,7 +215,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -235,7 +235,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockResolvedValue(JSON.stringify(fileConfig));
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -253,7 +253,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -268,7 +268,7 @@ describe('Configuration Module', () => {
       mockedFs.readFile.mockRejectedValue({ code: 'ENOENT' });
 
       const { loadCodespaceConfig } = await import('@/lib/config/config-service');
-      const result = await loadCodespaceConfig({ projectPath: '/test/project' });
+      const result = await loadCodespaceConfig({ codespacePath: '/test/project' });
 
       expect(result.ok).toBe(true);
     });


### PR DESCRIPTION
## Summary

Closes the lingering project/codespace inconsistencies at the API surface so the public surface matches CLAUDE.md's naming rule. Touches the route files, factories, schemas, config-service parameter, the API client, and the spec doc.

## Findings closed

- **F12-06 (P1)** — Project→codespace rename incomplete at API surface.
- **F07-04 (P1)** — `endpoints.md` two renames behind code.

## Changes

- Rename `src/server/routes/project-folders.ts` → `codespace-folders.ts` and factory `createProjectFoldersRoutes` → `createCodespaceFoldersRoutes`. Mount path renamed `/api/project-folders` → `/api/codespace-folders`.
- Rename `src/server/routes/project-members.ts` → `codespace-members.ts` and factory `createProjectMembersRoutes` → `createCodespaceMembersRoutes`. Mount point unchanged (`/api/codespaces/:id/members`).
- Rename `addProjectMemberSchema` → `addCodespaceMemberSchema` and `updateProjectMemberSchema` → `updateCodespaceMemberSchema` in `src/server/validation.ts`.
- Rename `loadCodespaceConfigFrom`/`loadCodespaceConfig` parameter `projectPath` → `codespacePath` in `src/lib/config/config-service.ts` (matches the function name).
- Add 308 Permanent Redirect from `/api/project-folders/*` → `/api/codespace-folders/*` in `router.ts` for one-release backward compat.
- Codespace-members list items expose `codespaceRole` (canonical) plus `projectRole` (deprecated mirror) for one-release backward compat.
- Update `src/lib/api/client.ts` to call the new `/api/codespace-folders/*` paths directly.
- Sync `specs/application/api/endpoints.md` to the current router state: Codespaces, Codespace Folders, Codespace Members, Team Project Folders, Codespace Tags. Stale `projectId` query-param mentions rewritten to `codespaceId`.

The error string `'scope must be "org" or "project"'` referenced in F12-06 was already fixed by W2-P (PR #213); the schema in `validation.ts` now reads `'scope must be "org" or "codespace"'` via `createTemplateSchema`. Error codes (`PROJECT_MEMBER_EXISTS`, `PROJECT_MEMBER_NOT_FOUND`) are preserved as-is for API contract stability of clients that key on `code`.

## Test bar (red→green)

- **before**: `tests/integration/codespace-rename-redirect.test.ts` does not exist; old paths return 401 (no redirect handler) — FAIL by inspection.
- **after**: 10 new tests in `codespace-rename-redirect.test.ts` cover GET/POST/PATCH/DELETE for `/api/project-folders` and `/api/project-folders/*` → 308 with `Location: /api/codespace-folders[...]`, query string preserved, and a self-loop guard that the new path itself does not 308. PASS.

## Verification

- `npx tsc --noEmit` clean
- `npx @biomejs/biome check src/` clean
- `npx vitest run --project unit` — 4531 tests pass
- `tests/integration/codespace-rename-redirect.test.ts` — 10 pass
- `tests/integration/route-codespace-folders.test.ts` — 22 pass
- `tests/integration/route-codespace-members.test.ts` — 13 pass
- `src/server/routes/__tests__/codespace-members.test.ts` — 26 pass
- `tests/lib/config/config.test.ts` + `src/lib/config/__tests__/config.test.ts` — 29 pass

## Status vs April 29 review

- F12-06 (P1) — **closed**: route file/factory/schema/parameter all renamed, 308 redirect for `/api/project-folders/*` registered, error message already fixed by W2-P, endpoints.md synced.
- F07-04 (P1) — **closed**: endpoints.md updated to reflect codespaces / codespace-folders / codespace-members / team-project-folders, plus the new module list (40+ files). Stale `projectId` query-param mentions rewritten to `codespaceId`.

## Test plan

- [x] All existing API tests pass against new paths
- [x] Redirect test covers GET/POST/PATCH/DELETE + query string
- [x] No `/api/projects` or `/api/project-folders` references left in `endpoints.md` outside the rename note
- [x] Backward-compat: `projectRole` field still present alongside `codespaceRole`

Signed-off-by: Simon Lynch <srlynch@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
