### PR TITLE
fix(arch29): address PR #221 review comments (Trivy SHA pin in 2 new jobs, PG cast, nullish schema)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=agent-sandbox
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/agent-sandbox@${{ steps.push.outputs.digest }}
           format: table
@@ -228,7 +228,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=agentcore
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/agentpane-agentcore@${{ steps.push.outputs.digest }}
           format: table

--- a/src/lib/db/dialect.ts
+++ b/src/lib/db/dialect.ts
@@ -81,9 +81,10 @@ export function jsonExtractText(col: SQL | unknown, ...parts: string[]): SQL {
   if (getDbDialect() === 'postgres') {
     // Use `#>>` (text extraction at path). Path is a literal `{a,b}` PG array;
     // values are pre-validated to contain only safe characters so building
-    // the literal as a string is safe.
+    // the literal as a string is safe. Explicit `::text[]` cast disambiguates
+    // the polymorphic resolution against postgres-js's untyped parameter binding.
     const pgPath = `{${parts.join(',')}}`;
-    return sql`(${col} #>> ${pgPath})`;
+    return sql`(${col} #>> ${pgPath}::text[])`;
   }
   // SQLite — build the JSON path expression `$.a.b`.
   const sqlitePath = `$.${parts.join('.')}`;

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -367,8 +367,9 @@ export const memoryModifySuggestionSchema = z.object({
 });
 
 /**
- * Per-skill dream config override. The `null` case (clear-override) is handled
- * outside zod because zod cannot represent JSON `null` as a top-level body.
+ * Per-skill dream config override. Both `null` (clear-override) and `undefined`
+ * (no body) are accepted; the route-level handler additionally treats `{}` as
+ * clear-override for clients that can't serialize null at the top level.
  */
 export const dreamSkillOverrideSchema = z
   .object({
@@ -377,7 +378,7 @@ export const dreamSkillOverrideSchema = z
     minRuns: z.number().int().min(1).max(1000).optional(),
   })
   .strict()
-  .optional();
+  .nullish();
 
 // ─── Task action body schemas ────────────────────────
 

--- a/tests/integration/release-workflows.test.ts
+++ b/tests/integration/release-workflows.test.ts
@@ -61,20 +61,20 @@ describe('F11-01: release.yml workflow', () => {
   // is safe; tags 0.0.1 - 0.34.2 are forever compromised. We pin to a SHA for defense-in-depth
   // because the safe tags themselves remain mutable in principle. Failing on `main` (which uses
   // `@0.30.0` tag — vulnerable) and passing here proves the regression test bar.
-  it('pins trivy-action to a SHA for v0.35.0+ (GHSA-69fq-xp46-6x23)', () => {
+  it('pins EVERY trivy-action ref to a SHA for v0.35.0+ (GHSA-69fq-xp46-6x23)', () => {
     const yaml = readFileSync(resolve(WORKFLOWS, 'release.yml'), 'utf8');
     // Reject any vulnerable tag form (anything ≤ 0.34.x without v-prefix; bare `@0.x.y` form).
     // The safe forms are: `@<40-char SHA>` or `@v0.35.0+` (v-prefix) or `@v0.34.x` (re-pinned).
     expect(yaml).not.toMatch(/aquasecurity\/trivy-action@0\.(?:[12]\d|3[0-4])\.\d+/);
-    // Require either a 40-char SHA pin OR an explicit v0.35.0+ tag.
-    const trivyPin = yaml.match(/aquasecurity\/trivy-action@([\w.-]+)/);
-    expect(trivyPin).toBeTruthy();
-    if (!trivyPin) return;
-    const ref = trivyPin[1];
-    // Either a full SHA (40 hex chars) or a v0.35+ tag.
-    const sha40 = /^[a-f0-9]{40}$/.test(ref);
-    const safeTag = /^v0\.(3[5-9]|[4-9]\d)\.\d+$/.test(ref) || /^v[1-9]\d*\.\d+\.\d+$/.test(ref);
-    expect(sha40 || safeTag).toBe(true);
+    // Require ALL occurrences (not just the first match) to be a 40-char SHA OR v0.35.0+ tag.
+    // Without matchAll, a single safe pin at the top of the file would mask any unsafe pins below.
+    const refs = [...yaml.matchAll(/aquasecurity\/trivy-action@([\w.-]+)/g)].map((m) => m[1]);
+    expect(refs.length).toBeGreaterThan(0);
+    for (const ref of refs) {
+      const sha40 = /^[a-f0-9]{40}$/.test(ref);
+      const safeTag = /^v0\.(3[5-9]|[4-9]\d)\.\d+$/.test(ref) || /^v[1-9]\d*\.\d+\.\d+$/.test(ref);
+      expect(sha40 || safeTag, `unsafe trivy-action ref: ${ref}`).toBe(true);
+    }
   });
 
   it('packages the Helm chart via helm package', () => {


### PR DESCRIPTION
## Summary

Fixes the 3 valid review comments raised on #221:

1. **Devin (release.yml:166, :231)** — The two new release jobs added by W2-T (#212) used `aquasecurity/trivy-action@0.30.0`, which falls in the GHSA-69fq-xp46-6x23 vulnerable tag range. The W3-A advisory fix (#217) only pinned the main app's scan. Pinned all three Trivy refs to `57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0`.

   Also strengthened `tests/integration/release-workflows.test.ts` to use `matchAll` — the previous test only checked the first match, which would have been masked by the safe pin at line 100.

2. **Gemini (dialect.ts:87)** — PostgreSQL `#>>` path now has an explicit `::text[]` cast (`${col} #>> ${pgPath}::text[]`) to disambiguate polymorphic resolution against postgres-js's untyped parameter binding.

3. **Gemini (memory.ts:276 / validation.ts:373)** — `dreamSkillOverrideSchema` switched from `.optional()` to `.nullish()` so the schema accepts both `null` (clear-override) and `undefined`. The route-level handler still treats `{}` as clear-override for clients that can't serialize `null` at the top level.

## Verification

- `npx tsc --noEmit` clean
- `npx @biomejs/biome check` clean (3 files)
- Affected tests: 50 integration tests pass (release-workflows + route-memory)
- 19 dialect/outbox tests pass
- The strengthened `matchAll` test would catch any future Trivy ref drift

## Test plan
- [x] All Trivy refs in `release.yml` pin to v0.35.0+ SHA
- [x] `release-workflows.test.ts` uses `matchAll` for full coverage
- [x] PG `#>>` operator casts path to `text[]`
- [x] `dreamSkillOverrideSchema` accepts `null` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
