### PR TITLE
fix(arch29): resolve PR #221 CI failures (api-keys gate + router.test.ts mock)

### DIFF
--- a/src/server/routes/api-keys.ts
+++ b/src/server/routes/api-keys.ts
@@ -3,10 +3,10 @@
  */
 
 import { Hono } from 'hono';
-import { z } from 'zod';
 import { createLogger } from '../../lib/logging/logger.js';
 import type { ApiKeyService } from '../../services/api-key.service.js';
 import { json } from '../shared.js';
+import { parseJsonBody, saveKeySchema } from '../validation.js';
 
 const log = createLogger('ApiKeysRoutes');
 
@@ -18,17 +18,6 @@ type KnownService = (typeof KNOWN_API_KEY_SERVICES)[number];
 function isKnownService(service: string): service is KnownService {
   return (KNOWN_API_KEY_SERVICES as readonly string[]).includes(service);
 }
-
-// Validation schemas.
-// F03-09 (arch29-W2-C): the optional `refreshToken` is the OAuth refresh
-// token issued alongside an `sk-ant-oat*` access token. It is encrypted with
-// the same AES-GCM key as the access token and stored in
-// `api_keys.encrypted_refresh_token` so the agent-runner can rotate the
-// access token mid-run.
-const saveKeySchema = z.object({
-  key: z.string().min(1, 'API key is required'),
-  refreshToken: z.string().min(1).optional(),
-});
 
 interface ApiKeysDeps {
   apiKeyService: ApiKeyService;
@@ -86,32 +75,8 @@ export function createApiKeysRoutes({ apiKeyService }: ApiKeysDeps) {
       );
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      // F07-15 (arch29-W2-H): standardise on VALIDATION_ERROR for both JSON
-      // parse failures and Zod validation failures so clients can branch on a
-      // single code. The other api-keys endpoints already use VALIDATION_ERROR.
-      return json(
-        { ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid JSON in request body' } },
-        400
-      );
-    }
-
-    const parsed = saveKeySchema.safeParse(body);
-    if (!parsed.success) {
-      return json(
-        {
-          ok: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: parsed.error.issues[0]?.message ?? 'Invalid request',
-          },
-        },
-        400
-      );
-    }
+    const parsed = await parseJsonBody(c, saveKeySchema);
+    if (!parsed.ok) return parsed.response;
 
     const result = await apiKeyService.saveKey(service, parsed.data.key, parsed.data.refreshToken);
 

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -380,6 +380,17 @@ export const dreamSkillOverrideSchema = z
   .strict()
   .nullish();
 
+/**
+ * `POST /api/keys/:service` body. The optional `refreshToken` (F03-09 / W2-C)
+ * is the OAuth refresh token issued alongside an `sk-ant-oat*` access token.
+ * It is encrypted with AES-GCM and stored in `api_keys.encrypted_refresh_token`
+ * so the agent-runner can rotate the access token mid-run.
+ */
+export const saveKeySchema = z.object({
+  key: z.string().min(1, 'API key is required').max(8192),
+  refreshToken: z.string().min(1).max(8192).optional(),
+});
+
 // ─── Task action body schemas ────────────────────────
 
 export const rejectPlanSchema = z

--- a/tests/server/router.test.ts
+++ b/tests/server/router.test.ts
@@ -15,20 +15,45 @@ import { createRouter, type RouterDependencies } from '@/server/router';
 // ---------------------------------------------------------------------------
 
 function stubDb(): RouterDependencies['db'] {
-  return {
-    query: {
-      codespaces: { findFirst: vi.fn().mockResolvedValue({ id: 'p1' }) },
-      userSessions: { findFirst: vi.fn().mockResolvedValue(null) },
-      apiTokens: { findFirst: vi.fn().mockResolvedValue(null) },
-      users: { findFirst: vi.fn().mockResolvedValue(null) },
-    },
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    insert: vi.fn().mockReturnThis(),
-    update: vi.fn().mockReturnThis(),
-    delete: vi.fn().mockReturnThis(),
-  } as unknown as RouterDependencies['db'];
+  // Fluent-builder mock: every method on the chain returns the same object so
+  // arbitrary `db.insert(t).values(v).onConflictDoUpdate({...})` etc. resolve.
+  // Terminal calls (`.then`/`await`) resolve to `[]`.
+  const chain: Record<string, unknown> = {};
+  const methods = [
+    'select',
+    'from',
+    'where',
+    'insert',
+    'update',
+    'delete',
+    'values',
+    'set',
+    'returning',
+    'onConflictDoUpdate',
+    'onConflictDoNothing',
+    'orderBy',
+    'limit',
+    'offset',
+    'leftJoin',
+    'innerJoin',
+    'groupBy',
+    'having',
+  ];
+  for (const m of methods) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // Make the chain awaitable — `await db.insert(...)...` resolves to `[]`.
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable for fluent-builder mock
+  (chain as { then: (resolve: (v: unknown[]) => unknown) => unknown }).then = (
+    resolve: (v: unknown[]) => unknown
+  ) => Promise.resolve([]).then(resolve);
+  chain.query = {
+    codespaces: { findFirst: vi.fn().mockResolvedValue({ id: 'p1' }) },
+    userSessions: { findFirst: vi.fn().mockResolvedValue(null) },
+    apiTokens: { findFirst: vi.fn().mockResolvedValue(null) },
+    users: { findFirst: vi.fn().mockResolvedValue(null) },
+  };
+  return chain as unknown as RouterDependencies['db'];
 }
 
 function stubService(overrides: Record<string, unknown> = {}): any {


### PR DESCRIPTION
## Summary

PR #221 CI showed 4 failing checks (`lint-and-typecheck`, `coverage`, `test (3/3)`, `mutation-test rbac`). All 4 cascade from 2 root causes — both fixed:

### 1. api-keys.ts:91 bare `c.req.json()` (lint-and-typecheck — API write validation gate)

W2-H rebased from W2-C which kept a local `saveKeySchema` and a manual `try { body = await c.req.json() }` block. The CI grep gate added by W2-H flagged it.

**Fix:** moved `saveKeySchema` to canonical `src/server/validation.ts` (with bounded `max(8192)` on key/refreshToken) and converted the route to `parseJsonBody(c, saveKeySchema)`. Removed local schema and manual try/catch.

### 2. `db.insert(...).values is not a function` in router.test.ts (test 3/3, coverage, mutation rbac)

`stubDb()` returned `mockReturnThis()` for `insert/update/delete/select/from/where` but didn't include `values`, `onConflictDoUpdate`, etc. The W2-N rate-limiter middleware now does `db.insert(rateLimitBuckets).values(...).onConflictDoUpdate({...})` per request, which broke every router test (12 assertion failures cascading into mutation rbac as initial-test-run failure).

**Fix:** rewrote `stubDb()` as a fluent-builder mock — every chain method on a single shared object so any chain resolves. Made the chain awaitable so `await db.foo(...).bar(...)` returns `[]`. Suppressed `noThenProperty` lint with biome-ignore explaining the intentional thenable.

## Verification
- `npx tsc --noEmit` clean
- `npx @biomejs/biome check` clean (3 files)
- `bash scripts/check-api-write-validation.sh` passes (1 allow-listed within 2-site budget)
- `npx vitest run tests/server/router.test.ts` → 52/52 pass (was 12 fail)
- 126 tests across affected areas pass

## Test plan
- [x] API write validation gate passes
- [x] router.test.ts: 52/52 green
- [x] No new biome violations
- [x] Type-check clean
- [ ] CI on #221 reruns: lint+test+coverage all pass (will run when merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentdevsl/agentpane/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
